### PR TITLE
feat(slack): add assistant thread status

### DIFF
--- a/src/services/codex/codex-broker.ts
+++ b/src/services/codex/codex-broker.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "node:events";
+
 import { AppServerClient } from "./app-server-client.js";
 import { AppServerProcess } from "./app-server-process.js";
 import type { SlackSessionRecord, SlackUserIdentity } from "../../types.js";
@@ -12,7 +14,7 @@ import type {
 import { logger } from "../../logger.js";
 import { getPersonalMemoryPath } from "./codex-home.js";
 
-export class CodexBroker {
+export class CodexBroker extends EventEmitter {
   readonly #appServerProcess?: AppServerProcess;
   #client: AppServerClient;
   readonly #loadedThreadIds = new Set<string>();
@@ -45,6 +47,7 @@ export class CodexBroker {
     readonly geminiAllProxy?: string | undefined;
     readonly openAiApiKey?: string | undefined;
   }) {
+    super();
     this.#serviceName = options.serviceName;
     this.#brokerHttpBaseUrl = options.brokerHttpBaseUrl;
     this.#openAiApiKey = options.openAiApiKey;
@@ -180,6 +183,13 @@ export class CodexBroker {
   }
 
   #bindClient(client: AppServerClient): void {
+    client.on("notification", (method, params) => {
+      if (client !== this.#client) {
+        return;
+      }
+      this.emit("notification", method, params);
+    });
+
     client.on("disconnected", (error) => {
       if (this.#ignoredDisconnectClients.has(client)) {
         return;

--- a/src/services/slack/slack-api.ts
+++ b/src/services/slack/slack-api.ts
@@ -97,6 +97,55 @@ export class SlackApi {
     return response.ts;
   }
 
+  async setAssistantThreadStatus(options: {
+    readonly channelId: string;
+    readonly threadTs: string;
+    readonly status: string;
+  }): Promise<void> {
+    await this.#post(
+      "assistant.threads.setStatus",
+      {
+        channel_id: options.channelId,
+        thread_ts: options.threadTs,
+        status: options.status,
+        loading_messages: options.status.trim() ? options.status : undefined
+      },
+      this.#botToken
+    );
+  }
+
+  async addReaction(options: {
+    readonly channelId: string;
+    readonly timestamp: string;
+    readonly name: string;
+  }): Promise<void> {
+    await this.#post(
+      "reactions.add",
+      {
+        channel: options.channelId,
+        timestamp: options.timestamp,
+        name: options.name
+      },
+      this.#botToken
+    );
+  }
+
+  async removeReaction(options: {
+    readonly channelId: string;
+    readonly timestamp: string;
+    readonly name: string;
+  }): Promise<void> {
+    await this.#post(
+      "reactions.remove",
+      {
+        channel: options.channelId,
+        timestamp: options.timestamp,
+        name: options.name
+      },
+      this.#botToken
+    );
+  }
+
   async uploadThreadFile(options: {
     readonly channelId: string;
     readonly threadTs: string;

--- a/src/services/slack/slack-assistant-status.ts
+++ b/src/services/slack/slack-assistant-status.ts
@@ -1,0 +1,457 @@
+import { logger } from "../../logger.js";
+import { SlackApi } from "./slack-api.js";
+
+const ASSISTANT_STATUS_MIN_INTERVAL_MS = 2_000;
+const FALLBACK_REACTION_NAME = "eyes";
+
+const TOOL_STATUS_LABELS = new Map<string, string>([
+  ["read", "Reading files..."],
+  ["list", "Reading files..."],
+  ["ls", "Reading files..."],
+  ["glob", "Reading files..."],
+  ["grep", "Reading files..."],
+  ["stat", "Checking files..."],
+  ["write", "Updating files..."],
+  ["edit", "Updating files..."],
+  ["apply_patch", "Updating files..."],
+  ["copy", "Updating files..."],
+  ["delete", "Updating files..."],
+  ["exec", "Running in environment..."],
+  ["bash", "Running in workspace..."],
+  ["exec_command", "Running in workspace..."],
+  ["python", "Running Python..."],
+  ["webbrowse", "Browsing the web..."],
+  ["search_query", "Searching the web..."],
+  ["image_query", "Searching the web..."],
+  ["memoryget", "Reading memory..."],
+  ["memorysearch", "Searching memory..."],
+  ["memorywrite", "Updating memory..."],
+  ["waitfor", "Waiting on external work..."],
+  ["slackpostmessage", "Updating Slack..."],
+  ["slackeditmessage", "Updating Slack..."],
+  ["slackuploadfile", "Uploading to Slack..."],
+  ["slackgetthread", "Checking Slack..."],
+  ["slackgetchannelhistory", "Checking Slack..."],
+  ["slackgetuserinfo", "Checking Slack..."],
+  ["slackaddreaction", "Checking Slack..."]
+]);
+
+interface AssistantStateLike {
+  readonly phase?: unknown;
+  readonly tools?: unknown;
+}
+
+export class SlackAssistantStatusController {
+  readonly #slackApi: SlackApi;
+  readonly #channelId: string;
+  readonly #threadTs: string;
+
+  #lastStatus = "";
+  #lastCallAtMs = 0;
+  #pendingStatus: string | undefined;
+  #timer: NodeJS.Timeout | undefined;
+  #sendChain: Promise<void> = Promise.resolve();
+  #stopped = false;
+  #fallbackOnly = false;
+  #reactionActive = false;
+  readonly #activeToolCalls = new Map<string, string>();
+  readonly #activeToolOrder: string[] = [];
+
+  constructor(options: {
+    readonly slackApi: SlackApi;
+    readonly channelId: string;
+    readonly threadTs: string;
+  }) {
+    this.#slackApi = options.slackApi;
+    this.#channelId = options.channelId;
+    this.#threadTs = options.threadTs;
+  }
+
+  setThinking(): void {
+    this.#scheduleStatus("Thinking...");
+  }
+
+  clear(): void {
+    this.#scheduleStatus("");
+  }
+
+  handleAssistantState(state: Record<string, unknown> | null | undefined): void {
+    if (!state) {
+      return;
+    }
+
+    const status = statusForAssistantState(state);
+    if (status === null) {
+      return;
+    }
+
+    this.#scheduleStatus(status);
+  }
+
+  handleToolStart(params: Record<string, unknown> | null | undefined): void {
+    const callId = extractCallId(params);
+    const toolName = extractToolName(params);
+    if (callId && toolName) {
+      this.#recordToolStart(callId, toolName);
+    }
+
+    this.#scheduleStatus(this.#currentToolStatus() || "Working on it...");
+  }
+
+  handleToolEnd(params: Record<string, unknown> | null | undefined): void {
+    const callId = extractCallId(params);
+    if (callId) {
+      this.#recordToolEnd(callId);
+    }
+
+    const toolStatus = this.#currentToolStatus();
+    if (toolStatus) {
+      this.#scheduleStatus(toolStatus);
+      return;
+    }
+
+    this.#scheduleStatus("Thinking...");
+  }
+
+  handleTerminalStatus(status: string | null | undefined): void {
+    if (clearsAssistantStatusForTerminal(status)) {
+      this.clear();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.#stopped) {
+      await this.#sendChain;
+      return;
+    }
+
+    this.#stopped = true;
+    this.#pendingStatus = undefined;
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = undefined;
+    }
+
+    await this.#enqueueSend("");
+  }
+
+  #recordToolStart(callId: string, toolName: string): void {
+    if (!this.#activeToolCalls.has(callId)) {
+      this.#activeToolOrder.push(callId);
+    }
+    this.#activeToolCalls.set(callId, toolName);
+  }
+
+  #recordToolEnd(callId: string): void {
+    this.#activeToolCalls.delete(callId);
+    const index = this.#activeToolOrder.lastIndexOf(callId);
+    if (index >= 0) {
+      this.#activeToolOrder.splice(index, 1);
+    }
+  }
+
+  #currentToolStatus(): string {
+    for (let index = this.#activeToolOrder.length - 1; index >= 0; index -= 1) {
+      const toolName = this.#activeToolCalls.get(this.#activeToolOrder[index]!);
+      if (!toolName) {
+        continue;
+      }
+      return statusForTool(toolName);
+    }
+
+    return "";
+  }
+
+  #scheduleStatus(status: string): void {
+    if (this.#stopped && status !== "") {
+      return;
+    }
+
+    if (status === this.#lastStatus) {
+      this.#clearPendingStatus();
+      return;
+    }
+
+    if (status === "") {
+      this.#clearPendingStatus();
+      void this.#enqueueSend(status);
+      return;
+    }
+
+    const elapsedMs = Date.now() - this.#lastCallAtMs;
+    if (elapsedMs < ASSISTANT_STATUS_MIN_INTERVAL_MS) {
+      this.#pendingStatus = status;
+      if (!this.#timer) {
+        this.#timer = setTimeout(() => {
+          this.#timer = undefined;
+          this.#flushPendingStatus();
+        }, ASSISTANT_STATUS_MIN_INTERVAL_MS - elapsedMs);
+      }
+      return;
+    }
+
+    void this.#enqueueSend(status);
+  }
+
+  #flushPendingStatus(): void {
+    const pendingStatus = this.#pendingStatus;
+    this.#pendingStatus = undefined;
+
+    if (!pendingStatus || pendingStatus === this.#lastStatus) {
+      return;
+    }
+
+    void this.#enqueueSend(pendingStatus);
+  }
+
+  #clearPendingStatus(): void {
+    this.#pendingStatus = undefined;
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  #enqueueSend(status: string): Promise<void> {
+    this.#lastStatus = status;
+    this.#lastCallAtMs = Date.now();
+    this.#sendChain = this.#sendChain
+      .catch(() => undefined)
+      .then(async () => {
+        await this.#send(status);
+      });
+    return this.#sendChain;
+  }
+
+  async #send(status: string): Promise<void> {
+    if (this.#fallbackOnly) {
+      await this.#applyFallbackReaction(status);
+      return;
+    }
+
+    try {
+      await this.#slackApi.setAssistantThreadStatus({
+        channelId: this.#channelId,
+        threadTs: this.#threadTs,
+        status
+      });
+      await this.#clearFallbackReactionIfNeeded();
+    } catch (error) {
+      if (shouldFallbackAssistantStatus(error)) {
+        this.#fallbackOnly = true;
+        await this.#applyFallbackReaction(status);
+        return;
+      }
+
+      logger.warn("Failed to update Slack assistant thread status", {
+        channelId: this.#channelId,
+        threadTs: this.#threadTs,
+        status,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  async #applyFallbackReaction(status: string): Promise<void> {
+    const shouldBeActive = status.trim() !== "";
+
+    if (shouldBeActive && !this.#reactionActive) {
+      try {
+        await this.#slackApi.addReaction({
+          channelId: this.#channelId,
+          timestamp: this.#threadTs,
+          name: FALLBACK_REACTION_NAME
+        });
+        this.#reactionActive = true;
+      } catch (error) {
+        if (!isSlackApiError(error, "already_reacted")) {
+          logger.warn("Failed to add Slack assistant fallback reaction", {
+            channelId: this.#channelId,
+            threadTs: this.#threadTs,
+            error: error instanceof Error ? error.message : String(error)
+          });
+          return;
+        }
+        this.#reactionActive = true;
+      }
+    }
+
+    if (!shouldBeActive && this.#reactionActive) {
+      try {
+        await this.#slackApi.removeReaction({
+          channelId: this.#channelId,
+          timestamp: this.#threadTs,
+          name: FALLBACK_REACTION_NAME
+        });
+      } catch (error) {
+        if (!isSlackApiError(error, "no_reaction")) {
+          logger.warn("Failed to remove Slack assistant fallback reaction", {
+            channelId: this.#channelId,
+            threadTs: this.#threadTs,
+            error: error instanceof Error ? error.message : String(error)
+          });
+          return;
+        }
+      }
+      this.#reactionActive = false;
+    }
+  }
+
+  async #clearFallbackReactionIfNeeded(): Promise<void> {
+    if (!this.#reactionActive) {
+      return;
+    }
+
+    try {
+      await this.#slackApi.removeReaction({
+        channelId: this.#channelId,
+        timestamp: this.#threadTs,
+        name: FALLBACK_REACTION_NAME
+      });
+    } catch (error) {
+      if (!isSlackApiError(error, "no_reaction")) {
+        logger.warn("Failed to clear Slack assistant fallback reaction", {
+          channelId: this.#channelId,
+          threadTs: this.#threadTs,
+          error: error instanceof Error ? error.message : String(error)
+        });
+        return;
+      }
+    }
+
+    this.#reactionActive = false;
+  }
+}
+
+function statusForAssistantState(state: Record<string, unknown>): string | null {
+  const phase = normalizeString((state as AssistantStateLike).phase);
+
+  switch (phase) {
+    case "thinking":
+      return "Thinking...";
+    case "execution":
+      return statusForExecutionState(state);
+    case "messaging":
+    case "idle":
+      return "";
+    default:
+      return null;
+  }
+}
+
+function statusForExecutionState(state: Record<string, unknown>): string {
+  const toolName = latestAssistantToolName((state as AssistantStateLike).tools);
+  if (!toolName) {
+    return "Working on it...";
+  }
+
+  return statusForTool(toolName);
+}
+
+function latestAssistantToolName(tools: unknown): string | undefined {
+  if (!Array.isArray(tools)) {
+    return undefined;
+  }
+
+  for (let index = tools.length - 1; index >= 0; index -= 1) {
+    const entry = tools[index];
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const toolName = normalizeString(
+      (entry as { readonly tool_name?: unknown; readonly toolName?: unknown }).tool_name ??
+      (entry as { readonly toolName?: unknown }).toolName
+    );
+    if (toolName) {
+      return toolName;
+    }
+  }
+
+  return undefined;
+}
+
+function statusForTool(toolName: string): string {
+  const normalized = normalizeToolName(toolName);
+  if (!normalized) {
+    return "Working on it...";
+  }
+
+  return TOOL_STATUS_LABELS.get(normalized) ?? "Working on it...";
+}
+
+function normalizeToolName(toolName: string | null | undefined): string {
+  return normalizeString(toolName)?.replace(/[^a-z0-9]+/g, "") ?? "";
+}
+
+function extractCallId(params: Record<string, unknown> | null | undefined): string | undefined {
+  if (!params) {
+    return undefined;
+  }
+
+  return normalizeString(
+    params.callId ??
+      params.call_id ??
+      params.toolCallId ??
+      params.tool_call_id ??
+      params.id
+  );
+}
+
+function extractToolName(params: Record<string, unknown> | null | undefined): string | undefined {
+  if (!params) {
+    return undefined;
+  }
+
+  if (typeof params.tool === "object" && params.tool) {
+    const toolName = normalizeString((params.tool as { readonly name?: unknown }).name);
+    if (toolName) {
+      return toolName;
+    }
+  }
+
+  return normalizeString(
+    params.toolName ??
+      params.tool_name ??
+      params.name
+  );
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.toLowerCase() : undefined;
+}
+
+function clearsAssistantStatusForTerminal(status: string | null | undefined): boolean {
+  switch (normalizeString(status)) {
+    case "paused":
+    case "waiting":
+    case "failed":
+    case "completed":
+    case "cancelled":
+    case "interrupted":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function shouldFallbackAssistantStatus(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return [
+    "missing_scope",
+    "unknown_method",
+    "not_allowed_token_type",
+    "feature_not_enabled",
+    "method_not_supported_for_channel_type"
+  ].some((token) => message.includes(token));
+}
+
+function isSlackApiError(error: unknown, code: string): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(`: ${code}`) || message.endsWith(code);
+}

--- a/src/services/slack/slack-assistant-status.ts
+++ b/src/services/slack/slack-assistant-status.ts
@@ -77,6 +77,7 @@ export class SlackAssistantStatusController {
   }
 
   clear(): void {
+    this.#resetToolTracking();
     this.#scheduleStatus("");
   }
 
@@ -131,6 +132,7 @@ export class SlackAssistantStatusController {
     }
 
     this.#stopped = true;
+    this.#resetToolTracking();
     this.#pendingStatus = undefined;
     if (this.#timer) {
       clearTimeout(this.#timer);
@@ -165,6 +167,11 @@ export class SlackAssistantStatusController {
     }
 
     return "";
+  }
+
+  #resetToolTracking(): void {
+    this.#activeToolCalls.clear();
+    this.#activeToolOrder.length = 0;
   }
 
   #scheduleStatus(status: string): void {

--- a/src/services/slack/slack-assistant-status.ts
+++ b/src/services/slack/slack-assistant-status.ts
@@ -4,7 +4,7 @@ import { SlackApi } from "./slack-api.js";
 const ASSISTANT_STATUS_MIN_INTERVAL_MS = 2_000;
 const FALLBACK_REACTION_NAME = "eyes";
 
-const TOOL_STATUS_LABELS = new Map<string, string>([
+const TOOL_STATUS_LABEL_ENTRIES: Array<readonly [string, string]> = [
   ["read", "Reading files..."],
   ["list", "Reading files..."],
   ["ls", "Reading files..."],
@@ -34,7 +34,11 @@ const TOOL_STATUS_LABELS = new Map<string, string>([
   ["slackgetchannelhistory", "Checking Slack..."],
   ["slackgetuserinfo", "Checking Slack..."],
   ["slackaddreaction", "Checking Slack..."]
-]);
+];
+
+const TOOL_STATUS_LABELS = new Map<string, string>(
+  TOOL_STATUS_LABEL_ENTRIES.map(([toolName, status]) => [normalizeToolName(toolName), status] as const)
+);
 
 interface AssistantStateLike {
   readonly phase?: unknown;
@@ -54,6 +58,7 @@ export class SlackAssistantStatusController {
   #stopped = false;
   #fallbackOnly = false;
   #reactionActive = false;
+  #queuedStatus: string | undefined;
   readonly #activeToolCalls = new Map<string, string>();
   readonly #activeToolOrder: string[] = [];
 
@@ -167,7 +172,7 @@ export class SlackAssistantStatusController {
       return;
     }
 
-    if (status === this.#lastStatus) {
+    if (status === this.#lastStatus || status === this.#queuedStatus) {
       this.#clearPendingStatus();
       return;
     }
@@ -197,7 +202,7 @@ export class SlackAssistantStatusController {
     const pendingStatus = this.#pendingStatus;
     this.#pendingStatus = undefined;
 
-    if (!pendingStatus || pendingStatus === this.#lastStatus) {
+    if (!pendingStatus || pendingStatus === this.#lastStatus || pendingStatus === this.#queuedStatus) {
       return;
     }
 
@@ -213,20 +218,26 @@ export class SlackAssistantStatusController {
   }
 
   #enqueueSend(status: string): Promise<void> {
-    this.#lastStatus = status;
+    this.#queuedStatus = status;
     this.#lastCallAtMs = Date.now();
     this.#sendChain = this.#sendChain
       .catch(() => undefined)
       .then(async () => {
-        await this.#send(status);
+        const sent = await this.#send(status);
+        if (this.#queuedStatus === status) {
+          this.#queuedStatus = undefined;
+        }
+        if (sent) {
+          this.#lastStatus = status;
+        }
       });
     return this.#sendChain;
   }
 
-  async #send(status: string): Promise<void> {
+  async #send(status: string): Promise<boolean> {
     if (this.#fallbackOnly) {
       await this.#applyFallbackReaction(status);
-      return;
+      return true;
     }
 
     try {
@@ -236,11 +247,12 @@ export class SlackAssistantStatusController {
         status
       });
       await this.#clearFallbackReactionIfNeeded();
+      return true;
     } catch (error) {
       if (shouldFallbackAssistantStatus(error)) {
         this.#fallbackOnly = true;
         await this.#applyFallbackReaction(status);
-        return;
+        return true;
       }
 
       logger.warn("Failed to update Slack assistant thread status", {
@@ -249,6 +261,7 @@ export class SlackAssistantStatusController {
         status,
         error: error instanceof Error ? error.message : String(error)
       });
+      return false;
     }
   }
 

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -18,6 +18,7 @@ import {
   SlackApi,
   type SlackUploadedFile
 } from "./slack-api.js";
+import { SlackAssistantStatusController } from "./slack-assistant-status.js";
 import {
   createSlackInputFromThreadMessage,
   isSlackMessageEffectivelyEmpty,
@@ -74,6 +75,7 @@ export class SlackConversationService {
   readonly #slackApi: SlackApi;
   readonly #selfMessageFilter: SlackSelfMessageFilter;
   readonly #runtimeSessions = new Map<string, RuntimeSessionState>();
+  readonly #statusControllers = new Map<string, SlackAssistantStatusController>();
   readonly #inboundStore: SlackInboundStore;
   readonly #turnRunner: SlackTurnRunner;
   readonly #turnReconciler: SlackTurnReconciler;
@@ -108,6 +110,9 @@ export class SlackConversationService {
       turnRunner: this.#turnRunner,
       inboundStore: this.#inboundStore
     });
+    options.codex.on("notification", (method: string, params: Record<string, unknown> | undefined) => {
+      this.#handleCodexNotification(method, params ?? {});
+    });
   }
 
   setBotUserId(botUserId: string): void {
@@ -130,6 +135,9 @@ export class SlackConversationService {
       clearTimeout(runtime.autoResumeTimer);
       runtime.autoResumeTimer = undefined;
     }
+    const stopPromises = [...this.#statusControllers.values()].map((controller) => controller.stop());
+    this.#statusControllers.clear();
+    await Promise.all(stopPromises);
   }
 
   isAlreadyHandled(session: SlackSessionRecord, messageTs?: string | undefined): boolean {
@@ -371,6 +379,7 @@ export class SlackConversationService {
       reason: options.reason,
       occurredAt: new Date().toISOString()
     });
+    this.#clearAssistantStatus(options.channelId, options.rootThreadTs);
   }
 
   async postSlackFile(options: {
@@ -414,6 +423,7 @@ export class SlackConversationService {
       throw new Error("Unable to determine filename for Slack upload");
     }
 
+    this.#clearAssistantStatus(options.channelId, options.rootThreadTs);
     const uploaded = await this.#slackApi.uploadThreadFile({
       channelId: options.channelId,
       threadTs: options.rootThreadTs,
@@ -519,6 +529,7 @@ export class SlackConversationService {
     await this.#turnRunner.interrupt(session);
     await this.#inboundStore.markTurnBatchDone(session, session.activeTurnId);
     await this.#sessions.setActiveTurnId(session.channelId, session.rootThreadTs, undefined);
+    this.#clearAssistantStatus(session.channelId, session.rootThreadTs);
     return true;
   }
 
@@ -534,6 +545,7 @@ export class SlackConversationService {
 
     this.#clearDispatchFailureBlock(session.key);
     const recordedSession = await this.#inboundStore.recordInboundMessage(session, item);
+    this.#setAssistantThinking(recordedSession);
     await this.#dispatchPersistedMessage(recordedSession, item.messageTs);
   }
 
@@ -618,6 +630,8 @@ export class SlackConversationService {
 
     if (outcome === "cleared") {
       this.#resetRuntimeProcessing(session.key);
+      const latestSession = this.#findSessionByKey(session.key);
+      this.#clearAssistantStatus(latestSession.channelId, latestSession.rootThreadTs);
       await this.#resumePendingDispatch(session.key);
     }
 
@@ -700,6 +714,7 @@ export class SlackConversationService {
       } | undefined;
     }
   ): Promise<string | undefined> {
+    this.#clearAssistantStatus(channelId, rootThreadTs);
     const ts = await this.#slackApi.postThreadMessage(channelId, rootThreadTs, text);
     if (ts) {
       this.#selfMessageFilter.rememberPostedMessageTs(ts);
@@ -781,6 +796,7 @@ export class SlackConversationService {
       return;
     }
 
+    this.#setAssistantThinking(latestSession);
     if (latestSession.activeTurnId) {
       try {
         const input = this.#inboundStore.createSlackInputFromPersistedMessage(pendingMessage);
@@ -823,6 +839,7 @@ export class SlackConversationService {
       return 0;
     }
 
+    this.#setAssistantThinking(latestSession);
     if (latestSession.activeTurnId) {
       try {
         const input = await this.#inboundStore.createRecoveredBatchInput(latestSession, pendingMessages, recoveryKind);
@@ -1027,6 +1044,7 @@ export class SlackConversationService {
           break;
         }
 
+        this.#setAssistantThinking(session);
         session = await this.#turnRunner.ensureCodexThread(session);
         const pendingMessages = this.#inboundStore.listPendingMessages(session);
 
@@ -1067,6 +1085,7 @@ export class SlackConversationService {
         session = await this.#handleCompletedTurnDisposition(session, result.turnId, dispatchMessages, {
           aborted: result.aborted
         });
+        this.#maybeClearAssistantStatusIfIdle(session);
       } catch (error) {
         if (runtime.generation !== generation) {
           return;
@@ -1121,6 +1140,7 @@ export class SlackConversationService {
             error: error instanceof Error ? error.message : String(error)
           });
         }
+        this.#clearAssistantStatus(session.channelId, session.rootThreadTs);
         break;
       }
     }
@@ -1211,6 +1231,7 @@ export class SlackConversationService {
       this.#resetRuntimeProcessing(sessionKey);
     }
 
+    this.#setAssistantThinking(session);
     this.#enqueueDispatch(session, {
       kind: "dispatch_pending"
     });
@@ -1317,4 +1338,139 @@ export class SlackConversationService {
     );
     return Date.now() - this.#lastMissedThreadRecoveryAtMs >= intervalMs;
   }
+
+  #setAssistantThinking(session: SlackSessionRecord): void {
+    this.#getStatusController(session.channelId, session.rootThreadTs).setThinking();
+  }
+
+  #clearAssistantStatus(channelId: string, rootThreadTs: string): void {
+    const sessionKey = SessionManager.createKey(channelId, rootThreadTs);
+    this.#statusControllers.get(sessionKey)?.clear();
+  }
+
+  #maybeClearAssistantStatusIfIdle(session: SlackSessionRecord): void {
+    if (session.activeTurnId) {
+      return;
+    }
+
+    const hasPendingOrInflightMessages = this.#sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      status: ["pending", "inflight"]
+    }).length > 0;
+
+    if (hasPendingOrInflightMessages) {
+      return;
+    }
+
+    this.#clearAssistantStatus(session.channelId, session.rootThreadTs);
+  }
+
+  #getStatusController(channelId: string, rootThreadTs: string): SlackAssistantStatusController {
+    const sessionKey = SessionManager.createKey(channelId, rootThreadTs);
+    let controller = this.#statusControllers.get(sessionKey);
+
+    if (!controller) {
+      controller = new SlackAssistantStatusController({
+        slackApi: this.#slackApi,
+        channelId,
+        threadTs: rootThreadTs
+      });
+      this.#statusControllers.set(sessionKey, controller);
+    }
+
+    return controller;
+  }
+
+  #handleCodexNotification(method: string, params: Record<string, unknown>): void {
+    const session = this.#findSessionForCodexNotification(params);
+    if (!session) {
+      return;
+    }
+
+    const controller = this.#getStatusController(session.channelId, session.rootThreadTs);
+
+    switch (method) {
+      case "assistant.state":
+      case "workspace.assistant.state":
+        controller.handleAssistantState(asRecord(params.state));
+        return;
+      case "tool_start":
+      case "codex/event/tool_start":
+        controller.handleToolStart(params);
+        return;
+      case "tool_end":
+      case "codex/event/tool_end":
+        controller.handleToolEnd(params);
+        return;
+      case "status":
+      case "codex/event/status":
+        controller.handleTerminalStatus(typeof params.status === "string" ? params.status : undefined);
+        return;
+      case "item/agentMessage/delta":
+      case "turn/completed":
+      case "codex/event/turn_aborted":
+      case "error":
+      case "codex/event/error":
+        controller.clear();
+        return;
+      default:
+        return;
+    }
+  }
+
+  #findSessionForCodexNotification(params: Record<string, unknown>): SlackSessionRecord | undefined {
+    const turnId = normalizeCodexTurnId(params);
+    if (turnId) {
+      return this.#sessions.listSessions().find((session) => session.activeTurnId === turnId);
+    }
+
+    const threadId = normalizeCodexThreadId(params);
+    if (threadId) {
+      return this.#sessions.listSessions().find((session) => session.codexThreadId === threadId);
+    }
+
+    return undefined;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function normalizeCodexTurnId(params: Record<string, unknown>): string | undefined {
+  const direct = normalizeNonEmptyString(
+    params.turnId ??
+      params.turn_id ??
+      (asRecord(params.turn)?.id) ??
+      (asRecord(params.msg)?.turn_id)
+  );
+  if (direct) {
+    return direct;
+  }
+
+  return normalizeNonEmptyString(asRecord(params.state)?.turn_id);
+}
+
+function normalizeCodexThreadId(params: Record<string, unknown>): string | undefined {
+  return normalizeNonEmptyString(
+    params.threadId ??
+      params.thread_id ??
+      (asRecord(params.thread)?.id) ??
+      (asRecord(params.msg)?.thread_id) ??
+      (asRecord(params.state)?.thread_id)
+  );
+}
+
+function normalizeNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -72,6 +72,7 @@ const NONRECOVERABLE_DISPATCH_RETRY_COOLDOWN_MS = 5 * 60 * 1_000;
 export class SlackConversationService {
   readonly #config: AppConfig;
   readonly #sessions: SessionManager;
+  readonly #codex: CodexBroker;
   readonly #slackApi: SlackApi;
   readonly #selfMessageFilter: SlackSelfMessageFilter;
   readonly #runtimeSessions = new Map<string, RuntimeSessionState>();
@@ -79,6 +80,7 @@ export class SlackConversationService {
   readonly #inboundStore: SlackInboundStore;
   readonly #turnRunner: SlackTurnRunner;
   readonly #turnReconciler: SlackTurnReconciler;
+  readonly #codexNotificationHandler: (method: string, params: Record<string, unknown> | undefined) => void;
   #botUserId = "";
   #activeTurnReconcileTimer: NodeJS.Timeout | undefined;
   #catchUpPromise: Promise<void> | undefined;
@@ -93,6 +95,7 @@ export class SlackConversationService {
   }) {
     this.#config = options.config;
     this.#sessions = options.sessions;
+    this.#codex = options.codex;
     this.#slackApi = options.slackApi;
     this.#selfMessageFilter = options.selfMessageFilter;
     this.#inboundStore = new SlackInboundStore({
@@ -110,9 +113,10 @@ export class SlackConversationService {
       turnRunner: this.#turnRunner,
       inboundStore: this.#inboundStore
     });
-    options.codex.on("notification", (method: string, params: Record<string, unknown> | undefined) => {
+    this.#codexNotificationHandler = (method: string, params: Record<string, unknown> | undefined) => {
       this.#handleCodexNotification(method, params ?? {});
-    });
+    };
+    this.#codex.on("notification", this.#codexNotificationHandler);
   }
 
   setBotUserId(botUserId: string): void {
@@ -128,6 +132,7 @@ export class SlackConversationService {
 
   async stop(): Promise<void> {
     this.#stopActiveTurnReconciler();
+    this.#codex.off("notification", this.#codexNotificationHandler);
     for (const runtime of this.#runtimeSessions.values()) {
       if (!runtime.autoResumeTimer) {
         continue;
@@ -1421,13 +1426,19 @@ export class SlackConversationService {
 
   #findSessionForCodexNotification(params: Record<string, unknown>): SlackSessionRecord | undefined {
     const turnId = normalizeCodexTurnId(params);
-    if (turnId) {
-      return this.#sessions.listSessions().find((session) => session.activeTurnId === turnId);
+    const threadId = normalizeCodexThreadId(params);
+    if (!turnId && !threadId) {
+      return undefined;
     }
 
-    const threadId = normalizeCodexThreadId(params);
-    if (threadId) {
-      return this.#sessions.listSessions().find((session) => session.codexThreadId === threadId);
+    const sessions = this.#sessions.listSessions();
+    for (const session of sessions) {
+      if (turnId && session.activeTurnId === turnId) {
+        return session;
+      }
+      if (threadId && session.codexThreadId === threadId) {
+        return session;
+      }
     }
 
     return undefined;

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -28,6 +28,184 @@ describe.sequential("slack-codex-broker e2e", () => {
     }
   });
 
+  it("shows Slack assistant thread status while a turn is running and clears it after replying", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
+    cleanups.push(async () => {
+      await removeTempRoot(tempRoot);
+    });
+
+    let brokerBaseUrl = "";
+    const mockSlack = new MockSlackServer("UBOT", {
+      botId: "BBOT",
+      appId: "AAPP"
+    });
+    const mockCodex = new MockCodexAppServer({
+      onTurnStart: async (context) => {
+        await waitFor(() => {
+          return mockSlack.assistantStatusUpdates.some((update) => update.status === "Thinking...");
+        }, "assistant thinking status");
+
+        const response = await fetch(`${brokerBaseUrl}/slack/post-message`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded; charset=utf-8"
+          },
+          body: new URLSearchParams({
+            channel_id: "C123",
+            thread_ts: "110.220",
+            text: "STATUS_REPLY_OK",
+            kind: "final"
+          }).toString()
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to post broker Slack reply: ${response.status}`);
+        }
+
+        context.complete("");
+      }
+    });
+    const slackPort = await mockSlack.start();
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+      await mockSlack.stop();
+    });
+
+    const broker = await startBrokerProcess({
+      port: await getFreePort(),
+      slackPort,
+      codexUrl,
+      tempRoot
+    });
+    brokerBaseUrl = broker.baseUrl;
+    cleanups.push(() => broker.stop());
+
+    await mockSlack.sendEvent("evt-status-mention", {
+      type: "app_mention",
+      user: "U123",
+      channel: "C123",
+      thread_ts: "110.220",
+      ts: "110.221",
+      text: "<@UBOT> status test"
+    });
+
+    await waitFor(() => {
+      return mockSlack.assistantStatusUpdates.some((update) => update.status === "Thinking...");
+    }, "assistant thinking status call");
+    await waitFor(() => {
+      return mockSlack.postedMessages.some((message) => message.text === "STATUS_REPLY_OK");
+    }, "broker-posted Slack reply");
+    await waitFor(() => {
+      return mockSlack.assistantStatusUpdates.some((update) => update.status === "");
+    }, "assistant status clear");
+
+    expect(mockSlack.assistantStatusUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          channel: "C123",
+          threadTs: "110.220",
+          status: "Thinking...",
+          loadingMessages: "Thinking..."
+        }),
+        expect.objectContaining({
+          channel: "C123",
+          threadTs: "110.220",
+          status: ""
+        })
+      ])
+    );
+  }, 90_000);
+
+  it("falls back to an eyes reaction when Slack assistant status is unavailable", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
+    cleanups.push(async () => {
+      await removeTempRoot(tempRoot);
+    });
+
+    let brokerBaseUrl = "";
+    const mockSlack = new MockSlackServer("UBOT", {
+      botId: "BBOT",
+      appId: "AAPP",
+      assistantStatusError: "unknown_method"
+    });
+    const mockCodex = new MockCodexAppServer({
+      onTurnStart: async (context) => {
+        await waitFor(() => {
+          return mockSlack.reactionOperations.some((operation) => (
+            operation.action === "add" &&
+            operation.channel === "C123" &&
+            operation.timestamp === "120.220" &&
+            operation.name === "eyes"
+          ));
+        }, "assistant fallback reaction add");
+
+        const response = await fetch(`${brokerBaseUrl}/slack/post-message`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded; charset=utf-8"
+          },
+          body: new URLSearchParams({
+            channel_id: "C123",
+            thread_ts: "120.220",
+            text: "FALLBACK_REPLY_OK",
+            kind: "final"
+          }).toString()
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to post broker Slack reply: ${response.status}`);
+        }
+
+        context.complete("");
+      }
+    });
+    const slackPort = await mockSlack.start();
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+      await mockSlack.stop();
+    });
+
+    const broker = await startBrokerProcess({
+      port: await getFreePort(),
+      slackPort,
+      codexUrl,
+      tempRoot
+    });
+    brokerBaseUrl = broker.baseUrl;
+    cleanups.push(() => broker.stop());
+
+    await mockSlack.sendEvent("evt-fallback-mention", {
+      type: "app_mention",
+      user: "U123",
+      channel: "C123",
+      thread_ts: "120.220",
+      ts: "120.221",
+      text: "<@UBOT> fallback test"
+    });
+
+    await waitFor(() => {
+      return mockSlack.reactionOperations.some((operation) => (
+        operation.action === "add" &&
+        operation.channel === "C123" &&
+        operation.timestamp === "120.220" &&
+        operation.name === "eyes"
+      ));
+    }, "assistant fallback reaction add");
+    await waitFor(() => {
+      return mockSlack.postedMessages.some((message) => message.text === "FALLBACK_REPLY_OK");
+    }, "fallback broker-posted Slack reply");
+    await waitFor(() => {
+      return mockSlack.reactionOperations.some((operation) => (
+        operation.action === "remove" &&
+        operation.channel === "C123" &&
+        operation.timestamp === "120.220" &&
+        operation.name === "eyes"
+      ));
+    }, "assistant fallback reaction clear");
+
+    expect(mockSlack.assistantStatusUpdates).toHaveLength(0);
+  }, 90_000);
+
   it("starts a new session, backfills history, and forwards full Slack card payloads", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
     cleanups.push(async () => {

--- a/test/manual/mock-slack-server.ts
+++ b/test/manual/mock-slack-server.ts
@@ -10,6 +10,20 @@ export interface PostedMessage {
   readonly ts: string;
 }
 
+export interface AssistantStatusUpdate {
+  readonly channel: string;
+  readonly threadTs: string;
+  readonly status: string;
+  readonly loadingMessages?: string | undefined;
+}
+
+export interface ReactionOperation {
+  readonly action: "add" | "remove";
+  readonly channel: string;
+  readonly timestamp: string;
+  readonly name: string;
+}
+
 export interface MockThreadMessage {
   readonly channel: string;
   readonly threadTs: string;
@@ -31,6 +45,9 @@ export class MockSlackServer {
   #socket: WebSocket | undefined;
   #nextTs = 9_000_000_000;
   readonly postedMessages: PostedMessage[] = [];
+  readonly assistantStatusUpdates: AssistantStatusUpdate[] = [];
+  readonly reactionOperations: ReactionOperation[] = [];
+  readonly #activeReactions = new Set<string>();
   readonly #users = new Map<string, {
     readonly id: string;
     readonly name: string;
@@ -72,6 +89,7 @@ export class MockSlackServer {
     private readonly options?: {
       readonly botId?: string;
       readonly appId?: string;
+      readonly assistantStatusError?: string;
     }
   ) {
     this.#server = http.createServer((request, response) => {
@@ -243,6 +261,71 @@ export class MockSlackServer {
       return;
     }
 
+    if (request.url === "/api/assistant.threads.setStatus") {
+      if (this.options?.assistantStatusError) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            ok: false,
+            error: this.options.assistantStatusError
+          })
+        );
+        return;
+      }
+
+      this.assistantStatusUpdates.push({
+        channel: String(body.channel_id),
+        threadTs: String(body.thread_ts),
+        status: String(body.status ?? ""),
+        loadingMessages:
+          typeof body.loading_messages === "string" && body.loading_messages.length > 0
+            ? body.loading_messages
+            : undefined
+      });
+
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    if (request.url === "/api/reactions.add") {
+      const reactionKey = getReactionKey(
+        String(body.channel),
+        String(body.timestamp),
+        String(body.name)
+      );
+      this.reactionOperations.push({
+        action: "add",
+        channel: String(body.channel),
+        timestamp: String(body.timestamp),
+        name: String(body.name)
+      });
+      this.#activeReactions.add(reactionKey);
+
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    if (request.url === "/api/reactions.remove") {
+      const reactionKey = getReactionKey(
+        String(body.channel),
+        String(body.timestamp),
+        String(body.name)
+      );
+      this.reactionOperations.push({
+        action: "remove",
+        channel: String(body.channel),
+        timestamp: String(body.timestamp),
+        name: String(body.name)
+      });
+      this.#activeReactions.delete(reactionKey);
+
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
     if (request.url === "/api/users.info") {
       const user = this.#users.get(String(body.user));
 
@@ -336,4 +419,8 @@ async function readRequestBody(request: http.IncomingMessage): Promise<Record<st
 
 function getThreadKey(channel: string, threadTs: string): string {
   return `${channel}:${threadTs}`;
+}
+
+function getReactionKey(channel: string, timestamp: string, name: string): string {
+  return `${channel}:${timestamp}:${name}`;
 }

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -151,6 +151,45 @@ describe("SlackApi.uploadThreadFile", () => {
   });
 });
 
+describe("SlackApi.setAssistantThreadStatus", () => {
+  it("sends the explicit loading message alongside the status label", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (!url.endsWith("/assistant.threads.setStatus")) {
+        throw new Error(`Unexpected fetch ${url}`);
+      }
+
+      expect(init?.method).toBe("POST");
+      const body = String(init?.body);
+      expect(body).toContain("channel_id=C123");
+      expect(body).toContain("thread_ts=111.222");
+      expect(body).toContain("status=Reading+files...");
+      expect(body).toContain("loading_messages=Reading+files...");
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new SlackApi({
+      baseUrl: "https://slack.test/api",
+      appToken: "xapp-test",
+      botToken: "xoxb-test"
+    });
+
+    await api.setAssistantThreadStatus({
+      channelId: "C123",
+      threadTs: "111.222",
+      status: "Reading files..."
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("SlackApi.listThreadMessages", () => {
   it("preserves bot/app card messages with raw Slack payload", async () => {
     const fetchMock = vi.fn(async (input: string | URL) => {

--- a/test/slack-assistant-status.test.ts
+++ b/test/slack-assistant-status.test.ts
@@ -127,4 +127,65 @@ describe("SlackAssistantStatusController", () => {
       });
     });
   });
+
+  it("drops stale tool state when a cleared turn is followed by a new tool lifecycle", async () => {
+    vi.useFakeTimers();
+    const setAssistantThreadStatus = vi.fn(async () => undefined);
+
+    const controller = new SlackAssistantStatusController({
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      channelId: "C123",
+      threadTs: "111.222"
+    });
+
+    controller.handleToolStart({
+      id: "stale-tool",
+      name: "apply_patch"
+    });
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenNthCalledWith(1, {
+        channelId: "C123",
+        threadTs: "111.222",
+        status: "Updating files..."
+      });
+    });
+
+    controller.clear();
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenNthCalledWith(2, {
+        channelId: "C123",
+        threadTs: "111.222",
+        status: ""
+      });
+    });
+
+    controller.handleToolStart({
+      id: "fresh-tool",
+      name: "search_query"
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenNthCalledWith(3, {
+        channelId: "C123",
+        threadTs: "111.222",
+        status: "Searching the web..."
+      });
+    });
+
+    controller.handleToolEnd({
+      id: "fresh-tool"
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenNthCalledWith(4, {
+        channelId: "C123",
+        threadTs: "111.222",
+        status: "Thinking..."
+      });
+    });
+  });
 });

--- a/test/slack-assistant-status.test.ts
+++ b/test/slack-assistant-status.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { SlackAssistantStatusController } from "../src/services/slack/slack-assistant-status.js";
+
+describe("SlackAssistantStatusController", () => {
+  it("maps assistant execution state into a Slack status label", async () => {
+    const setAssistantThreadStatus = vi.fn(async () => undefined);
+
+    const controller = new SlackAssistantStatusController({
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      channelId: "C123",
+      threadTs: "111.222"
+    });
+
+    controller.handleAssistantState({
+      phase: "execution",
+      tools: [{ tool_name: "read" }]
+    });
+
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenCalledWith({
+        channelId: "C123",
+        threadTs: "111.222",
+        status: "Reading files..."
+      });
+    });
+  });
+
+  it("falls back to an eyes reaction when assistant thread status is unavailable", async () => {
+    const addReaction = vi.fn(async () => undefined);
+    const removeReaction = vi.fn(async () => undefined);
+
+    const controller = new SlackAssistantStatusController({
+      slackApi: {
+        setAssistantThreadStatus: vi.fn(async () => {
+          throw new Error("Slack API error for assistant.threads.setStatus: unknown_method");
+        }),
+        addReaction,
+        removeReaction
+      } as never,
+      channelId: "C123",
+      threadTs: "111.222"
+    });
+
+    controller.setThinking();
+
+    await vi.waitFor(() => {
+      expect(addReaction).toHaveBeenCalledWith({
+        channelId: "C123",
+        timestamp: "111.222",
+        name: "eyes"
+      });
+    });
+
+    controller.clear();
+
+    await vi.waitFor(() => {
+      expect(removeReaction).toHaveBeenCalledWith({
+        channelId: "C123",
+        timestamp: "111.222",
+        name: "eyes"
+      });
+    });
+  });
+});

--- a/test/slack-assistant-status.test.ts
+++ b/test/slack-assistant-status.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SlackAssistantStatusController } from "../src/services/slack/slack-assistant-status.js";
 
 describe("SlackAssistantStatusController", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it("maps assistant execution state into a Slack status label", async () => {
     const setAssistantThreadStatus = vi.fn(async () => undefined);
 
@@ -27,6 +32,62 @@ describe("SlackAssistantStatusController", () => {
         threadTs: "111.222",
         status: "Reading files..."
       });
+    });
+  });
+
+  it("normalizes underscored tool names before looking up status labels", async () => {
+    const setAssistantThreadStatus = vi.fn(async () => undefined);
+
+    const controller = new SlackAssistantStatusController({
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      channelId: "C123",
+      threadTs: "111.222"
+    });
+
+    controller.handleToolStart({
+      id: "call-1",
+      name: "apply_patch"
+    });
+
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenCalledWith({
+        channelId: "C123",
+        threadTs: "111.222",
+        status: "Updating files..."
+      });
+    });
+  });
+
+  it("retries the same status after a transient Slack API failure", async () => {
+    vi.useFakeTimers();
+    const setAssistantThreadStatus = vi.fn()
+      .mockRejectedValueOnce(new Error("Slack API request failed (500 Internal Server Error) for assistant.threads.setStatus"))
+      .mockResolvedValueOnce(undefined);
+
+    const controller = new SlackAssistantStatusController({
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      channelId: "C123",
+      threadTs: "111.222"
+    });
+
+    controller.setThinking();
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+    });
+
+    controller.setThinking();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/test/slack-conversation-service.test.ts
+++ b/test/slack-conversation-service.test.ts
@@ -1,0 +1,108 @@
+import { EventEmitter } from "node:events";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AppConfig } from "../src/config.js";
+import { SlackConversationService } from "../src/services/slack/slack-conversation-service.js";
+import type { SlackSessionRecord } from "../src/types.js";
+
+const TEST_SESSION: SlackSessionRecord = {
+  key: "C123:111.222",
+  channelId: "C123",
+  rootThreadTs: "111.222",
+  workspacePath: "/tmp/workspace",
+  codexThreadId: "thread-1",
+  activeTurnId: "turn-1",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString()
+};
+
+const TEST_CONFIG = {
+  slackInitialThreadHistoryCount: 8,
+  slackHistoryApiMaxLimit: 50,
+  slackActiveTurnReconcileIntervalMs: 15_000,
+  slackMissedThreadRecoveryIntervalMs: 15_000,
+  slackProgressReminderAfterMs: 120_000,
+  slackProgressReminderRepeatMs: 120_000
+} as AppConfig;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SlackConversationService", () => {
+  it("removes the Codex notification listener on stop", async () => {
+    const codex = new EventEmitter();
+    const listSessions = vi.fn(() => [TEST_SESSION]);
+    const setAssistantThreadStatus = vi.fn(async () => undefined);
+
+    const service = new SlackConversationService({
+      config: TEST_CONFIG,
+      sessions: {
+        listSessions
+      } as never,
+      codex: codex as never,
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      selfMessageFilter: {} as never
+    });
+
+    expect(codex.listenerCount("notification")).toBe(1);
+
+    codex.emit("notification", "assistant.state", {
+      thread_id: TEST_SESSION.codexThreadId,
+      state: { phase: "thinking" }
+    });
+
+    await vi.waitFor(() => {
+      expect(setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+    });
+
+    await service.stop();
+
+    expect(codex.listenerCount("notification")).toBe(0);
+    expect(setAssistantThreadStatus).toHaveBeenCalledTimes(2);
+
+    codex.emit("notification", "assistant.state", {
+      thread_id: TEST_SESSION.codexThreadId,
+      state: { phase: "thinking" }
+    });
+
+    await Promise.resolve();
+    expect(setAssistantThreadStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips session scans for notifications without a turn or thread id", async () => {
+    const codex = new EventEmitter();
+    const listSessions = vi.fn(() => [TEST_SESSION]);
+    const setAssistantThreadStatus = vi.fn(async () => undefined);
+
+    const service = new SlackConversationService({
+      config: TEST_CONFIG,
+      sessions: {
+        listSessions
+      } as never,
+      codex: codex as never,
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      selfMessageFilter: {} as never
+    });
+
+    codex.emit("notification", "assistant.state", {
+      state: { phase: "thinking" }
+    });
+
+    await Promise.resolve();
+
+    expect(listSessions).not.toHaveBeenCalled();
+    expect(setAssistantThreadStatus).not.toHaveBeenCalled();
+
+    await service.stop();
+  });
+});


### PR DESCRIPTION
## Context

- This change adds thread-level assistant status to `slack-codex-broker`, so Slack users can see more than just the final reply.
- Before this change, the broker exposed final messages and terminal state, but had almost no thread-visible execution feedback while a turn was actively running.
- That made long tool calls or slower turns feel silent in Slack, even when the agent was still making progress.
- The implementation also needs to tolerate Slack workspace capability differences: if `assistant.threads.setStatus` is unavailable, the broker should degrade gracefully instead of losing all in-progress signal.

## Collaboration Process

```mermaid
sequenceDiagram
    participant User as User
    participant Codex as Codex
    participant Repo as slack-codex-broker
    participant Slack as Slack API

    User->>Codex: Add assistant status to the Slack broker
    Codex->>Repo: Compare the current broker turn lifecycle with the missing status surface
    Codex->>Slack: Run a real API smoke test to verify workspace support
    Note right of Codex: Confirmed real set/clear calls for assistant thread status
    Codex->>Repo: Re-emit app-server notifications from CodexBroker
    Codex->>Repo: Add SlackAssistantStatusController for mapping, throttling, and fallback
    Codex->>Repo: Wire thinking/tool/final-clear transitions into SlackConversationService
    Codex->>Repo: Add :eyes: fallback when assistant status is unavailable
    Codex->>Repo: Expand unit tests, e2e coverage, and the mock Slack server
    Codex->>Slack: Run a live broker smoke test to verify Thinking -> reply -> clear end-to-end
```

Note:
This implementation was not validated only against mocks. It was verified in two real environments as well: a direct Slack Web API smoke test for `assistant.threads.setStatus`, and a local live-broker run against a real workspace bot to confirm the full thread reply and status-clear path.

## Design Discussion

### Option A: Hard-code one static status around dispatch

- The main benefit is low implementation cost: set one status at turn start and clear it at the end.
- The downside is that the signal is too coarse. It does not reflect tool execution and does not provide the richer assistant-state behavior we want for Slack threads.
- It also tends to drift out of sync when a turn emits a visible Slack reply, uploads a file, or records `wait` / `block` / `final` through a different code path.

### Option B: Infer status only from Slack outbound reply paths

- This approach would let the broker clean up status when `postSlackMessage` / `postSlackState` / upload paths run.
- The problem is that it only sees outbound Slack actions and misses app-server internal state such as `assistant.state`, `tool_start`, and `tool_end`.
- In practice that would still leave execution mostly opaque until the run is already near completion.

### Option C: Feed Codex app-server notifications into Slack conversation runtime and centralize status lifecycle in one controller

- This is the approach implemented here.
- Once `CodexBroker` re-emits notifications, `SlackConversationService` can observe `assistant.state`, `tool_start`, `tool_end`, and terminal `status` updates, then hand them to a dedicated `SlackAssistantStatusController`.
- That keeps status behavior centralized instead of scattering `assistant.threads.setStatus` calls across many turn branches.
- It also makes Slack capability fallback a controller concern: unsupported workspaces can transparently degrade to a root-message `:eyes:` reaction without leaking Slack feature-matrix logic into the broader conversation lifecycle.

## Final Approach

- Add `SlackAssistantStatusController` to manage:
  - default `Thinking...` state
  - tool-name to Slack-status label mapping
  - dedupe and 2-second throttling
  - automatic fallback to a root-message `:eyes:` reaction when `assistant.threads.setStatus` is unavailable
- Extend `SlackApi` with wrappers for `assistant.threads.setStatus`, `reactions.add`, and `reactions.remove`.
- Make `CodexBroker` extend `EventEmitter` and forward app-server notifications so Slack runtime can react to execution state changes.
- Wire status lifecycle into `SlackConversationService` at these points:
  - new inbound message, backlog recovery, and pending-dispatch resume set `Thinking...`
  - `assistant.state`, `tool_start`, `tool_end`, and terminal `status` update or clear the status
  - posting Slack text, recording state, uploading files, turn completion, failure handling, and idle cleanup clear status
- Expand test coverage in unit tests, e2e tests, and the mock Slack server.

```mermaid
sequenceDiagram
    participant SlackThread as Slack Thread
    participant Conversation as SlackConversationService
    participant Broker as CodexBroker
    participant Controller as SlackAssistantStatusController
    participant SlackAPI as Slack API

    SlackThread->>Conversation: inbound message or recovered backlog
    Conversation->>Controller: setThinking()
    Controller->>SlackAPI: assistant.threads.setStatus("Thinking...")
    Conversation->>Broker: startTurn / steerTurn
    Broker-->>Conversation: assistant.state / tool_start / tool_end / status
    Conversation->>Controller: handle notification
    Controller->>SlackAPI: update thread status
    Conversation->>SlackAPI: post message / post state / upload file
    Conversation->>Controller: clear()
    Controller->>SlackAPI: clear status or remove :eyes:
```

## Validation

- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test`
- Real Slack API smoke test covering `auth.test`, `apps.connections.open`, thread reads, and `assistant.threads.setStatus` set / clear
- Live broker smoke test against a real workspace bot covering `Thinking... -> visible reply -> clear -> final state`
- `<!-- Please add any validation performed outside this CC session -->`

## Known Limitations / Follow-up

- The current tool-to-status mapping is still an alias table. If the broker starts surfacing new tool names, that label map will likely need to grow.
- The fallback reaction only preserves a single busy / idle bit and cannot express richer progress semantics like native assistant thread status can.
- This change is intentionally scoped to thread-level assistant status. It does not add cross-thread aggregation, admin visualization, or broader queue-level status surfaces.
