### PR TITLE
fix(slack): convert markdownish output to mrkdwn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.33.0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Optional fields:
 - `snippet_type`
 - `content_type`
 
+`initial_comment` accepts normal Markdown/markdownish input and is converted to Slack `mrkdwn` before upload completion.
+
 ## Slack Recovery API
 
 The broker also exposes a local-only operator endpoint for manually resuming a stuck session:

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ curl -sS -X POST http://127.0.0.1:3000/slack/post-message \
   -d '{"channel_id":"C123","thread_ts":"111.222","text":"working on it"}'
 ```
 
+`text` accepts normal Markdown/markdownish input. The broker converts it to Slack `mrkdwn` before posting.
+
 ### Upload a local image or file
 
 ```bash

--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -13,6 +13,7 @@ Current Slack thread coordinates:
 Slack broker API usage for this session:
 - Send text with: {{post_message_command}}
 - Write normal Markdown in the `text` field. Do not handcraft Slack `mrkdwn`; the broker converts markdownish output to `mrkdwn` before posting.
+- For `/slack/post-file`, `initial_comment` also accepts normal Markdown and is converted before posting.
 - When sending a terminal Slack state, set kind to final, block, or wait. For block/wait, include a short reason field.
 - Record a silent final state without posting another Slack message with: {{post_state_final_command}}
 - Record a silent wait state without posting to Slack with: {{post_state_wait_command}}

--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -12,6 +12,7 @@ Current Slack thread coordinates:
 
 Slack broker API usage for this session:
 - Send text with: {{post_message_command}}
+- Write normal Markdown in the `text` field. Do not handcraft Slack `mrkdwn`; the broker converts markdownish output to `mrkdwn` before posting.
 - When sending a terminal Slack state, set kind to final, block, or wait. For block/wait, include a short reason field.
 - Record a silent final state without posting another Slack message with: {{post_state_final_command}}
 - Record a silent wait state without posting to Slack with: {{post_state_wait_command}}

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -438,7 +438,9 @@ export class SlackConversationService {
       filename,
       bytes,
       title: options.title?.trim() || undefined,
-      initialComment: options.initialComment?.trim() || undefined,
+      initialComment: options.initialComment
+        ? markdownishToMrkdwn(options.initialComment.trim())
+        : undefined,
       altText: options.altText?.trim() || undefined,
       snippetType: options.snippetType?.trim() || undefined,
       contentType: options.contentType?.trim() || undefined

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -46,6 +46,7 @@ import { SlackInboundStore } from "./slack-inbound-store.js";
 import {
   formatSlackHistoryContextForCodex
 } from "./slack-message-format.js";
+import { markdownishToMrkdwn } from "./slack-mrkdwn.js";
 import { SlackSelfMessageFilter } from "./slack-self-filter.js";
 import { SlackTurnReconciler } from "./slack-turn-reconciler.js";
 import { SlackTurnRunner } from "./slack-turn-runner.js";
@@ -353,9 +354,11 @@ export class SlackConversationService {
     readonly kind?: SlackTurnSignalKind | undefined;
     readonly reason?: string | undefined;
   }): Promise<void> {
-    const chunks = chunkSlackMessage(options.text);
+    const formattedText = markdownishToMrkdwn(options.text);
+    const chunks = chunkSlackMessage(formattedText);
     for (const [index, chunk] of chunks.entries()) {
       await this.#postBotThreadMessage(options.channelId, options.rootThreadTs, chunk, {
+        alreadyFormatted: true,
         turnSignal:
           index === 0 && options.kind
             ? {
@@ -713,6 +716,7 @@ export class SlackConversationService {
     rootThreadTs: string,
     text: string,
     options?: {
+      readonly alreadyFormatted?: boolean | undefined;
       readonly turnSignal?: {
         readonly kind: SlackTurnSignalKind;
         readonly reason?: string | undefined;
@@ -720,7 +724,8 @@ export class SlackConversationService {
     }
   ): Promise<string | undefined> {
     this.#clearAssistantStatus(channelId, rootThreadTs);
-    const ts = await this.#slackApi.postThreadMessage(channelId, rootThreadTs, text);
+    const formattedText = options?.alreadyFormatted ? text : markdownishToMrkdwn(text);
+    const ts = await this.#slackApi.postThreadMessage(channelId, rootThreadTs, formattedText);
     if (ts) {
       this.#selfMessageFilter.rememberPostedMessageTs(ts);
       const occurredAt = new Date().toISOString();

--- a/src/services/slack/slack-mrkdwn.ts
+++ b/src/services/slack/slack-mrkdwn.ts
@@ -1,0 +1,320 @@
+const mdBoldItalicRe = /\*\*\*(.+?)\*\*\*/g;
+const mdBoldRe = /\*\*(.+?)\*\*/g;
+const mdItalicRe = /\*([^*\n]+?)\*/g;
+const mdLinkRe = /\[([^\]]+)\]\(([^)]+)\)/g;
+const mdHeaderRe = /^#{1,6}\s+(.+)$/gm;
+const mdStrikeRe = /~~(.+?)~~/g;
+const mdUnorderedListRe = /^(\s*)[-*]\s+/gm;
+const mdOrderedListRe = /^(\s*)\d+\.\s+/gm;
+const mdTableRowRe = /^\|(.+)\|$/m;
+const mdTableSepRe = /^\|[\s:]*-{2,}[\s:]*(\|[\s:]*-{2,}[\s:]*)*\|$/m;
+const inlineCodeUrlRe = /(https?:\/\/|www\.|(?:[a-z0-9-]+\.)+[a-z]{2,}(?:[:/]|$))/i;
+const slackLinkLabelRe = /^<([^>|]+)\|([^>]+)>$/;
+const slackLinkBareRe = /^<([^>]+)>$/;
+
+const phBIOpen = "\x00BI\x01";
+const phBIClose = "\x00BI\x02";
+const phBOpen = "\x00B\x01";
+const phBClose = "\x00B\x02";
+
+interface MarkdownSegment {
+  readonly text: string;
+  readonly isCode: boolean;
+}
+
+interface ProtectedCodeSegment {
+  readonly token: string;
+  readonly replacement: string;
+}
+
+export function markdownToMrkdwn(text: string): string {
+  const [protectedText, codeSegments] = protectCodeSegments(text);
+  return restoreCodeSegments(transformMarkdownText(protectedText), codeSegments);
+}
+
+export function markdownishToMrkdwn(text: string): string {
+  const [protectedText, codeSegments] = protectCodeSegments(text);
+  return restoreCodeSegments(transformMarkdownishText(protectedText), codeSegments);
+}
+
+export function markdownToSlackFallbackText(text: string): string {
+  const fallback = markdownToMrkdwn(text).trim();
+  if (fallback === "") {
+    return text;
+  }
+  return fallback;
+}
+
+function sanitizeSlackCodeSegment(text: string): string {
+  if (text.startsWith("```")) {
+    return text;
+  }
+  if (text.length < 2 || text[0] !== "`" || text[text.length - 1] !== "`") {
+    return text;
+  }
+
+  let inner = text.slice(1, -1);
+  inner = normalizeInlineCodeSlackLink(inner);
+  if (!inlineCodeUrlRe.test(inner)) {
+    return text;
+  }
+
+  inner = breakSlackAutolink(inner);
+  return `\`${inner}\``;
+}
+
+function normalizeInlineCodeSlackLink(text: string): string {
+  const trimmed = text.trim();
+  const labeledMatch = slackLinkLabelRe.exec(trimmed);
+  if (labeledMatch) {
+    const [, target, label] = labeledMatch;
+    if (target!.startsWith("mailto:")) {
+      if (label!.trim() !== "") {
+        return label!;
+      }
+      return target!.slice("mailto:".length);
+    }
+    if (label!.trim() !== "" && label === target) {
+      return label!;
+    }
+    return target!;
+  }
+
+  const bareMatch = slackLinkBareRe.exec(trimmed);
+  if (bareMatch) {
+    return bareMatch[1]!.replace(/^mailto:/, "");
+  }
+
+  return text;
+}
+
+function breakSlackAutolink(text: string): string {
+  const protocolIndex = text.indexOf("://");
+  if (protocolIndex >= 0) {
+    const prefix = text.slice(0, protocolIndex + 3);
+    const rest = text.slice(protocolIndex + 3);
+    const dotIndex = rest.indexOf(".");
+    if (dotIndex >= 0) {
+      return `${prefix}${rest.slice(0, dotIndex + 1)}\u200B${rest.slice(dotIndex + 1)}`;
+    }
+    const slashIndex = rest.indexOf("/");
+    if (slashIndex >= 0) {
+      return `${prefix}${rest.slice(0, slashIndex + 1)}\u200B${rest.slice(slashIndex + 1)}`;
+    }
+    if (rest !== "") {
+      return `${prefix}\u200B${rest}`;
+    }
+    return text;
+  }
+
+  const atIndex = text.indexOf("@");
+  if (atIndex >= 0) {
+    return `${text.slice(0, atIndex + 1)}\u200B${text.slice(atIndex + 1)}`;
+  }
+
+  const dotIndex = text.indexOf(".");
+  if (dotIndex >= 0) {
+    return `${text.slice(0, dotIndex + 1)}\u200B${text.slice(dotIndex + 1)}`;
+  }
+
+  const slashIndex = text.indexOf("/");
+  if (slashIndex >= 0) {
+    return `${text.slice(0, slashIndex + 1)}\u200B${text.slice(slashIndex + 1)}`;
+  }
+
+  return text;
+}
+
+function splitCodeSegments(text: string): MarkdownSegment[] {
+  const segments: MarkdownSegment[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    if (index + 2 < text.length && text.slice(index, index + 3) === "```") {
+      const end = text.indexOf("```", index + 3);
+      if (end >= 0) {
+        segments.push({ text: text.slice(index, end + 3), isCode: true });
+        index = end + 3;
+        continue;
+      }
+      segments.push({ text: text.slice(index), isCode: true });
+      return segments;
+    }
+
+    if (text[index] === "`") {
+      const end = text.indexOf("`", index + 1);
+      if (end >= 0) {
+        segments.push({ text: text.slice(index, end + 1), isCode: true });
+        index = end + 1;
+        continue;
+      }
+    }
+
+    let next = text.length;
+    for (let cursor = index + 1; cursor < text.length; cursor += 1) {
+      if (text[cursor] === "`") {
+        next = cursor;
+        break;
+      }
+    }
+    segments.push({ text: text.slice(index, next), isCode: false });
+    index = next;
+  }
+
+  return segments;
+}
+
+function protectCodeSegments(text: string): readonly [string, ProtectedCodeSegment[]] {
+  const segments = splitCodeSegments(text);
+  if (segments.length === 0) {
+    return [text, []];
+  }
+
+  let protectedText = "";
+  const protectedSegments: ProtectedCodeSegment[] = [];
+
+  for (const [index, segment] of segments.entries()) {
+    if (!segment.isCode) {
+      protectedText += segment.text;
+      continue;
+    }
+
+    const token = `\x00CODE${index}\x00`;
+    protectedText += token;
+    protectedSegments.push({
+      token,
+      replacement: sanitizeSlackCodeSegment(segment.text)
+    });
+  }
+
+  return [protectedText, protectedSegments];
+}
+
+function restoreCodeSegments(text: string, segments: readonly ProtectedCodeSegment[]): string {
+  let restored = text;
+  for (const segment of segments) {
+    restored = restored.replaceAll(segment.token, segment.replacement);
+  }
+  return restored;
+}
+
+function transformMarkdownText(text: string): string {
+  return convertCommonMarkdown(convertEmphasis(text));
+}
+
+function transformMarkdownishText(text: string): string {
+  return convertCommonMarkdown(convertStrongEmphasis(text));
+}
+
+function convertCommonMarkdown(text: string): string {
+  let converted = convertMarkdownTable(text);
+  converted = converted.replaceAll(mdLinkRe, (_match, label: string, target: string) => {
+    return `<${normalizeMarkdownLinkTarget(target)}|${label}>`;
+  });
+  converted = converted.replaceAll(mdHeaderRe, "*$1*");
+  converted = converted.replaceAll(mdStrikeRe, "~$1~");
+  converted = converted.replaceAll(mdUnorderedListRe, "$1• ");
+  converted = converted.replaceAll(mdOrderedListRe, normalizeOrderedListPrefix);
+  converted = converted.replaceAll("\n---\n", "\n———\n");
+  converted = converted.replaceAll("\n***\n", "\n———\n");
+  converted = converted.replaceAll("\n___\n", "\n———\n");
+  return converted;
+}
+
+function normalizeMarkdownLinkTarget(target: string): string {
+  const trimmed = target.trim();
+  const bareMatch = slackLinkBareRe.exec(trimmed);
+  if (bareMatch) {
+    return bareMatch[1]!;
+  }
+  return trimmed;
+}
+
+function normalizeOrderedListPrefix(match: string): string {
+  const trimmed = match.replace(/^[ \t]*/, "");
+  const indent = match.slice(0, match.length - trimmed.length);
+  if (trimmed === "") {
+    return match;
+  }
+  const marker = trimmed.trim();
+  if (!marker.endsWith(".")) {
+    return match;
+  }
+  return `${indent}${marker} `;
+}
+
+function convertEmphasis(text: string): string {
+  let converted = text.replaceAll(mdBoldItalicRe, `${phBIOpen}$1${phBIClose}`);
+  converted = converted.replaceAll(mdBoldRe, `${phBOpen}$1${phBClose}`);
+  converted = converted.replaceAll(mdItalicRe, "_$1_");
+
+  converted = converted.replaceAll(phBIOpen, "*_");
+  converted = converted.replaceAll(phBIClose, "_*");
+  converted = converted.replaceAll(phBOpen, "*");
+  converted = converted.replaceAll(phBClose, "*");
+  return converted;
+}
+
+function convertStrongEmphasis(text: string): string {
+  let converted = text.replaceAll(mdBoldItalicRe, "*_$1_*");
+  converted = converted.replaceAll(mdBoldRe, "*$1*");
+  return converted;
+}
+
+function convertMarkdownTable(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+
+  for (let index = 0; index < lines.length;) {
+    if (
+      index + 1 < lines.length &&
+      mdTableRowRe.test(lines[index]!) &&
+      mdTableSepRe.test(lines[index + 1]!)
+    ) {
+      const headers = parseTableRow(lines[index]!);
+      index += 2;
+
+      while (index < lines.length && mdTableRowRe.test(lines[index]!)) {
+        const columns = parseTableRow(lines[index]!);
+        const parts: string[] = [];
+
+        for (const [columnIndex, column] of columns.entries()) {
+          const trimmedColumn = column.trim();
+          if (trimmedColumn === "") {
+            continue;
+          }
+
+          if (columnIndex < headers.length) {
+            const header = headers[columnIndex]!.trim();
+            if (header !== "") {
+              parts.push(`*${header}*: ${trimmedColumn}`);
+              continue;
+            }
+          }
+
+          parts.push(trimmedColumn);
+        }
+
+        if (parts.length > 0) {
+          result.push(`• ${parts.join("  ·  ")}`);
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    result.push(lines[index]!);
+    index += 1;
+  }
+
+  return result.join("\n");
+}
+
+function parseTableRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((part) => part.trim());
+}

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -647,6 +647,12 @@ describe("AppServerClient disconnect handling", () => {
       expect.stringContaining("BROKER_JOB_HELPER")
     );
     expect(threadStartParams?.baseInstructions).toEqual(
+      expect.stringContaining("Write normal Markdown in the `text` field")
+    );
+    expect(threadStartParams?.baseInstructions).toEqual(
+      expect.stringContaining("the broker converts markdownish output to `mrkdwn` before posting")
+    );
+    expect(threadStartParams?.baseInstructions).toEqual(
       expect.stringContaining("The main Codex runtime for this Slack broker does not load the linear or notion MCPs directly")
     );
     expect(threadStartParams?.baseInstructions).toEqual(

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -1085,6 +1085,129 @@ describe.sequential("slack-codex-broker e2e", () => {
     await delay(2_000);
     expect(mockCodex.turnsStarted).toHaveLength(turnCountBeforeRestart);
   }, 60_000);
+
+  it("converts markdownish Slack posts to mrkdwn before delivery", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
+    cleanups.push(async () => {
+      await removeTempRoot(tempRoot);
+    });
+
+    const brokerPort = await getFreePort();
+    const brokerBaseUrl = `http://127.0.0.1:${brokerPort}`;
+    const mockSlack = new MockSlackServer("UBOT", {
+      botId: "BBOT",
+      appId: "AAPP"
+    });
+    const mockCodex = new MockCodexAppServer();
+    const slackPort = await mockSlack.start();
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+      await mockSlack.stop();
+    });
+
+    const broker = await startBrokerProcess({
+      port: brokerPort,
+      slackPort,
+      codexUrl,
+      tempRoot
+    });
+    cleanups.push(() => broker.stop());
+
+    await mockSlack.sendEvent("evt-format-session", {
+      type: "app_mention",
+      user: "U123",
+      channel: "C123",
+      thread_ts: "777.220",
+      ts: "777.221",
+      text: "<@UBOT> 开个 session"
+    });
+    await waitFor(() => mockCodex.turnsStarted.length >= 1, "format session bootstrap turn");
+    await waitForSessionIdle(tempRoot, "C123:777.220");
+
+    await postJson(`${brokerBaseUrl}/slack/post-message`, {
+      channel_id: "C123",
+      thread_ts: "777.220",
+      text: "## Summary\n- **done**\n- [docs](https://example.com)\n- `https://linear.app/settings/api`"
+    });
+
+    await waitFor(
+      () => mockSlack.postedMessages.some((message) => message.threadTs === "777.220" && message.text.includes("*Summary*")),
+      "converted slack markdown post"
+    );
+
+    const posted = mockSlack.postedMessages.find((message) => message.threadTs === "777.220" && message.text.includes("*Summary*"));
+    expect(posted?.text).toBe(
+      "*Summary*\n• *done*\n• <https://example.com|docs>\n• `https://linear.\u200Bapp/settings/api`"
+    );
+  }, 60_000);
+
+  it("chunks long Slack posts after markdownish conversion", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
+    cleanups.push(async () => {
+      await removeTempRoot(tempRoot);
+    });
+
+    const brokerPort = await getFreePort();
+    const brokerBaseUrl = `http://127.0.0.1:${brokerPort}`;
+    const mockSlack = new MockSlackServer("UBOT", {
+      botId: "BBOT",
+      appId: "AAPP"
+    });
+    const mockCodex = new MockCodexAppServer();
+    const slackPort = await mockSlack.start();
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+      await mockSlack.stop();
+    });
+
+    const broker = await startBrokerProcess({
+      port: brokerPort,
+      slackPort,
+      codexUrl,
+      tempRoot
+    });
+    cleanups.push(() => broker.stop());
+
+    await mockSlack.sendEvent("evt-long-format-session", {
+      type: "app_mention",
+      user: "U123",
+      channel: "C123",
+      thread_ts: "888.220",
+      ts: "888.221",
+      text: "<@UBOT> 开个 session"
+    });
+    await waitFor(() => mockCodex.turnsStarted.length >= 1, "long format session bootstrap turn");
+    await waitForSessionIdle(tempRoot, "C123:888.220");
+
+    const markdownUnit = "1. **item**\n";
+    const mrkdwnUnit = "1. *item*\n";
+    const markdown = markdownUnit.repeat(400).trimEnd();
+
+    await postJson(`${brokerBaseUrl}/slack/post-message`, {
+      channel_id: "C123",
+      thread_ts: "888.220",
+      text: markdown
+    });
+
+    await waitFor(
+      () =>
+        mockSlack.postedMessages.filter(
+          (message) => message.threadTs === "888.220" && message.text.startsWith("1. *item*")
+        ).length >= 2,
+      "multi-chunk converted slack post"
+    );
+
+    const posted = mockSlack.postedMessages.filter(
+      (message) => message.threadTs === "888.220" && message.text.startsWith("1. *item*")
+    );
+    expect(posted).toHaveLength(2);
+    expect(posted[0]?.text).toBe(mrkdwnUnit.repeat(350));
+    expect(posted[1]?.text).toBe(mrkdwnUnit.repeat(49) + "1. *item*");
+    expect(posted[0]?.text).not.toContain("**");
+    expect(posted[1]?.text).not.toContain("**");
+  }, 60_000);
 });
 
 async function startBrokerProcess(options: {

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -731,13 +731,13 @@ describe.sequential("slack-codex-broker e2e", () => {
       text: "<@UBOT> 继续把这个做完"
     });
 
-    await waitFor(() => mockCodex.turnsStarted.length >= 2, "unexpected stop wake turn", 60_000);
+    await waitFor(() => mockCodex.turnsStarted.length >= 2, "unexpected stop wake turn", 120_000);
     const wakeText = collectTextInput(mockCodex.turnsStarted[1]!.input);
     expect(wakeText).toContain("unexpected_turn_stop_json");
     expect(wakeText).toContain("explicit final, block, or wait state");
     await waitForSessionIdle(tempRoot, "C123:666.220");
     expect(turnCount).toBe(2);
-  }, 90_000);
+  }, 150_000);
 
   it("wakes a wait turn when no running async job backs that wait state", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));

--- a/test/slack-conversation-service.test.ts
+++ b/test/slack-conversation-service.test.ts
@@ -105,4 +105,44 @@ describe("SlackConversationService", () => {
 
     await service.stop();
   });
+
+  it("converts file upload initial comments from markdownish to mrkdwn", async () => {
+    const codex = new EventEmitter();
+    const uploadThreadFile = vi.fn(async () => ({
+      fileId: "F123"
+    }));
+    const setLastSlackReplyAt = vi.fn(async () => TEST_SESSION);
+
+    const service = new SlackConversationService({
+      config: TEST_CONFIG,
+      sessions: {
+        setLastSlackReplyAt
+      } as never,
+      codex: codex as never,
+      slackApi: {
+        uploadThreadFile,
+        setAssistantThreadStatus: vi.fn(),
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      selfMessageFilter: {} as never
+    });
+
+    await service.postSlackFile({
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      contentBase64: Buffer.from("hello world").toString("base64"),
+      filename: "report.txt",
+      initialComment: "## Summary\n- **done**\n- [docs](https://example.com)"
+    });
+
+    expect(uploadThreadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialComment: "*Summary*\n• *done*\n• <https://example.com|docs>"
+      })
+    );
+    expect(setLastSlackReplyAt).toHaveBeenCalledTimes(1);
+
+    await service.stop();
+  });
 });

--- a/test/slack-mrkdwn.test.ts
+++ b/test/slack-mrkdwn.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  markdownishToMrkdwn,
+  markdownToMrkdwn,
+  markdownToSlackFallbackText
+} from "../src/services/slack/slack-mrkdwn.js";
+
+describe("markdownToMrkdwn", () => {
+  const cases = [
+    {
+      name: "bold and links",
+      input: "Use **bold** and [docs](https://example.com).",
+      expected: "Use *bold* and <https://example.com|docs>."
+    },
+    {
+      name: "headers and lists",
+      input: "## Summary\n- first\n2. second",
+      expected: "*Summary*\n• first\n2. second"
+    },
+    {
+      name: "ordered list preserves numbering",
+      input: "1. first\n2. second\n10. tenth",
+      expected: "1. first\n2. second\n10. tenth"
+    },
+    {
+      name: "strikethrough and hr",
+      input: "before\n---\n~~done~~",
+      expected: "before\n———\n~done~"
+    },
+    {
+      name: "tables become bullets",
+      input: "| Name | Status |\n| --- | --- |\n| Alice | Done |",
+      expected: "• *Name*: Alice  ·  *Status*: Done"
+    },
+    {
+      name: "code is preserved and autolink-safe",
+      input: "Use `ghcr.io/afk-surf/unbox` and ```go\nfunc **main**() {}\n``` after **bold**",
+      expected: "Use `ghcr.\u200Bio/afk-surf/unbox` and ```go\nfunc **main**() {}\n``` after *bold*"
+    },
+    {
+      name: "single asterisk becomes italic",
+      input: "this is *italic* text",
+      expected: "this is _italic_ text"
+    },
+    {
+      name: "bold can wrap inline code",
+      input: "• **bridge-staging 那边的 `linear-cli`** — 需要确认是哪个版本",
+      expected: "• *bridge-staging 那边的 `linear-cli`* — 需要确认是哪个版本"
+    },
+    {
+      name: "inline code URL is protected without broken autolink",
+      input: "去 `https://linear.app/settings/api` 创建一个可供我使用的 API key",
+      expected: "去 `https://linear.\u200Bapp/settings/api` 创建一个可供我使用的 API key"
+    },
+    {
+      name: "inline code email is protected without autolink",
+      input: "我的邮箱是：`06ek3ybnehw4vb7zaz1damtae8@a-staging.bridge.surf`",
+      expected: "我的邮箱是：`06ek3ybnehw4vb7zaz1damtae8@\u200Ba-staging.bridge.surf`"
+    },
+    {
+      name: "inline code unwraps slack bare autolink before protecting",
+      input: "`<https://example.com/a/b>`",
+      expected: "`https://example.\u200Bcom/a/b`"
+    },
+    {
+      name: "inline code unwraps slack mailto autolink before protecting",
+      input: "`<mailto:name@example.com|name@example.com>`",
+      expected: "`name@\u200Bexample.com`"
+    },
+    {
+      name: "markdown link strips slack angle wrapped target",
+      input: "[OpenAI](<https://openai.com>)",
+      expected: "<https://openai.com|OpenAI>"
+    }
+  ] as const;
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      expect(markdownToMrkdwn(testCase.input)).toBe(testCase.expected);
+    });
+  }
+});
+
+describe("markdownishToMrkdwn", () => {
+  const cases = [
+    {
+      name: "preserves slack bold while converting markdown links",
+      input: ":calendar: *Weekly Sync*\n[Open doc](https://example.com/doc)",
+      expected: ":calendar: *Weekly Sync*\n<https://example.com/doc|Open doc>"
+    },
+    {
+      name: "converts markdown bold and ordered list",
+      input: "<@U123> **Please check** this:\n1. [Spec](https://example.com/spec)\n2. ~~Old note~~",
+      expected: "<@U123> *Please check* this:\n1. <https://example.com/spec|Spec>\n2. ~Old note~"
+    },
+    {
+      name: "preserves inline code and mrkdwn links",
+      input: "Use `rg \"foo\"` and see <https://example.com|existing link>.",
+      expected: "Use `rg \"foo\"` and see <https://example.com|existing link>."
+    }
+  ] as const;
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      expect(markdownishToMrkdwn(testCase.input)).toBe(testCase.expected);
+    });
+  }
+});
+
+describe("markdownToSlackFallbackText", () => {
+  it("returns converted fallback text when markdown produces mrkdwn", () => {
+    expect(markdownToSlackFallbackText("See **status** in [Linear](https://linear.app).")).toBe(
+      "See *status* in <https://linear.app|Linear>."
+    );
+  });
+
+  it("returns original text for blank output", () => {
+    expect(markdownToSlackFallbackText("   ")).toBe("   ");
+  });
+});


### PR DESCRIPTION
## Context

- 这次改动解决的是 broker 出站 Slack 文本格式职责放错层的问题。
- 之前 broker 基本把 `text` 原样发给 Slack，导致模型需要自己直接产出正确的 Slack `mrkdwn`；一旦输出偏向普通 Markdown，Slack 里的可读性就会明显变差。
- 这次的目标不是重新设计一套新的转换规则，而是把一套既有的 `markdownish -> mrkdwn` 语义稳定搬到 broker，并把“先写 Markdown、broker 负责转 Slack 格式”变成统一契约。

## 协作过程

```mermaid
sequenceDiagram
    participant User as User
    participant Codex as Codex
    participant Broker as slack-codex-broker
    participant Ref as Existing formatter logic
    participant Slack as Slack API

    User->>Codex: 把 broker 改成 markdown -> mrkdwn
    Codex->>Broker: 定位当前 Slack 文本出站链路
    Codex->>Ref: 对照既有 markdownish -> mrkdwn 实现与测试
    Note right of Codex: 明确要求不重新发明转换规则
    Codex->>Broker: 移植转换器并接到统一 Slack 出站层
    Codex->>Broker: 更新系统提示和 README 契约
    Codex->>Broker: 增补单测、base instructions 测试、e2e 验证
    Codex->>Slack: 通过 mock Slack e2e 验证“先转换再切 chunk 再发消息”
```

Note:
关键决策点有两个。第一，转换逻辑不是只挂在 `/slack/post-message` 的 HTTP 入口，而是挂在统一文本出站层，这样 broker 自己补发的失败提示和其他文本出口也能自动复用同一套规则。第二，chunking 放在转换之后，避免 Markdown 语法先被截断，再去做不稳定的格式转换。

## 方案讨论

### 方案一：继续要求 Codex 直接输出正确的 mrkdwn

- 优点是 broker 不需要新增文本格式层。
- 问题是这会把 Slack 语法细节压给模型，稳定性差，而且不同模型/提示词一变，Slack 渲染就容易漂。
- 这个方案没有把格式职责从模型侧剥离出来，也违背了这次需求的核心方向。

### 方案二：在 broker 里重新实现一套新的 Markdown 转换规则

- 理论上可以做出更“贴 broker” 的实现。
- 但这会引入第二份语义来源，后续行为和既有实现很容易漂移，测试样例也会开始分叉。
- 这次明确不采用，避免重复维护和行为不一致。

### 方案三：移植既有的 `markdownish -> mrkdwn` 语义，并在 broker 出站统一接入

- 这是本次采用的方案。
- `src/services/slack/slack-mrkdwn.ts` 逐语义实现已有转换规则，包括 code segment 保护、links / headers / emphasis / lists / tables / hr 转换，以及 inline code 里的 autolink 打断逻辑。
- `SlackConversationService` 在统一文本出站链路上先做 `markdownishToMrkdwn`，再做 `chunkSlackMessage`，最后发 Slack；这样调用方继续只管写 Markdown。

## 最终方案

- 新增一个独立的 Slack 文本格式模块，作为 broker 内唯一的 markdownish -> mrkdwn 语义来源。
- 把统一文本出站流程改成：`markdownishToMrkdwn(text) -> chunkSlackMessage(formattedText) -> SlackApi.postThreadMessage(...)`。
- 保留原有 `/slack/post-message` 接口形状，不新增 `render_mode` 或其他配置字段，避免把选择权重新暴露给调用方。
- 更新 Slack thread base instructions 和 README，明确 `text` 字段应该写普通 Markdown，broker 会在投递前转成 Slack `mrkdwn`。
- 测试层面补齐转换器样例和 broker 侧 e2e，锁住“转换发生在 chunk 之前”的行为。

```mermaid
sequenceDiagram
    participant Agent as Codex Agent
    participant Broker as SlackConversationService
    participant Formatter as slack-mrkdwn
    participant Chunker as chunkSlackMessage
    participant Slack as Slack API

    Agent->>Broker: POST /slack/post-message { text: markdown }
    Broker->>Formatter: markdownishToMrkdwn(text)
    Formatter-->>Broker: formatted mrkdwn
    Broker->>Chunker: chunkSlackMessage(formattedText)
    Chunker-->>Broker: chunks
    Broker->>Slack: chat.postMessage(chunk 1..n)
```

## 验证情况

- `pnpm vitest run test/slack-mrkdwn.test.ts test/app-server-client.test.ts test/e2e-broker.test.ts`
- `pnpm build`
- `pnpm test`
- `<!-- 请补充 CC 之外的验证 -->`

## 已知局限 / 后续工作

- 这次只覆盖纯文本 Slack 消息的 Markdown/markdownish 归一化；没有扩展到 Block Kit 或 `rich_text` 自动构造。
- 当前实现仍然是 broker 内维护的一份 TypeScript 版本；如果后续既有语义继续演进，最好补一个更明确的同步约定。
- 这次没有引入可配置的 render mode，因为当前目标是先统一默认行为，避免调用方再次承担 Slack 渲染策略选择。
