### PR TITLE
fix(admin): persist session ui state

### DIFF
--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -535,8 +535,10 @@ function renderAdminPage(options: {
     const addProfileDialog = document.getElementById("add-profile-dialog");
     const deployRefInput = document.getElementById("deploy-ref-input");
     const uiStateStorageKey = "admin-ui-state:" + window.location.pathname;
+    const deferredUiStatePersistMs = 150;
     let latestStatus = null;
     let uiState = loadUiState();
+    let uiStatePersistTimer = null;
 
     function esc(value) {
       return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
@@ -578,14 +580,35 @@ function renderAdminPage(options: {
       }
     }
 
+    function cancelScheduledUiStatePersistence() {
+      if (uiStatePersistTimer == null) {
+        return;
+      }
+      window.clearTimeout(uiStatePersistTimer);
+      uiStatePersistTimer = null;
+    }
+
     function persistUiState() {
+      cancelScheduledUiStatePersistence();
       try {
         window.localStorage.setItem(uiStateStorageKey, JSON.stringify(uiState));
       } catch {}
     }
 
-    function updateUiState(patch) {
+    function scheduleUiStatePersistence() {
+      cancelScheduledUiStatePersistence();
+      uiStatePersistTimer = window.setTimeout(() => {
+        uiStatePersistTimer = null;
+        persistUiState();
+      }, deferredUiStatePersistMs);
+    }
+
+    function updateUiState(patch, options) {
       uiState = normalizeUiState(Object.assign({}, uiState, patch || {}));
+      if (options?.deferPersist) {
+        scheduleUiStatePersistence();
+        return;
+      }
       persistUiState();
     }
 
@@ -602,6 +625,17 @@ function renderAdminPage(options: {
       }
       updateUiState({
         expandedSessionKeys: [...next]
+      });
+    }
+
+    function pruneExpandedSessionKeys(sessionKeys) {
+      const allowedKeys = new Set((sessionKeys || []).map((sessionKey) => String(sessionKey)));
+      const expandedSessionKeys = uiState.expandedSessionKeys.filter((sessionKey) => allowedKeys.has(sessionKey));
+      if (expandedSessionKeys.length === uiState.expandedSessionKeys.length) {
+        return;
+      }
+      updateUiState({
+        expandedSessionKeys
       });
     }
 
@@ -833,6 +867,7 @@ function renderAdminPage(options: {
     function renderSessions(data) {
       const panel = document.getElementById("sessions-panel");
       const list = data.state?.sessions || [];
+      pruneExpandedSessionKeys(list.map((session) => session.key));
       const query = (sessionSearch.value || "").toLowerCase();
       const mode = sessionFilter.value;
       
@@ -1063,8 +1098,11 @@ function renderAdminPage(options: {
 
     refreshButton.onclick = refresh;
     sessionSearch.oninput = () => {
-      updateUiState({ sessionSearch: sessionSearch.value });
+      updateUiState({ sessionSearch: sessionSearch.value }, { deferPersist: true });
       if (latestStatus) renderSessions(latestStatus);
+    };
+    sessionSearch.onblur = () => {
+      persistUiState();
     };
     sessionFilter.onchange = () => {
       updateUiState({ sessionFilter: sessionFilter.value });

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -534,10 +534,75 @@ function renderAdminPage(options: {
     const sessionFilter = document.getElementById("session-filter");
     const addProfileDialog = document.getElementById("add-profile-dialog");
     const deployRefInput = document.getElementById("deploy-ref-input");
+    const uiStateStorageKey = "admin-ui-state:" + window.location.pathname;
     let latestStatus = null;
+    let uiState = loadUiState();
 
     function esc(value) {
       return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+    }
+
+    function defaultUiState() {
+      return {
+        sessionSearch: "",
+        sessionFilter: "all",
+        expandedSessionKeys: []
+      };
+    }
+
+    function normalizeUiState(value) {
+      const next = value && typeof value === "object" ? value : {};
+      const sessionFilterValue = ["all", "active", "inbound", "jobs", "issues"].includes(String(next.sessionFilter || ""))
+        ? String(next.sessionFilter)
+        : "all";
+      const sessionSearchValue = typeof next.sessionSearch === "string" ? next.sessionSearch : "";
+      const expandedSessionKeys = Array.isArray(next.expandedSessionKeys)
+        ? [...new Set(next.expandedSessionKeys.map((item) => String(item)).filter(Boolean))]
+        : [];
+      return {
+        sessionSearch: sessionSearchValue,
+        sessionFilter: sessionFilterValue,
+        expandedSessionKeys
+      };
+    }
+
+    function loadUiState() {
+      try {
+        const raw = window.localStorage.getItem(uiStateStorageKey);
+        if (!raw) {
+          return defaultUiState();
+        }
+        return normalizeUiState(JSON.parse(raw));
+      } catch {
+        return defaultUiState();
+      }
+    }
+
+    function persistUiState() {
+      try {
+        window.localStorage.setItem(uiStateStorageKey, JSON.stringify(uiState));
+      } catch {}
+    }
+
+    function updateUiState(patch) {
+      uiState = normalizeUiState(Object.assign({}, uiState, patch || {}));
+      persistUiState();
+    }
+
+    function isSessionExpanded(sessionKey) {
+      return uiState.expandedSessionKeys.includes(String(sessionKey));
+    }
+
+    function updateSessionExpansion(sessionKey, expanded) {
+      const next = new Set(uiState.expandedSessionKeys);
+      if (expanded) {
+        next.add(String(sessionKey));
+      } else {
+        next.delete(String(sessionKey));
+      }
+      updateUiState({
+        expandedSessionKeys: [...next]
+      });
     }
 
     function fmtTime(value) {
@@ -788,7 +853,8 @@ function renderAdminPage(options: {
       panel.innerHTML = filtered.map(s => {
         const lead = summarizeSessionLead(s);
         const isActive = !!s.activeTurnId;
-        return '<details class="session-row">' +
+        const expanded = isSessionExpanded(s.key);
+        return '<details class="session-row" data-session-key="' + esc(s.key) + '"' + (expanded ? " open" : "") + ">" +
           '<summary class="session-summary">' +
             '<div class="session-key">' + esc(s.key) + '<div style="font-size:10px; font-weight:normal; color:var(--muted)">' + esc(s.channelId) + '</div></div>' +
             '<div>' + renderBadge(isActive ? "ACTIVE" : "IDLE", isActive ? "good" : "warn") + '<div style="font-size:10px; color:var(--muted)">UP: ' + fmtTime(s.updatedAt) + '</div></div>' +
@@ -805,6 +871,16 @@ function renderAdminPage(options: {
           '</div>' +
         '</details>';
       }).join("");
+
+      panel.querySelectorAll(".session-row").forEach((row) => {
+        row.addEventListener("toggle", () => {
+          const sessionKey = row.getAttribute("data-session-key");
+          if (!sessionKey) {
+            return;
+          }
+          updateSessionExpansion(sessionKey, row.open);
+        });
+      });
     }
 
     function renderInboundTable(items) {
@@ -982,9 +1058,18 @@ function renderAdminPage(options: {
       finally { refreshButton.disabled = false; }
     }
 
+    sessionSearch.value = uiState.sessionSearch;
+    sessionFilter.value = uiState.sessionFilter;
+
     refreshButton.onclick = refresh;
-    sessionSearch.oninput = () => { if (latestStatus) renderSessions(latestStatus); };
-    sessionFilter.onchange = () => { if (latestStatus) renderSessions(latestStatus); };
+    sessionSearch.oninput = () => {
+      updateUiState({ sessionSearch: sessionSearch.value });
+      if (latestStatus) renderSessions(latestStatus);
+    };
+    sessionFilter.onchange = () => {
+      updateUiState({ sessionFilter: sessionFilter.value });
+      if (latestStatus) renderSessions(latestStatus);
+    };
     document.getElementById("open-add-profile-dialog").onclick = () => {
       document.getElementById("add-profile-status").textContent = "";
       addProfileDialog.showModal();

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -134,6 +134,58 @@ describe("admin routes", () => {
     expect(html).not.toContain("/admin/api/runtime-files");
   });
 
+  it("persists session ui state in the admin page script", async () => {
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv);
+    const adminService = {
+      getStatus: async () => ({ ok: true, status: "admin-ok" }),
+      addAuthProfile: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      activateAuthProfile: async () => ({ ok: true }),
+      deployWorker: async () => ({ ok: true }),
+      rollbackWorker: async () => ({ ok: true })
+    };
+
+    const server = http.createServer(
+      createHttpHandler({
+        adminService: adminService as never,
+        bridge: {} as never,
+        isolatedMcp: {} as never,
+        jobManager: {} as never,
+        config
+      })
+    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start test server");
+    }
+
+    const page = await fetch(`http://127.0.0.1:${address.port}/admin`);
+    expect(page.status).toBe(200);
+    const html = await page.text();
+
+    expect(html).toContain("admin-ui-state:");
+    expect(html).toContain("expandedSessionKeys");
+    expect(html).toContain('data-session-key="');
+    expect(html).toContain("window.localStorage.getItem");
+    expect(html).toContain('row.addEventListener("toggle"');
+  });
+
   it("accepts auth profile creation without an explicit name", async () => {
     const config = loadConfig({
       SLACK_APP_TOKEN: "xapp-test",

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -15,21 +15,8 @@ describe("admin routes", () => {
     }
   });
 
-  it("requires the configured admin token for admin api requests", async () => {
-    const config = loadConfig({
-      SLACK_APP_TOKEN: "xapp-test",
-      SLACK_BOT_TOKEN: "xoxb-test",
-      BROKER_ADMIN_TOKEN: "secret-token"
-    } as NodeJS.ProcessEnv);
-    const adminService = {
-      getStatus: async () => ({ ok: true, status: "admin-ok" }),
-      addAuthProfile: async () => ({ ok: true }),
-      deleteAuthProfile: async () => ({ ok: true }),
-      activateAuthProfile: async () => ({ ok: true }),
-      deployWorker: async () => ({ ok: true }),
-      rollbackWorker: async () => ({ ok: true })
-    };
-
+  async function startAdminServer(configEnv: NodeJS.ProcessEnv, adminService: Record<string, unknown>): Promise<string> {
+    const config = loadConfig(configEnv);
     const server = http.createServer(
       createHttpHandler({
         adminService: adminService as never,
@@ -56,7 +43,22 @@ describe("admin routes", () => {
     if (!address || typeof address === "string") {
       throw new Error("failed to start test server");
     }
-    const baseUrl = `http://127.0.0.1:${address.port}`;
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  it("requires the configured admin token for admin api requests", async () => {
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      BROKER_ADMIN_TOKEN: "secret-token"
+    } as NodeJS.ProcessEnv, {
+      getStatus: async () => ({ ok: true, status: "admin-ok" }),
+      addAuthProfile: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      activateAuthProfile: async () => ({ ok: true }),
+      deployWorker: async () => ({ ok: true }),
+      rollbackWorker: async () => ({ ok: true })
+    });
 
     const unauthorized = await fetch(`${baseUrl}/admin/api/status`);
     expect(unauthorized.status).toBe(401);
@@ -74,47 +76,19 @@ describe("admin routes", () => {
   });
 
   it("renders auth profile management and session console sections in the admin page", async () => {
-    const config = loadConfig({
+    const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",
       SLACK_BOT_TOKEN: "xoxb-test"
-    } as NodeJS.ProcessEnv);
-    const adminService = {
+    } as NodeJS.ProcessEnv, {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
       rollbackWorker: async () => ({ ok: true })
-    };
-
-    const server = http.createServer(
-      createHttpHandler({
-        adminService: adminService as never,
-        bridge: {} as never,
-        isolatedMcp: {} as never,
-        jobManager: {} as never,
-        config
-      })
-    );
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    cleanups.push(async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     });
 
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("failed to start test server");
-    }
-
-    const page = await fetch(`http://127.0.0.1:${address.port}/admin`);
+    const page = await fetch(`${baseUrl}/admin`);
     expect(page.status).toBe(200);
     const html = await page.text();
 
@@ -135,64 +109,38 @@ describe("admin routes", () => {
   });
 
   it("persists session ui state in the admin page script", async () => {
-    const config = loadConfig({
+    const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",
       SLACK_BOT_TOKEN: "xoxb-test"
-    } as NodeJS.ProcessEnv);
-    const adminService = {
+    } as NodeJS.ProcessEnv, {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
       rollbackWorker: async () => ({ ok: true })
-    };
-
-    const server = http.createServer(
-      createHttpHandler({
-        adminService: adminService as never,
-        bridge: {} as never,
-        isolatedMcp: {} as never,
-        jobManager: {} as never,
-        config
-      })
-    );
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    cleanups.push(async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     });
 
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("failed to start test server");
-    }
-
-    const page = await fetch(`http://127.0.0.1:${address.port}/admin`);
+    const page = await fetch(`${baseUrl}/admin`);
     expect(page.status).toBe(200);
     const html = await page.text();
 
     expect(html).toContain("admin-ui-state:");
     expect(html).toContain("expandedSessionKeys");
     expect(html).toContain('data-session-key="');
+    expect(html).toContain("scheduleUiStatePersistence");
+    expect(html).toContain("pruneExpandedSessionKeys");
     expect(html).toContain("window.localStorage.getItem");
     expect(html).toContain('row.addEventListener("toggle"');
+    expect(html).toContain("sessionSearch.onblur");
   });
 
   it("accepts auth profile creation without an explicit name", async () => {
-    const config = loadConfig({
+    const calls: Array<Record<string, unknown>> = [];
+    const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",
       SLACK_BOT_TOKEN: "xoxb-test"
-    } as NodeJS.ProcessEnv);
-    const calls: Array<Record<string, unknown>> = [];
-    const adminService = {
+    } as NodeJS.ProcessEnv, {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async (payload: Record<string, unknown>) => {
         calls.push(payload);
@@ -202,36 +150,9 @@ describe("admin routes", () => {
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
       rollbackWorker: async () => ({ ok: true })
-    };
-
-    const server = http.createServer(
-      createHttpHandler({
-        adminService: adminService as never,
-        bridge: {} as never,
-        isolatedMcp: {} as never,
-        jobManager: {} as never,
-        config
-      })
-    );
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    cleanups.push(async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     });
 
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("failed to start test server");
-    }
-
-    const response = await fetch(`http://127.0.0.1:${address.port}/admin/api/auth-profiles`, {
+    const response = await fetch(`${baseUrl}/admin/api/auth-profiles`, {
       method: "POST",
       headers: {
         "content-type": "application/json"
@@ -250,47 +171,19 @@ describe("admin routes", () => {
   });
 
   it("emits admin page inline script without syntax errors", async () => {
-    const config = loadConfig({
+    const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",
       SLACK_BOT_TOKEN: "xoxb-test"
-    } as NodeJS.ProcessEnv);
-    const adminService = {
+    } as NodeJS.ProcessEnv, {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
       rollbackWorker: async () => ({ ok: true })
-    };
-
-    const server = http.createServer(
-      createHttpHandler({
-        adminService: adminService as never,
-        bridge: {} as never,
-        isolatedMcp: {} as never,
-        jobManager: {} as never,
-        config
-      })
-    );
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    cleanups.push(async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     });
 
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("failed to start test server");
-    }
-
-    const page = await fetch(`http://127.0.0.1:${address.port}/admin`);
+    const page = await fetch(`${baseUrl}/admin`);
     const html = await page.text();
     const scriptMatch = html.match(/<script>([\s\S]*)<\/script>/);
     expect(scriptMatch?.[1]).toBeTruthy();
@@ -302,12 +195,11 @@ describe("admin routes", () => {
   });
 
   it("forwards deploy requests to the admin service", async () => {
-    const config = loadConfig({
+    const calls: Array<Record<string, unknown>> = [];
+    const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",
       SLACK_BOT_TOKEN: "xoxb-test"
-    } as NodeJS.ProcessEnv);
-    const calls: Array<Record<string, unknown>> = [];
-    const adminService = {
+    } as NodeJS.ProcessEnv, {
       getStatus: async () => ({ ok: true }),
       addAuthProfile: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
@@ -317,33 +209,9 @@ describe("admin routes", () => {
         return { ok: true };
       },
       rollbackWorker: async () => ({ ok: true })
-    };
-
-    const server = http.createServer(
-      createHttpHandler({
-        adminService: adminService as never,
-        config
-      })
-    );
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    cleanups.push(async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     });
 
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("failed to start test server");
-    }
-
-    const response = await fetch(`http://127.0.0.1:${address.port}/admin/api/deploy`, {
+    const response = await fetch(`${baseUrl}/admin/api/deploy`, {
       method: "POST",
       headers: {
         "content-type": "application/json"
@@ -363,12 +231,11 @@ describe("admin routes", () => {
   });
 
   it("forwards rollback requests to the admin service", async () => {
-    const config = loadConfig({
+    const calls: Array<Record<string, unknown>> = [];
+    const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",
       SLACK_BOT_TOKEN: "xoxb-test"
-    } as NodeJS.ProcessEnv);
-    const calls: Array<Record<string, unknown>> = [];
-    const adminService = {
+    } as NodeJS.ProcessEnv, {
       getStatus: async () => ({ ok: true }),
       addAuthProfile: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
@@ -378,33 +245,9 @@ describe("admin routes", () => {
         calls.push(payload);
         return { ok: true };
       }
-    };
-
-    const server = http.createServer(
-      createHttpHandler({
-        adminService: adminService as never,
-        config
-      })
-    );
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    cleanups.push(async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     });
 
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("failed to start test server");
-    }
-
-    const response = await fetch(`http://127.0.0.1:${address.port}/admin/api/rollback`, {
+    const response = await fetch(`${baseUrl}/admin/api/rollback`, {
       method: "POST",
       headers: {
         "content-type": "application/json"


### PR DESCRIPTION
## Context

- admin 页面当前是服务端拼接的一页原生 HTML/JS，session 列表通过内联脚本定时刷新。
- 刷新前 row 展开状态、搜索词、筛选条件都只存在当前 DOM / JS 运行态里；无论是手动刷新页面，还是 10 秒自动刷新触发 `renderSessions()` 重绘，都会把这些 UI 状态清空。
- 这次修复聚焦在“保住 admin 操作上下文”，先解决最影响使用体验的 session row 展开态，并顺手把同一块的搜索/筛选条件一起持久化，避免页面每次刷新都回到初始态。

## 协作过程

```mermaid
sequenceDiagram
    participant User as User
    participant Codex as Codex
    participant AdminUI as admin inline script
    participant Browser as localStorage
    participant Tests as admin-routes test

    User->>Codex: 反馈 admin 刷新后会丢 row 展开状态
    Codex->>AdminUI: 排查 /admin 页面状态管理路径
    Note right of Codex: 确认页面不是 React，而是服务端拼接 HTML + 原生 JS
    Codex->>AdminUI: 定位 renderSessions() 每次 innerHTML 全量重绘
    Codex->>Codex: 判断展开态仅存在 DOM，刷新后必然丢失
    Codex->>Browser: 设计轻量 localStorage UI state 持久化
    Codex->>AdminUI: 恢复 expanded rows + search/filter 初始值
    Codex->>Tests: 补回归测试，锁住持久化脚本片段
```

Note:
这次没有引入新的后端接口，也没有把 UI 状态写回服务端。核心判断是这些状态完全属于浏览器侧临时视图状态，而且只需要按 `/admin` 页面维度在本地恢复；因此最小改动方案是让前端脚本自己维护一份可序列化 UI state。

## 方案讨论

### 方案一：保持现状，只接受刷新丢状态

- 实现成本最低，但实际体验很差。
- admin 页面本身就有 10 秒自动刷新；如果展开态每次刷新都丢，session 明细几乎无法连续查看。
- 这个方案没有修复真实问题，直接排除。

### 方案二：把展开态等 UI 状态同步到服务端

- 理论上可以跨设备共享状态，但会引入完全没必要的后端复杂度。
- 这类状态是纯浏览器视图偏好，不属于 broker 运行时事实，也不值得为此设计 API / 存储结构。
- 对当前问题来说太重，不采用。

### 方案三：在 admin 内联脚本里引入本地 UI state 持久化

- 这是本次采用的方案。
- 用 `localStorage` 维护一个按页面路径隔离的 `uiState`，只保存 `expandedSessionKeys`、`sessionSearch`、`sessionFilter`。
- `renderSessions()` 根据 `session key` 恢复 `details[open]`，并通过 `toggle` 事件持续回写状态。
- 搜索框和筛选框初始化时也读取同一份状态，这样整页刷新后仍能保持当前工作上下文。

## 最终方案

- 在 admin 页内联脚本中新增 `uiState` 读写层，负责加载、归一化和持久化 UI 状态。
- session rows 渲染时给每个 `details` 注入 `data-session-key`，并根据持久化状态决定是否加 `open`。
- session list 重绘完成后，为每个 row 绑定 `toggle` 监听，实时更新 `expandedSessionKeys`。
- 搜索词和筛选条件在页面初始化时恢复，在用户输入/切换时同步写回。
- 增加 admin route 测试，确保页面脚本包含这套持久化逻辑，避免后续重构把“页面记忆”悄悄删掉。

## 验证情况

- `pnpm exec vitest run test/admin-routes.test.ts`
- `pnpm build`
- `pnpm test`：运行过程中各测试文件均报告通过，但命令未在会话内正常退出；已手动停止，因此不计为一次完整通过
- `<!-- 请补充 CC 之外的验证 -->`

## 已知局限 / 后续工作

- 这次只持久化了 session 展开态、搜索词和筛选条件；如果后续希望保留更多 admin 视图偏好，需要继续扩展同一份 `uiState`。
- 状态当前按浏览器本地 `localStorage` 保存，不会跨浏览器或跨机器同步。
- 这次没有增加真实浏览器层面的端到端测试；目前回归主要依赖 admin 页面 HTML/script 级别测试。
