### PR TITLE
feat(slack): add co-author commit gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ On the first `@bot` inside an existing Slack thread, the broker backfills a boun
 Create a Slack app with:
 
 - Socket Mode enabled
+- Interactivity enabled
 - App-level token with `connections:write`
 - Bot token scopes:
   - `app_mentions:read`
@@ -26,6 +27,7 @@ Create a Slack app with:
   - `files:read` if you want Codex to receive image attachments from Slack messages
   - `files:write` if you want Codex to upload images/files back into Slack threads
   - `users:read` if you want Codex to see Slack display names instead of only raw user IDs
+  - `users:read.email` if you want the broker to infer GitHub co-author mappings from Slack profile email
 
 Event subscriptions needed for the current broker flow:
 
@@ -34,6 +36,8 @@ Event subscriptions needed for the current broker flow:
 - `message.im` for direct-message sessions
 
 If you want to support private channels or DMs, add the corresponding `groups:history`, `im:history`, or `mpim:history` scopes plus matching message events.
+
+The broker's Slack co-author flow uses Socket Mode interactive envelopes, thread ephemerals, and modals. With Socket Mode enabled, you do not need a separate public interactivity Request URL for this flow.
 
 ## Environment
 
@@ -236,6 +240,8 @@ GET /admin/api/status
 POST /admin/api/auth-profiles
 POST /admin/api/auth-profiles/:name/activate
 DELETE /admin/api/auth-profiles/:name
+POST /admin/api/github-authors
+DELETE /admin/api/github-authors/:slackUserId
 POST /admin/api/deploy
 POST /admin/api/rollback
 ```
@@ -247,6 +253,8 @@ Typical first-run flow:
 3. Activate the profile you want the worker to use.
 4. Later, deploy a commit / branch / tag from the Deploy panel.
 5. Roll back from the same panel when needed.
+
+The same admin page also exposes a `GitHub Authors` panel for manually maintaining `Slack user -> GitHub author` mappings. Manual entries override Slack-inferred mappings.
 
 If `BROKER_ADMIN_TOKEN` is set, `/admin/api/*` requires that token via `x-admin-token` or `Authorization: Bearer ...`. If it is unset, the admin API is still enabled, so only expose the broker port in environments you trust.
 

--- a/src/admin-index.ts
+++ b/src/admin-index.ts
@@ -7,6 +7,7 @@ import { AdminService } from "./services/admin-service.js";
 import { AuthProfileService } from "./services/auth-profile-service.js";
 import { AuthFileRuntimeControl } from "./services/auth-file-runtime-control.js";
 import { WorkerDeploymentService } from "./services/deploy/worker-deployment-service.js";
+import { GitHubAuthorMappingService } from "./services/github-author-mapping-service.js";
 import { SessionManager } from "./services/session-manager.js";
 import { StateStore } from "./store/state-store.js";
 
@@ -32,6 +33,10 @@ export async function startAdminService(): Promise<{
   const authProfiles = new AuthProfileService({
     config
   });
+  const githubAuthorMappings = new GitHubAuthorMappingService({
+    stateDir: config.stateDir
+  });
+  await githubAuthorMappings.load();
   const deployment = createWorkerDeploymentService(config);
   const runtime = new AuthFileRuntimeControl(config, {
     onRestart: async (reason) => {
@@ -46,6 +51,7 @@ export async function startAdminService(): Promise<{
     sessions,
     runtime,
     authProfiles,
+    githubAuthorMappings,
     startedAt,
     deployment
   });

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -66,6 +66,32 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "POST" && url.pathname === "/admin/api/github-authors") {
+    const body = await readAdminBody(request, response);
+    if (!body) {
+      return true;
+    }
+
+    const slackUserId = readString(body.slack_user_id);
+    const githubAuthor = readString(body.github_author);
+    if (!slackUserId || !githubAuthor) {
+      respondJson(response, 400, {
+        ok: false,
+        error: "missing_required_body",
+        required: ["slack_user_id", "github_author"]
+      });
+      return true;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.upsertGitHubAuthorMapping({
+        slackUserId,
+        githubAuthor
+      })
+    );
+    return true;
+  }
+
   if (method === "POST" && url.pathname === "/admin/api/deploy") {
     const body = await readAdminBody(request, response);
     if (!body) {
@@ -131,6 +157,20 @@ export async function handleAdminRequest(
     await runAdminOperation(response, () =>
       options.adminService.deleteAuthProfile({
         name: profileName
+      })
+    );
+    return true;
+  }
+
+  if (method === "DELETE" && url.pathname.startsWith("/admin/api/github-authors/")) {
+    const slackUserId = decodeURIComponent(url.pathname.slice("/admin/api/github-authors/".length));
+    if (!slackUserId || slackUserId.includes("/")) {
+      return false;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.deleteGitHubAuthorMapping({
+        slackUserId
       })
     );
     return true;
@@ -491,6 +531,18 @@ function renderAdminPage(options: {
 
         <section>
           <div class="section-head">
+            <div class="section-title">GitHub Authors</div>
+            <button id="open-github-author-dialog">ADD</button>
+          </div>
+          <div class="toolbar" style="border-bottom:none;">
+            <input id="github-author-search" type="search" placeholder="FILTER AUTHORS..." />
+          </div>
+          <div id="github-authors-panel" style="padding:12px; display:grid; gap:8px;"></div>
+          <div id="github-authors-status" style="padding:8px; font-size:10px;"></div>
+        </section>
+
+        <section>
+          <div class="section-head">
             <div class="section-title">Deploy</div>
             <button id="deploy-release-button">DEPLOY</button>
           </div>
@@ -525,14 +577,28 @@ function renderAdminPage(options: {
     <div id="add-profile-status" style="font-size:10px;"></div>
   </div></dialog>
 
+  <dialog id="github-author-dialog"><div class="modal-content">
+    <div class="section-title">GitHub author mapping</div>
+    <input id="github-author-slack-user-id" type="text" placeholder="SLACK USER ID (U123...)" />
+    <input id="github-author-value" type="text" placeholder="Name <email@example.com>" />
+    <div style="display:flex; gap:8px; justify-content:flex-end;">
+      <button id="close-github-author-dialog" class="secondary">CANCEL</button>
+      <button id="submit-github-author-dialog">SAVE</button>
+    </div>
+    <div id="github-author-dialog-status" style="font-size:10px;"></div>
+  </div></dialog>
+
   <script>
     const refreshButton = document.getElementById("refresh-button");
     const replaceStatus = document.getElementById("replace-status");
     const deployStatus = document.getElementById("deploy-status");
+    const githubAuthorsStatus = document.getElementById("github-authors-status");
     const lastRefresh = document.getElementById("last-refresh");
     const sessionSearch = document.getElementById("session-search");
     const sessionFilter = document.getElementById("session-filter");
+    const githubAuthorSearch = document.getElementById("github-author-search");
     const addProfileDialog = document.getElementById("add-profile-dialog");
+    const githubAuthorDialog = document.getElementById("github-author-dialog");
     const deployRefInput = document.getElementById("deploy-ref-input");
     let latestStatus = null;
 
@@ -756,6 +822,75 @@ function renderAdminPage(options: {
       });
     }
 
+    function renderGitHubAuthors(data) {
+      const mappings = [...(data.githubAuthorMappings?.mappings || [])];
+      const panel = document.getElementById("github-authors-panel");
+      const query = String(githubAuthorSearch.value || "").toLowerCase();
+      const filtered = mappings.filter((mapping) => {
+        if (!query) {
+          return true;
+        }
+
+        return [
+          mapping.slackUserId,
+          mapping.githubAuthor,
+          mapping.slackIdentity?.displayName,
+          mapping.slackIdentity?.realName,
+          mapping.slackIdentity?.username,
+          mapping.slackIdentity?.email
+        ].some((value) => String(value || "").toLowerCase().includes(query));
+      });
+
+      if (!filtered.length) {
+        panel.innerHTML = '<div class="summary-detail" style="padding-top:12px;">NO GITHUB AUTHOR MAPPINGS</div>';
+        return;
+      }
+
+      panel.innerHTML = filtered.map((mapping) => {
+        const identity = mapping.slackIdentity || {};
+        const label = identity.realName || identity.displayName || identity.username || mapping.slackUserId;
+        const detail = [mapping.slackUserId, identity.email].filter(Boolean).join(" · ");
+        return '<div class="profile-row">' +
+                 '<div class="profile-line">' +
+                   '<span class="profile-account">' + esc(label) + "</span>" +
+                   '<span class="profile-plan">' + esc(detail || mapping.slackUserId) + "</span>" +
+                   renderBadge(mapping.source === "manual" ? "manual" : "auto", mapping.source === "manual" ? "good" : "warn") +
+                 "</div>" +
+                 '<div class="summary-detail">' + esc(mapping.githubAuthor) + "</div>" +
+                 '<div class="summary-detail">UPDATED: ' + esc(new Date(mapping.updatedAt).toLocaleString()) + "</div>" +
+                 '<div class="profile-actions">' +
+                   '<button class="secondary" data-edit-github-author="' + esc(mapping.slackUserId) + '"' +
+                     ' data-edit-github-author-value="' + esc(mapping.githubAuthor) + '">EDIT</button>' +
+                   '<button class="danger" data-delete-github-author="' + esc(mapping.slackUserId) + '">DELETE</button>' +
+                 "</div>" +
+               "</div>";
+      }).join("");
+
+      document.querySelectorAll("[data-edit-github-author]").forEach((button) => {
+        button.addEventListener("click", () => {
+          document.getElementById("github-author-dialog-status").textContent = "";
+          document.getElementById("github-author-slack-user-id").value = button.getAttribute("data-edit-github-author") || "";
+          document.getElementById("github-author-value").value = button.getAttribute("data-edit-github-author-value") || "";
+          githubAuthorDialog.showModal();
+        });
+      });
+
+      document.querySelectorAll("[data-delete-github-author]").forEach((button) => {
+        button.addEventListener("click", async () => {
+          const slackUserId = button.getAttribute("data-delete-github-author");
+          if (!slackUserId) {
+            return;
+          }
+
+          if (!window.confirm("DELETE GITHUB AUTHOR MAPPING FOR " + slackUserId + "?")) {
+            return;
+          }
+
+          await deleteGitHubAuthorMapping(slackUserId);
+        });
+      });
+    }
+
     function summarizeSessionLead(s) {
       if (s.openInbound?.length) return s.openInbound[0].textPreview || "NEW MSG";
       if (s.backgroundJobs?.length) {
@@ -839,6 +974,7 @@ function renderAdminPage(options: {
       renderSummary(data);
       renderService(data);
       renderAuthProfiles(data);
+      renderGitHubAuthors(data);
       renderDeployment(data);
       renderSessions(data);
       renderLogs(data);
@@ -982,20 +1118,82 @@ function renderAdminPage(options: {
       finally { refreshButton.disabled = false; }
     }
 
+    async function submitGitHubAuthorMapping() {
+      const slackUserId = document.getElementById("github-author-slack-user-id").value.trim();
+      const githubAuthor = document.getElementById("github-author-value").value.trim();
+      const status = document.getElementById("github-author-dialog-status");
+      const submitButton = document.getElementById("submit-github-author-dialog");
+      status.textContent = "SAVING...";
+      submitButton.disabled = true;
+
+      try {
+        if (!slackUserId || !githubAuthor) {
+          throw new Error("SLACK USER ID AND GITHUB AUTHOR ARE REQUIRED");
+        }
+
+        const response = await fetch("/admin/api/github-authors", {
+          method: "POST",
+          headers: authHeaders({ "content-type": "application/json" }),
+          body: JSON.stringify({
+            slack_user_id: slackUserId,
+            github_author: githubAuthor
+          })
+        });
+        const payload = await parseResponse(response);
+        render(payload.status);
+        githubAuthorsStatus.innerHTML = '<span style="color:var(--good)">MAPPING SAVED</span>';
+        status.innerHTML = '<span style="color:var(--good)">MAPPING SAVED</span>';
+        githubAuthorDialog.close();
+      } catch (error) {
+        status.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+      } finally {
+        submitButton.disabled = false;
+      }
+    }
+
+    async function deleteGitHubAuthorMapping(slackUserId) {
+      githubAuthorsStatus.textContent = "DELETING MAPPING...";
+      try {
+        const response = await fetch("/admin/api/github-authors/" + encodeURIComponent(slackUserId), {
+          method: "DELETE",
+          headers: authHeaders()
+        });
+        const payload = await parseResponse(response);
+        render(payload.status);
+        githubAuthorsStatus.innerHTML = '<span style="color:var(--good)">MAPPING DELETED</span>';
+      } catch (error) {
+        githubAuthorsStatus.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+      }
+    }
+
     refreshButton.onclick = refresh;
     sessionSearch.oninput = () => { if (latestStatus) renderSessions(latestStatus); };
     sessionFilter.onchange = () => { if (latestStatus) renderSessions(latestStatus); };
+    githubAuthorSearch.oninput = () => { if (latestStatus) renderGitHubAuthors(latestStatus); };
     document.getElementById("open-add-profile-dialog").onclick = () => {
       document.getElementById("add-profile-status").textContent = "";
       addProfileDialog.showModal();
     };
+    document.getElementById("open-github-author-dialog").onclick = () => {
+      document.getElementById("github-author-dialog-status").textContent = "";
+      document.getElementById("github-author-slack-user-id").value = "";
+      document.getElementById("github-author-value").value = "";
+      githubAuthorDialog.showModal();
+    };
     document.getElementById("deploy-release-button").onclick = deployRelease;
     document.getElementById("rollback-release-button").onclick = rollbackRelease;
     document.getElementById("close-add-profile-dialog").onclick = () => addProfileDialog.close();
+    document.getElementById("close-github-author-dialog").onclick = () => githubAuthorDialog.close();
     document.getElementById("submit-add-profile-dialog").onclick = submitAddProfile;
+    document.getElementById("submit-github-author-dialog").onclick = submitGitHubAuthorMapping;
     addProfileDialog.onclick = (event) => {
       if (event.target === addProfileDialog) {
         addProfileDialog.close();
+      }
+    };
+    githubAuthorDialog.onclick = (event) => {
+      if (event.target === githubAuthorDialog) {
+        githubAuthorDialog.close();
       }
     };
 

--- a/src/http/slack-routes.ts
+++ b/src/http/slack-routes.ts
@@ -5,6 +5,7 @@ import type { AppConfig } from "../config.js";
 import { logger } from "../logger.js";
 import type { SlackCodexBridge } from "../services/slack/slack-codex-bridge.js";
 import {
+  readJsonBody,
   readFormBody,
   respondJson
 } from "./common.js";
@@ -46,6 +47,11 @@ export async function handleSlackRequest(
 
   if (method === "POST" && url.pathname === "/slack/post-file") {
     await handleSlackPostFileRequest(request, response, options);
+    return true;
+  }
+
+  if (method === "POST" && url.pathname === "/slack/git-coauthors/resolve-commit-message") {
+    await handleResolveCommitCoauthorsRequest(request, response, options);
     return true;
   }
 
@@ -445,6 +451,57 @@ async function handleSlackPostFileRequest(
     respondJson(response, 200, {
       ok: true,
       file: uploaded
+    });
+  } catch (error) {
+    respondJson(response, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+async function handleResolveCommitCoauthorsRequest(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  options: {
+    readonly bridge: SlackCodexBridge;
+  }
+): Promise<void> {
+  try {
+    const body = await readJsonBody(request);
+    const cwd = typeof body.cwd === "string" ? body.cwd.trim() : "";
+    const commitMessage = typeof body.commit_message === "string" ? body.commit_message : "";
+    const primaryAuthorEmail =
+      typeof body.primary_author_email === "string" ? body.primary_author_email.trim() : undefined;
+
+    if (!cwd || !commitMessage) {
+      respondJson(response, 400, {
+        ok: false,
+        error: "missing_required_body",
+        required: ["cwd", "commit_message"]
+      });
+      return;
+    }
+
+    const result = await options.bridge.resolveCommitCoauthors({
+      cwd,
+      commitMessage,
+      primaryAuthorEmail
+    });
+
+    if (result.status === "blocked") {
+      respondJson(response, 409, {
+        ok: false,
+        error: result.errorCode ?? "coauthor_resolution_blocked",
+        message: result.message,
+        sessionKey: result.sessionKey
+      });
+      return;
+    }
+
+    respondJson(response, 200, {
+      ok: true,
+      ...result
     });
   } catch (error) {
     respondJson(response, 500, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { AuthProfileService } from "./services/auth-profile-service.js";
 import { CodexBroker } from "./services/codex/codex-broker.js";
 import { CodexRuntimeControl } from "./services/codex-runtime-control.js";
 import { IsolatedMcpService } from "./services/codex/isolated-mcp-service.js";
+import { GitHubAuthorMappingService } from "./services/github-author-mapping-service.js";
 import { JobManager } from "./services/job-manager.js";
 import { SessionManager } from "./services/session-manager.js";
 import { SlackCodexBridge } from "./services/slack/slack-codex-bridge.js";
@@ -30,6 +31,10 @@ export async function startService(): Promise<{
     stateStore,
     sessionsRoot: config.sessionsRoot
   });
+  const githubAuthorMappings = new GitHubAuthorMappingService({
+    stateDir: config.stateDir
+  });
+  await githubAuthorMappings.load();
   const codexBroker = new CodexBroker({
     serviceName: config.serviceName,
     brokerHttpBaseUrl: config.brokerHttpBaseUrl,
@@ -50,7 +55,8 @@ export async function startService(): Promise<{
   const bridge = new SlackCodexBridge({
     config,
     sessions: sessionManager,
-    codex: codexBroker
+    codex: codexBroker,
+    mappings: githubAuthorMappings
   });
   const isolatedMcp = new IsolatedMcpService({
     codexHome: config.codexHome,
@@ -73,6 +79,7 @@ export async function startService(): Promise<{
     sessions: sessionManager,
     runtime: new CodexRuntimeControl(codexBroker),
     authProfiles,
+    githubAuthorMappings,
     startedAt
   });
   const server = http.createServer(

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -5,6 +5,7 @@ import type { AppConfig } from "../config.js";
 import type { PersistedBackgroundJob, PersistedInboundMessage, SlackSessionRecord } from "../types.js";
 import type { SessionManager } from "./session-manager.js";
 import type { AuthProfileService } from "./auth-profile-service.js";
+import type { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
 import type { RuntimeControl } from "./runtime-control.js";
 import type {
   DeployWorkerOptions,
@@ -34,6 +35,7 @@ export class AdminService {
       readonly sessions: SessionManager;
       readonly runtime: RuntimeControl;
       readonly authProfiles: AuthProfileService;
+      readonly githubAuthorMappings: GitHubAuthorMappingService;
       readonly startedAt: Date;
       readonly deployment?: WorkerDeploymentService | undefined;
     }
@@ -51,6 +53,7 @@ export class AdminService {
 
   async getStatus(): Promise<Record<string, unknown>> {
     await this.#refreshSessions();
+    await this.options.githubAuthorMappings.load();
     const allSessions = this.options.sessions
       .listSessions()
       .sort((left, right) => compareSessions(left, right));
@@ -112,6 +115,10 @@ export class AdminService {
         configToml: await this.#fileInfo(path.join(this.options.config.codexHome, "config.toml"))
       },
       authProfiles,
+      githubAuthorMappings: {
+        count: this.options.githubAuthorMappings.listMappings().length,
+        mappings: this.options.githubAuthorMappings.listMappings()
+      },
       account,
       rateLimits,
       deployment,
@@ -201,6 +208,34 @@ export class AdminService {
     return {
       ok: true,
       deployment,
+      status: await this.getStatus()
+    };
+  }
+
+  async upsertGitHubAuthorMapping(options: {
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+  }): Promise<Record<string, unknown>> {
+    await this.options.githubAuthorMappings.load();
+    const mapping = await this.options.githubAuthorMappings.upsertManualMapping({
+      slackUserId: options.slackUserId,
+      githubAuthor: options.githubAuthor
+    });
+    return {
+      ok: true,
+      mapping,
+      status: await this.getStatus()
+    };
+  }
+
+  async deleteGitHubAuthorMapping(options: {
+    readonly slackUserId: string;
+  }): Promise<Record<string, unknown>> {
+    await this.options.githubAuthorMappings.load();
+    await this.options.githubAuthorMappings.deleteMapping(options.slackUserId);
+    return {
+      ok: true,
+      slackUserId: options.slackUserId,
       status: await this.getStatus()
     };
   }

--- a/src/services/codex/app-server-client.ts
+++ b/src/services/codex/app-server-client.ts
@@ -43,6 +43,11 @@ interface ActiveTurn {
   reject: (error: Error) => void;
 }
 
+interface BufferedTurnEvents {
+  text: string;
+  terminalState: "completed" | "aborted" | null;
+}
+
 export interface StartedTurn {
   readonly turnId: string;
   readonly completion: Promise<CodexTurnResult>;
@@ -118,6 +123,7 @@ export class AppServerClient extends EventEmitter {
   #requestCounter = 0;
   readonly #pendingRequests = new Map<string, PendingRequest>();
   readonly #activeTurns = new Map<string, ActiveTurn>();
+  readonly #bufferedTurnEvents = new Map<string, BufferedTurnEvents>();
   #connected = false;
   #disconnectHandled = false;
   #slackBotIdentity: SlackUserIdentity | null = null;
@@ -352,6 +358,7 @@ export class AppServerClient extends EventEmitter {
         reject
       });
     });
+    this.#applyBufferedTurnEvents(result.turn.id);
 
     return {
       turnId: result.turn.id,
@@ -562,9 +569,17 @@ export class AppServerClient extends EventEmitter {
 
   #handleTurnEvent(method: string, params: Record<string, any>): void {
     if (method === "item/agentMessage/delta") {
-      const turn = this.#activeTurns.get(params.turnId as string);
+      const turnId = params.turnId as string | undefined;
+      if (!turnId) {
+        return;
+      }
+
+      const delta = String(params.delta ?? "");
+      const turn = this.#activeTurns.get(turnId);
       if (turn) {
-        turn.text += String(params.delta ?? "");
+        turn.text += delta;
+      } else if (delta) {
+        this.#bufferTurnText(turnId, delta);
       }
       return;
     }
@@ -577,16 +592,11 @@ export class AppServerClient extends EventEmitter {
 
       const turn = this.#activeTurns.get(turnId);
       if (!turn) {
+        this.#bufferTurnTerminalState(turnId, "completed");
         return;
       }
 
-      this.#activeTurns.delete(turnId);
-      turn.resolve({
-        threadId: turn.threadId,
-        turnId,
-        finalMessage: turn.text.trim(),
-        aborted: false
-      });
+      this.#resolveActiveTurn(turn, false);
       return;
     }
 
@@ -598,16 +608,11 @@ export class AppServerClient extends EventEmitter {
 
       const turn = this.#activeTurns.get(turnId);
       if (!turn) {
+        this.#bufferTurnTerminalState(turnId, "aborted");
         return;
       }
 
-      this.#activeTurns.delete(turnId);
-      turn.resolve({
-        threadId: turn.threadId,
-        turnId,
-        finalMessage: turn.text.trim(),
-        aborted: true
-      });
+      this.#resolveActiveTurn(turn, true);
     }
   }
 
@@ -630,6 +635,7 @@ export class AppServerClient extends EventEmitter {
       this.#activeTurns.delete(turnId);
       turn.reject(error);
     }
+    this.#bufferedTurnEvents.clear();
 
     this.emit("disconnected", error);
   }
@@ -645,6 +651,7 @@ export class AppServerClient extends EventEmitter {
     }
 
     this.#activeTurns.delete(turnId);
+    this.#bufferedTurnEvents.delete(turnId);
 
     if (result.status === "completed") {
       turn.resolve({
@@ -676,7 +683,63 @@ export class AppServerClient extends EventEmitter {
     }
 
     this.#activeTurns.delete(turnId);
+    this.#bufferedTurnEvents.delete(turnId);
     turn.reject(new Error("Codex turn missing from thread snapshot"));
+  }
+
+  #bufferTurnText(turnId: string, delta: string): void {
+    const buffered = this.#bufferedTurnEvents.get(turnId) ?? {
+      text: "",
+      terminalState: null
+    };
+    buffered.text += delta;
+    this.#bufferedTurnEvents.set(turnId, buffered);
+  }
+
+  #bufferTurnTerminalState(turnId: string, terminalState: "completed" | "aborted"): void {
+    const buffered = this.#bufferedTurnEvents.get(turnId) ?? {
+      text: "",
+      terminalState: null
+    };
+    buffered.terminalState = terminalState;
+    this.#bufferedTurnEvents.set(turnId, buffered);
+  }
+
+  #applyBufferedTurnEvents(turnId: string): void {
+    const turn = this.#activeTurns.get(turnId);
+    if (!turn) {
+      return;
+    }
+
+    const buffered = this.#bufferedTurnEvents.get(turnId);
+    if (!buffered) {
+      return;
+    }
+
+    this.#bufferedTurnEvents.delete(turnId);
+    if (buffered.text) {
+      turn.text += buffered.text;
+    }
+
+    if (buffered.terminalState === "completed") {
+      this.#resolveActiveTurn(turn, false);
+      return;
+    }
+
+    if (buffered.terminalState === "aborted") {
+      this.#resolveActiveTurn(turn, true);
+    }
+  }
+
+  #resolveActiveTurn(turn: ActiveTurn, aborted: boolean): void {
+    this.#activeTurns.delete(turn.turnId);
+    this.#bufferedTurnEvents.delete(turn.turnId);
+    turn.resolve({
+      threadId: turn.threadId,
+      turnId: turn.turnId,
+      finalMessage: turn.text.trim(),
+      aborted
+    });
   }
 
   #startHeartbeat(socket: WebSocket, intervalMs = 30_000): void {

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -13,6 +13,7 @@ import { syncGeminiHome } from "./gemini-home.js";
 const ALL_MCP_SERVERS = "*";
 
 export class AppServerProcess {
+  readonly #brokerHttpBaseUrl: string;
   readonly #codexHome: string;
   readonly #runtimeHome: string;
   readonly #port: number;
@@ -29,6 +30,7 @@ export class AppServerProcess {
   #homePrepared = false;
 
   constructor(options: {
+    readonly brokerHttpBaseUrl: string;
     readonly codexHome: string;
     readonly port: number;
     readonly openAiApiKey?: string | undefined;
@@ -41,6 +43,7 @@ export class AppServerProcess {
     readonly geminiHttpsProxy?: string | undefined;
     readonly geminiAllProxy?: string | undefined;
   }) {
+    this.#brokerHttpBaseUrl = options.brokerHttpBaseUrl;
     this.#codexHome = options.codexHome;
     this.#runtimeHome = path.join(path.dirname(options.codexHome), "runtime-home");
     this.#port = options.port;
@@ -67,13 +70,17 @@ export class AppServerProcess {
     await this.#prepareCodexHome();
     await this.#bootstrapAuth();
     await this.#disableConfiguredMcpServers();
+    await this.#ensureGitCommitHook();
     const tempadLinkServiceUrl = await this.#resolveTempadLinkServiceUrl();
 
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       CODEX_HOME: this.#codexHome,
       HOME: this.#runtimeHome,
+      BROKER_API_BASE: this.#brokerHttpBaseUrl,
       TEMPAD_LINK_SERVICE_URL: tempadLinkServiceUrl,
+      BROKER_GIT_COAUTHOR_HELPER:
+        process.env.BROKER_GIT_COAUTHOR_HELPER?.trim() || resolveRuntimeToolPath("git-coauthor.js"),
       BROKER_GEMINI_UI_HELPER:
         process.env.BROKER_GEMINI_UI_HELPER?.trim() || resolveRuntimeToolPath("gemini-ui.js")
     };
@@ -195,6 +202,24 @@ export class AppServerProcess {
     }
   }
 
+  async #ensureGitCommitHook(): Promise<void> {
+    const hooksDir = path.join(this.#runtimeHome, ".config", "git", "hooks");
+    await ensureDir(hooksDir);
+
+    const hookPath = path.join(hooksDir, "commit-msg");
+    const hookScript = [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "if [ -z \"${BROKER_GIT_COAUTHOR_HELPER:-}\" ]; then",
+      "  exit 0",
+      "fi",
+      "node \"$BROKER_GIT_COAUTHOR_HELPER\" commit-msg \"$1\""
+    ].join("\n");
+    await fs.writeFile(hookPath, `${hookScript}\n`, { mode: 0o755 });
+    await fs.chmod(hookPath, 0o755);
+    await this.#runGit(["config", "--global", "core.hooksPath", hooksDir]);
+  }
+
   async #disableConfiguredMcpServers(): Promise<void> {
     if (this.#disabledMcpServers.length === 0) {
       return;
@@ -264,6 +289,38 @@ export class AppServerProcess {
         }
 
         reject(new Error(`codex ${args.join(" ")} failed with code ${code ?? "null"}: ${stderr || stdout}`));
+      });
+    });
+  }
+
+  async #runGit(args: string[]): Promise<string> {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: this.#runtimeHome
+    };
+
+    return await new Promise<string>((resolve, reject) => {
+      const child = spawn("git", args, {
+        env,
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      let stdout = "";
+      let stderr = "";
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      child.once("error", reject);
+      child.once("exit", (code) => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+
+        reject(new Error(`git ${args.join(" ")} failed with code ${code ?? "null"}: ${stderr || stdout}`));
       });
     });
   }

--- a/src/services/codex/codex-broker.ts
+++ b/src/services/codex/codex-broker.ts
@@ -62,6 +62,7 @@ export class CodexBroker extends EventEmitter {
     }
 
     this.#appServerProcess = new AppServerProcess({
+      brokerHttpBaseUrl: options.brokerHttpBaseUrl,
       codexHome: options.codexHome,
       hostCodexHomePath: options.hostCodexHomePath,
       hostGeminiHomePath: options.hostGeminiHomePath,

--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -66,6 +66,12 @@ Repository workflow contract:
 - When you need isolated code changes, create git worktrees from canonical repos into subdirectories of {{session_workspace}}.
 - Do not treat {{shared_repos_root}} as the default development workspace. Use it as shared repo storage, not as the main place for edits.
 
+Git commit co-author contract:
+- Commits created from this Slack session may be blocked by a broker-managed co-author gate.
+- Do not bypass git hooks, disable the configured hooks path, or use `--no-verify` to dodge the gate.
+- If `git commit` fails because co-authors still need confirmation or mapping, pause there, wait for the Slack co-author flow to finish, and retry the same commit.
+- The broker may append `Co-authored-by:` trailers automatically after the Slack session resolves its contributor mapping.
+
 Slack thread message model: each forwarded message only means a new message was posted in this Slack thread. Do not assume it is addressed to you. Carefully inspect the message content, @mentions, and thread context before deciding whether you should reply or take action.
 
 Follow-up question rule: if someone in the Slack thread asks you an explicit status question or direct follow-up such as whether you pushed, replied, finished, or still have updates, bias toward sending a short direct Slack answer. Do not silently classify that kind of follow-up as a duplicate just because the underlying work topic is unchanged.

--- a/src/services/git/github-author-utils.ts
+++ b/src/services/git/github-author-utils.ts
@@ -1,0 +1,88 @@
+import type { SlackUserIdentity } from "../../types.js";
+
+export interface ParsedGitHubAuthor {
+  readonly name: string;
+  readonly email: string;
+}
+
+export function inferGitHubAuthorFromSlackIdentity(identity: SlackUserIdentity): string | undefined {
+  const name = identity.realName?.trim() || identity.displayName?.trim() || identity.username?.trim();
+  const email = normalizeEmail(identity.email);
+
+  if (!name || !email) {
+    return undefined;
+  }
+
+  return `${name} <${email}>`;
+}
+
+export function parseGitHubAuthor(value: string): ParsedGitHubAuthor | null {
+  const match = value.match(/^\s*(.+?)\s*<([^<>@\s]+@[^<>@\s]+)>\s*$/u);
+  if (!match) {
+    return null;
+  }
+
+  const name = match[1]?.trim();
+  const email = normalizeEmail(match[2]);
+  if (!name || !email) {
+    return null;
+  }
+
+  return {
+    name,
+    email
+  };
+}
+
+export function isValidGitHubAuthor(value: string): boolean {
+  return parseGitHubAuthor(value) !== null;
+}
+
+export function normalizeEmail(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+export function appendCoAuthorTrailers(
+  commitMessage: string,
+  options: {
+    readonly coAuthors: readonly string[];
+    readonly primaryAuthorEmail?: string | undefined;
+  }
+): string {
+  const newline = commitMessage.includes("\r\n") ? "\r\n" : "\n";
+  const existingLines = commitMessage.split(/\r?\n/u);
+  const existingEmails = new Set(
+    existingLines
+      .map((line) => line.match(/^Co-authored-by:\s*(.+)$/iu)?.[1])
+      .filter((value): value is string => Boolean(value))
+      .map((value) => parseGitHubAuthor(value))
+      .filter((value): value is ParsedGitHubAuthor => value !== null)
+      .map((value) => value.email)
+  );
+  const primaryAuthorEmail = normalizeEmail(options.primaryAuthorEmail);
+  const additions: string[] = [];
+
+  for (const candidate of options.coAuthors) {
+    const parsed = parseGitHubAuthor(candidate);
+    if (!parsed) {
+      continue;
+    }
+
+    if (parsed.email === primaryAuthorEmail || existingEmails.has(parsed.email)) {
+      continue;
+    }
+
+    existingEmails.add(parsed.email);
+    additions.push(`Co-authored-by: ${parsed.name} <${parsed.email}>`);
+  }
+
+  if (additions.length === 0) {
+    return commitMessage;
+  }
+
+  const trimmed = commitMessage.replace(/\s+$/u, "");
+  const hasExistingTrailers = /^(?:[A-Za-z-]+):\s.+$/mu.test(trimmed.split(/\r?\n/u).at(-1) ?? "");
+  const separator = trimmed.length === 0 ? "" : hasExistingTrailers ? newline : `${newline}${newline}`;
+  return `${trimmed}${separator}${additions.join(newline)}${newline}`;
+}

--- a/src/services/github-author-mapping-service.ts
+++ b/src/services/github-author-mapping-service.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  GitHubAuthorMappingRecord,
+  GitHubAuthorMappingSource,
+  SlackUserIdentity
+} from "../types.js";
+import { ensureDir } from "../utils/fs.js";
+import { inferGitHubAuthorFromSlackIdentity } from "./git/github-author-utils.js";
+
+export class GitHubAuthorMappingService {
+  readonly #rootDir: string;
+  readonly #mappingsDir: string;
+  #mappings = new Map<string, GitHubAuthorMappingRecord>();
+
+  constructor(options: {
+    readonly stateDir: string;
+  }) {
+    this.#rootDir = path.join(options.stateDir, "github-author-mappings");
+    this.#mappingsDir = this.#rootDir;
+  }
+
+  async load(): Promise<void> {
+    await ensureDir(this.#mappingsDir);
+    const entries = await fs.readdir(this.#mappingsDir, { withFileTypes: true });
+    const next = new Map<string, GitHubAuthorMappingRecord>();
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) {
+        continue;
+      }
+
+      const filePath = path.join(this.#mappingsDir, entry.name);
+      const raw = JSON.parse(await fs.readFile(filePath, "utf8")) as Partial<GitHubAuthorMappingRecord>;
+      const normalized = normalizeMapping(raw);
+      if (!normalized) {
+        continue;
+      }
+
+      next.set(normalized.slackUserId, normalized);
+    }
+
+    this.#mappings = next;
+  }
+
+  listMappings(): GitHubAuthorMappingRecord[] {
+    return [...this.#mappings.values()].sort((left, right) => {
+      return String(right.updatedAt).localeCompare(String(left.updatedAt));
+    });
+  }
+
+  getMapping(slackUserId: string): GitHubAuthorMappingRecord | undefined {
+    return this.#mappings.get(slackUserId);
+  }
+
+  async upsertManualMapping(options: {
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+    readonly slackIdentity?: SlackUserIdentity | undefined;
+  }): Promise<GitHubAuthorMappingRecord> {
+    const existing = await this.#readRecord(options.slackUserId) ?? this.#mappings.get(options.slackUserId);
+    const slackIdentity = normalizeSlackIdentity(options.slackIdentity) ??
+      existing?.slackIdentity ??
+      {
+        userId: options.slackUserId,
+        mention: `<@${options.slackUserId}>`
+      };
+
+    const record = this.#buildRecord({
+      slackUserId: options.slackUserId,
+      githubAuthor: options.githubAuthor,
+      source: "manual",
+      slackIdentity
+    });
+    await this.#writeRecord(record);
+    return record;
+  }
+
+  async deleteMapping(slackUserId: string): Promise<void> {
+    this.#mappings.delete(slackUserId);
+    await fs.rm(path.join(this.#mappingsDir, `${encodeKey(slackUserId)}.json`), {
+      force: true
+    });
+  }
+
+  async recordObservedIdentity(identity: SlackUserIdentity): Promise<GitHubAuthorMappingRecord | null> {
+    const normalizedIdentity = normalizeSlackIdentity(identity);
+    if (!normalizedIdentity) {
+      return null;
+    }
+
+    const inferredAuthor = inferGitHubAuthorFromSlackIdentity(normalizedIdentity);
+    const existing = await this.#readRecord(normalizedIdentity.userId) ?? this.#mappings.get(normalizedIdentity.userId);
+
+    if (existing?.source === "manual") {
+      if (!sameSlackIdentity(existing.slackIdentity, normalizedIdentity)) {
+        const updated = this.#buildRecord({
+          slackUserId: existing.slackUserId,
+          githubAuthor: existing.githubAuthor,
+          source: existing.source,
+          slackIdentity: normalizedIdentity
+        });
+        await this.#writeRecord(updated);
+        return updated;
+      }
+
+      return existing;
+    }
+
+    if (!inferredAuthor) {
+      return existing ?? null;
+    }
+
+    if (
+      existing &&
+      existing.source === "slack_inferred" &&
+      existing.githubAuthor === inferredAuthor &&
+      sameSlackIdentity(existing.slackIdentity, normalizedIdentity)
+    ) {
+      return existing;
+    }
+
+    const record = this.#buildRecord({
+      slackUserId: normalizedIdentity.userId,
+      githubAuthor: inferredAuthor,
+      source: "slack_inferred",
+      slackIdentity: normalizedIdentity
+    });
+    await this.#writeRecord(record);
+    return record;
+  }
+
+  #buildRecord(options: {
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+    readonly source: GitHubAuthorMappingSource;
+    readonly slackIdentity: SlackUserIdentity;
+  }): GitHubAuthorMappingRecord {
+    return {
+      slackUserId: options.slackUserId,
+      githubAuthor: options.githubAuthor.trim(),
+      source: options.source,
+      slackIdentity: options.slackIdentity,
+      updatedAt: new Date().toISOString()
+    };
+  }
+
+  async #writeRecord(record: GitHubAuthorMappingRecord): Promise<void> {
+    this.#mappings.set(record.slackUserId, record);
+    await ensureDir(this.#mappingsDir);
+    const filePath = path.join(this.#mappingsDir, `${encodeKey(record.slackUserId)}.json`);
+    const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+    await fs.writeFile(tempPath, JSON.stringify(record, null, 2));
+    await fs.rename(tempPath, filePath);
+  }
+
+  async #readRecord(slackUserId: string): Promise<GitHubAuthorMappingRecord | null> {
+    try {
+      const raw = JSON.parse(
+        await fs.readFile(path.join(this.#mappingsDir, `${encodeKey(slackUserId)}.json`), "utf8")
+      ) as Partial<GitHubAuthorMappingRecord>;
+      const normalized = normalizeMapping(raw);
+      if (normalized) {
+        this.#mappings.set(normalized.slackUserId, normalized);
+      }
+      return normalized;
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    }
+  }
+}
+
+function normalizeMapping(raw: Partial<GitHubAuthorMappingRecord>): GitHubAuthorMappingRecord | null {
+  const slackUserId = typeof raw.slackUserId === "string" ? raw.slackUserId.trim() : "";
+  const githubAuthor = typeof raw.githubAuthor === "string" ? raw.githubAuthor.trim() : "";
+  const source = raw.source === "manual" || raw.source === "slack_inferred" ? raw.source : undefined;
+  const slackIdentity = normalizeSlackIdentity(raw.slackIdentity);
+
+  if (!slackUserId || !githubAuthor || !source || !slackIdentity) {
+    return null;
+  }
+
+  return {
+    slackUserId,
+    githubAuthor,
+    source,
+    slackIdentity,
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date().toISOString()
+  };
+}
+
+function normalizeSlackIdentity(identity: SlackUserIdentity | null | undefined): SlackUserIdentity | null {
+  if (!identity?.userId?.trim()) {
+    return null;
+  }
+
+  return {
+    userId: identity.userId.trim(),
+    mention: identity.mention?.trim() || `<@${identity.userId.trim()}>`,
+    username: normalizeOptionalString(identity.username),
+    displayName: normalizeOptionalString(identity.displayName),
+    realName: normalizeOptionalString(identity.realName),
+    email: normalizeOptionalString(identity.email)?.toLowerCase()
+  };
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function sameSlackIdentity(left: SlackUserIdentity, right: SlackUserIdentity): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function encodeKey(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -42,6 +42,10 @@ export class SessionManager {
     return this.#stateStore.listSessions();
   }
 
+  getSessionByKey(key: string): SlackSessionRecord | undefined {
+    return this.#stateStore.getSession(key);
+  }
+
   hasProcessedEvent(eventId: string): boolean {
     return this.#stateStore.hasProcessedEvent(eventId);
   }
@@ -78,6 +82,15 @@ export class SessionManager {
       ...record,
       updatedAt: new Date().toISOString()
     });
+  }
+
+  findSessionByWorkspace(cwd: string): SlackSessionRecord | undefined {
+    const targetPath = path.resolve(cwd);
+    const candidates = this.listSessions()
+      .filter((session) => isSubpathOf(session.workspacePath, targetPath))
+      .sort((left, right) => right.workspacePath.length - left.workspacePath.length);
+
+    return candidates[0];
   }
 
   async setCodexThreadId(
@@ -154,6 +167,61 @@ export class SessionManager {
       lastTurnSignalKind: signal.kind,
       lastTurnSignalReason: signal.reason?.trim() || undefined,
       lastTurnSignalAt: signal.occurredAt ?? new Date().toISOString()
+    });
+  }
+
+  async addCoAuthorCandidates(
+    channelId: string,
+    rootThreadTs: string,
+    userIds: readonly string[]
+  ): Promise<SlackSessionRecord> {
+    const session = this.#requireSession(channelId, rootThreadTs);
+    const additions = userIds
+      .map((userId) => userId.trim())
+      .filter(Boolean)
+      .filter((userId, index, array) => array.indexOf(userId) === index)
+      .filter((userId) => !(session.coAuthorCandidateUserIds ?? []).includes(userId));
+
+    if (additions.length === 0) {
+      return session;
+    }
+
+    return await this.#patchSession(channelId, rootThreadTs, {
+      coAuthorCandidateUserIds: [...(session.coAuthorCandidateUserIds ?? []), ...additions],
+      coAuthorCandidateRevision: (session.coAuthorCandidateRevision ?? 0) + 1,
+      coAuthorPromptRevision: undefined,
+      coAuthorPromptedAt: undefined
+    });
+  }
+
+  async confirmCoAuthors(
+    channelId: string,
+    rootThreadTs: string,
+    options: {
+      readonly userIds: readonly string[];
+      readonly candidateRevision: number;
+    }
+  ): Promise<SlackSessionRecord> {
+    const session = this.#requireSession(channelId, rootThreadTs);
+    const confirmedUserIds = (session.coAuthorCandidateUserIds ?? [])
+      .filter((userId) => options.userIds.includes(userId));
+
+    return await this.#patchSession(channelId, rootThreadTs, {
+      coAuthorConfirmedUserIds: confirmedUserIds,
+      coAuthorConfirmedRevision: options.candidateRevision,
+      coAuthorPromptRevision: options.candidateRevision,
+      coAuthorPromptedAt: undefined
+    });
+  }
+
+  async markCoAuthorPrompted(
+    channelId: string,
+    rootThreadTs: string,
+    promptRevision: number
+  ): Promise<SlackSessionRecord> {
+    return await this.#patchSession(channelId, rootThreadTs, {
+      coAuthorPromptRevision: promptRevision,
+      coAuthorPromptedAt: new Date().toISOString()
     });
   }
 
@@ -270,4 +338,9 @@ export class SessionManager {
       updatedAt: new Date().toISOString()
     });
   }
+}
+
+function isSubpathOf(rootPath: string, targetPath: string): boolean {
+  const relative = path.relative(path.resolve(rootPath), targetPath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }

--- a/src/services/slack/slack-api.ts
+++ b/src/services/slack/slack-api.ts
@@ -97,6 +97,42 @@ export class SlackApi {
     return response.ts;
   }
 
+  async postEphemeral(options: {
+    readonly channelId: string;
+    readonly threadTs?: string | undefined;
+    readonly userId: string;
+    readonly text: string;
+    readonly blocks?: readonly Record<string, unknown>[] | undefined;
+  }): Promise<string | undefined> {
+    const response = await this.#post<{ message_ts?: string; ts?: string }>(
+      "chat.postEphemeral",
+      {
+        channel: options.channelId,
+        user: options.userId,
+        thread_ts: options.threadTs,
+        text: options.text,
+        blocks: options.blocks ? JSON.stringify(options.blocks) : undefined
+      },
+      this.#botToken
+    );
+
+    return response.message_ts ?? response.ts;
+  }
+
+  async openView(options: {
+    readonly triggerId: string;
+    readonly view: Record<string, unknown>;
+  }): Promise<void> {
+    await this.#post(
+      "views.open",
+      {
+        trigger_id: options.triggerId,
+        view: JSON.stringify(options.view)
+      },
+      this.#botToken
+    );
+  }
+
   async setAssistantThreadStatus(options: {
     readonly channelId: string;
     readonly threadTs: string;
@@ -355,6 +391,7 @@ export class SlackApi {
           display_name_normalized?: string;
           real_name?: string;
           real_name_normalized?: string;
+          email?: string;
         };
       };
     }>(
@@ -385,7 +422,8 @@ export class SlackApi {
       mention: `<@${response.user.id}>`,
       username,
       displayName,
-      realName
+      realName,
+      email: normalizeSlackField(response.user.profile?.email)?.toLowerCase()
     };
   }
 

--- a/src/services/slack/slack-coauthor-service.ts
+++ b/src/services/slack/slack-coauthor-service.ts
@@ -401,6 +401,7 @@ export class SlackCoauthorService {
           return {
             type: "input",
             block_id: authorBlockId(userId),
+            optional: true,
             label: {
               type: "plain_text",
               text: `${describeSlackUser(identity, userId)} GitHub author`

--- a/src/services/slack/slack-coauthor-service.ts
+++ b/src/services/slack/slack-coauthor-service.ts
@@ -1,0 +1,539 @@
+import { logger } from "../../logger.js";
+import type {
+  GitHubAuthorMappingRecord,
+  SlackInputMessage,
+  SlackSessionRecord,
+  SlackUserIdentity
+} from "../../types.js";
+import { SessionManager } from "../session-manager.js";
+import { GitHubAuthorMappingService } from "../github-author-mapping-service.js";
+import {
+  appendCoAuthorTrailers,
+  isValidGitHubAuthor,
+  normalizeEmail
+} from "../git/github-author-utils.js";
+import { SlackApi } from "./slack-api.js";
+
+const PROMPT_COOLDOWN_MS = 5 * 60 * 1_000;
+const COAUTHOR_CONFIGURE_ACTION_ID = "coauthor_configure";
+const COAUTHOR_MODAL_CALLBACK_ID = "coauthor_confirm";
+const CONTRIBUTOR_BLOCK_ID = "contributors";
+const CONTRIBUTOR_ACTION_ID = "selected";
+
+export interface ResolveCommitCoauthorsResult {
+  readonly status: "noop" | "blocked" | "resolved";
+  readonly sessionKey?: string | undefined;
+  readonly message?: string | undefined;
+  readonly errorCode?: string | undefined;
+  readonly coAuthors?: readonly string[] | undefined;
+}
+
+export class SlackCoauthorService {
+  readonly #sessions: SessionManager;
+  readonly #slackApi: SlackApi;
+  readonly #mappings: GitHubAuthorMappingService;
+
+  constructor(options: {
+    readonly sessions: SessionManager;
+    readonly slackApi: SlackApi;
+    readonly mappings: GitHubAuthorMappingService;
+  }) {
+    this.#sessions = options.sessions;
+    this.#slackApi = options.slackApi;
+    this.#mappings = options.mappings;
+  }
+
+  async noteIncomingSlackInput(
+    session: SlackSessionRecord,
+    input: SlackInputMessage
+  ): Promise<SlackSessionRecord> {
+    const identities = await this.#resolveContributorIdentities(input);
+    for (const identity of identities) {
+      await this.#mappings.recordObservedIdentity(identity);
+    }
+
+    if (identities.length === 0) {
+      return session;
+    }
+
+    return await this.#sessions.addCoAuthorCandidates(
+      session.channelId,
+      session.rootThreadTs,
+      identities.map((identity) => identity.userId)
+    );
+  }
+
+  async listMappings(): Promise<GitHubAuthorMappingRecord[]> {
+    await this.#mappings.load();
+    return this.#mappings.listMappings();
+  }
+
+  async upsertManualMapping(options: {
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+  }): Promise<GitHubAuthorMappingRecord> {
+    await this.#mappings.load();
+    const slackIdentity = await this.#slackApi.getUserIdentity(options.slackUserId);
+    return await this.#mappings.upsertManualMapping({
+      slackUserId: options.slackUserId,
+      githubAuthor: options.githubAuthor,
+      slackIdentity: slackIdentity ?? undefined
+    });
+  }
+
+  async deleteMapping(slackUserId: string): Promise<void> {
+    await this.#mappings.load();
+    await this.#mappings.deleteMapping(slackUserId);
+  }
+
+  async handleInteractivePayload(payload: Record<string, unknown>): Promise<void> {
+    const type = typeof payload.type === "string" ? payload.type : undefined;
+    if (type === "block_actions") {
+      await this.#handleBlockActions(payload);
+      return;
+    }
+
+    if (type === "view_submission") {
+      await this.#handleViewSubmission(payload);
+    }
+  }
+
+  async resolveCommitCoauthors(options: {
+    readonly cwd: string;
+    readonly commitMessage: string;
+    readonly primaryAuthorEmail?: string | undefined;
+  }): Promise<ResolveCommitCoauthorsResult & {
+    readonly commitMessage?: string | undefined;
+  }> {
+    await this.#mappings.load();
+    const session = this.#sessions.findSessionByWorkspace(options.cwd);
+    if (!session) {
+      return {
+        status: "noop"
+      };
+    }
+
+    const candidateUserIds = session.coAuthorCandidateUserIds ?? [];
+    if (candidateUserIds.length === 0) {
+      return {
+        status: "noop",
+        sessionKey: session.key
+      };
+    }
+
+    if (session.coAuthorConfirmedRevision !== session.coAuthorCandidateRevision) {
+      await this.#ensurePrompt(session);
+      return {
+        status: "blocked",
+        sessionKey: session.key,
+        errorCode: "coauthor_confirmation_required",
+        message: "Commit blocked by Slack co-author gate. Open the Slack thread and confirm co-authors, then retry the commit."
+      };
+    }
+
+    const confirmedUserIds = session.coAuthorConfirmedUserIds ?? [];
+    const mappings = await Promise.all(
+      confirmedUserIds.map(async (userId) => {
+        let mapping = this.#mappings.getMapping(userId);
+        if (!mapping) {
+          const identity = await this.#slackApi.getUserIdentity(userId);
+          if (identity) {
+            mapping = await this.#mappings.recordObservedIdentity(identity) ?? undefined;
+          }
+        }
+        return mapping ?? null;
+      })
+    );
+
+    const missingUserIds = confirmedUserIds.filter((userId, index) => !mappings[index]);
+    if (missingUserIds.length > 0) {
+      await this.#ensurePrompt(session);
+      return {
+        status: "blocked",
+        sessionKey: session.key,
+        errorCode: "coauthor_mapping_required",
+        message: "Commit blocked by Slack co-author gate. At least one confirmed Slack contributor is still missing a GitHub author mapping."
+      };
+    }
+
+    const coAuthors = mappings
+      .filter((mapping): mapping is GitHubAuthorMappingRecord => mapping !== null)
+      .map((mapping) => mapping.githubAuthor);
+    const commitMessage = appendCoAuthorTrailers(options.commitMessage, {
+      coAuthors,
+      primaryAuthorEmail: options.primaryAuthorEmail
+    });
+
+    if (commitMessage === options.commitMessage) {
+      return {
+        status: "noop",
+        sessionKey: session.key,
+        coAuthors
+      };
+    }
+
+    return {
+      status: "resolved",
+      sessionKey: session.key,
+      coAuthors,
+      commitMessage
+    };
+  }
+
+  async #handleBlockActions(payload: Record<string, unknown>): Promise<void> {
+    const triggerId = readString(payload.trigger_id);
+    const actions = Array.isArray(payload.actions) ? payload.actions : [];
+    const action = actions.find((entry) => {
+      return entry && typeof entry === "object" && (entry as { action_id?: string }).action_id === COAUTHOR_CONFIGURE_ACTION_ID;
+    }) as { value?: string } | undefined;
+
+    if (!triggerId || !action?.value) {
+      return;
+    }
+
+    const metadata = parsePrivateMetadata(action.value);
+    if (!metadata) {
+      return;
+    }
+
+    const session = this.#sessions.getSessionByKey(metadata.sessionKey);
+    if (!session) {
+      return;
+    }
+
+    await this.#mappings.load();
+    const modalView = await this.#buildModalView(session);
+    await this.#slackApi.openView({
+      triggerId,
+      view: modalView
+    });
+  }
+
+  async #handleViewSubmission(payload: Record<string, unknown>): Promise<void> {
+    const userId = readString((payload.user as { id?: string } | undefined)?.id);
+    const view = payload.view as {
+      private_metadata?: string;
+      state?: {
+        values?: Record<string, Record<string, Record<string, unknown>>>;
+      };
+    } | undefined;
+    const metadata = parsePrivateMetadata(view?.private_metadata);
+    if (!metadata) {
+      return;
+    }
+
+    const session = this.#sessions.getSessionByKey(metadata.sessionKey);
+    if (!session || session.coAuthorCandidateRevision !== metadata.candidateRevision) {
+      await this.#postSubmitResult(userId, metadata.sessionKey, "Co-author candidates changed. Open the Slack prompt again before retrying the commit.");
+      return;
+    }
+
+    const values = view?.state?.values ?? {};
+    const selectedUserIds = readSelectedContributorUserIds(values);
+    const invalidUserIds: string[] = [];
+
+    await this.#mappings.load();
+    for (const userId of selectedUserIds) {
+      const githubAuthor = readGitHubAuthorInput(values, userId);
+      if (!githubAuthor || !isValidGitHubAuthor(githubAuthor)) {
+        invalidUserIds.push(userId);
+        continue;
+      }
+
+      const slackIdentity = await this.#slackApi.getUserIdentity(userId);
+      await this.#mappings.upsertManualMapping({
+        slackUserId: userId,
+        githubAuthor,
+        slackIdentity: slackIdentity ?? undefined
+      });
+    }
+
+    if (invalidUserIds.length > 0) {
+      await this.#postSubmitResult(
+        userId,
+        session.key,
+        "Some selected co-authors still have an invalid `Name <email>` value. Re-open the Slack prompt and fix them."
+      );
+      return;
+    }
+
+    await this.#sessions.confirmCoAuthors(session.channelId, session.rootThreadTs, {
+      userIds: selectedUserIds,
+      candidateRevision: metadata.candidateRevision
+    });
+    await this.#postSubmitResult(userId, session.key, "Co-author mapping saved. The next commit retry can continue.");
+  }
+
+  async #ensurePrompt(session: SlackSessionRecord): Promise<void> {
+    const candidateRevision = session.coAuthorCandidateRevision;
+    if (!candidateRevision || (session.coAuthorCandidateUserIds ?? []).length === 0) {
+      return;
+    }
+
+    const promptAtMs = session.coAuthorPromptedAt ? Date.parse(session.coAuthorPromptedAt) : Number.NaN;
+    const promptedRecently =
+      session.coAuthorPromptRevision === candidateRevision &&
+      Number.isFinite(promptAtMs) &&
+      Date.now() - promptAtMs < PROMPT_COOLDOWN_MS;
+    if (promptedRecently) {
+      return;
+    }
+
+    const blocks = [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "*Git commit paused:* this Slack session needs co-author confirmation before the commit can go through."
+        }
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: {
+              type: "plain_text",
+              text: "Configure co-authors"
+            },
+            action_id: COAUTHOR_CONFIGURE_ACTION_ID,
+            value: JSON.stringify({
+              session_key: session.key,
+              candidate_revision: candidateRevision
+            })
+          }
+        ]
+      }
+    ];
+
+    let delivered = false;
+    for (const userId of session.coAuthorCandidateUserIds ?? []) {
+      try {
+        await this.#slackApi.postEphemeral({
+          channelId: session.channelId,
+          threadTs: session.rootThreadTs,
+          userId,
+          text: "This commit is waiting on Slack co-author confirmation.",
+          blocks
+        });
+        delivered = true;
+      } catch (error) {
+        logger.warn("Failed to post Slack co-author prompt", {
+          sessionKey: session.key,
+          userId,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+
+    if (delivered) {
+      await this.#sessions.markCoAuthorPrompted(session.channelId, session.rootThreadTs, candidateRevision);
+    }
+  }
+
+  async #buildModalView(session: SlackSessionRecord): Promise<Record<string, unknown>> {
+    const candidateUserIds = session.coAuthorCandidateUserIds ?? [];
+    const selectedUserIds = session.coAuthorConfirmedRevision === session.coAuthorCandidateRevision
+      ? (session.coAuthorConfirmedUserIds ?? [])
+      : candidateUserIds;
+    const identities = await Promise.all(candidateUserIds.map(async (userId) => {
+      const identity = await this.#slackApi.getUserIdentity(userId);
+      if (identity) {
+        await this.#mappings.recordObservedIdentity(identity);
+      }
+      return identity;
+    }));
+    const contributorOptions = candidateUserIds.map((userId, index) => {
+      const identity = identities[index];
+      return {
+        text: {
+          type: "plain_text",
+          text: describeSlackUser(identity, userId)
+        },
+        value: userId
+      };
+    });
+
+    return {
+      type: "modal",
+      callback_id: COAUTHOR_MODAL_CALLBACK_ID,
+      private_metadata: JSON.stringify({
+        session_key: session.key,
+        candidate_revision: session.coAuthorCandidateRevision ?? 0
+      }),
+      title: {
+        type: "plain_text",
+        text: "Confirm co-authors"
+      },
+      submit: {
+        type: "plain_text",
+        text: "Save"
+      },
+      close: {
+        type: "plain_text",
+        text: "Cancel"
+      },
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "Choose which Slack participants should be written as GitHub co-authors for commits from this session."
+          }
+        },
+        {
+          type: "input",
+          block_id: CONTRIBUTOR_BLOCK_ID,
+          label: {
+            type: "plain_text",
+            text: "Contributors"
+          },
+          element: {
+            type: "checkboxes",
+            action_id: CONTRIBUTOR_ACTION_ID,
+            options: contributorOptions,
+            initial_options: contributorOptions.filter((entry) => selectedUserIds.includes(String(entry.value)))
+          }
+        },
+        ...candidateUserIds.map((userId, index) => {
+          const identity = identities[index];
+          const initialValue = this.#mappings.getMapping(userId)?.githubAuthor ?? "";
+          return {
+            type: "input",
+            block_id: authorBlockId(userId),
+            label: {
+              type: "plain_text",
+              text: `${describeSlackUser(identity, userId)} GitHub author`
+            },
+            element: {
+              type: "plain_text_input",
+              action_id: "value",
+              initial_value: initialValue,
+              placeholder: {
+                type: "plain_text",
+                text: "Name <email@example.com>"
+              }
+            }
+          };
+        })
+      ]
+    };
+  }
+
+  async #resolveContributorIdentities(input: SlackInputMessage): Promise<readonly SlackUserIdentity[]> {
+    const identities = new Map<string, Awaited<ReturnType<SlackApi["getUserIdentity"]>>>();
+
+    if (input.senderKind === "user") {
+      identities.set(input.userId, await this.#slackApi.getUserIdentity(input.userId));
+    }
+
+    for (const message of input.batchMessages ?? []) {
+      if (message.senderKind !== "user") {
+        continue;
+      }
+
+      const sender = message.sender ?? await this.#slackApi.getUserIdentity(message.userId);
+      identities.set(message.userId, sender);
+    }
+
+    return [...identities.values()].filter((identity): identity is NonNullable<typeof identity> => identity !== null);
+  }
+
+  async #postSubmitResult(
+    userId: string | undefined,
+    sessionKey: string,
+    text: string
+  ): Promise<void> {
+    if (!userId) {
+      return;
+    }
+
+    const session = this.#sessions.getSessionByKey(sessionKey);
+    if (!session) {
+      return;
+    }
+
+    await this.#slackApi.postEphemeral({
+      channelId: session.channelId,
+      threadTs: session.rootThreadTs,
+      userId,
+      text
+    }).catch((error) => {
+      logger.warn("Failed to post Slack co-author modal result", {
+        sessionKey,
+        userId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    });
+  }
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parsePrivateMetadata(value: unknown): { sessionKey: string; candidateRevision: number } | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as {
+      session_key?: string;
+      candidate_revision?: number;
+    };
+    const sessionKey = readString(parsed.session_key);
+    const candidateRevision = Number(parsed.candidate_revision);
+    if (!sessionKey || !Number.isFinite(candidateRevision)) {
+      return null;
+    }
+
+    return {
+      sessionKey,
+      candidateRevision
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readSelectedContributorUserIds(
+  values: Record<string, Record<string, Record<string, unknown>>>
+): string[] {
+  const selectedOptions = values[CONTRIBUTOR_BLOCK_ID]?.[CONTRIBUTOR_ACTION_ID]?.selected_options;
+  if (!Array.isArray(selectedOptions)) {
+    return [];
+  }
+
+  return selectedOptions
+    .map((entry) => readString((entry as { value?: string } | undefined)?.value))
+    .filter((value): value is string => Boolean(value));
+}
+
+function readGitHubAuthorInput(
+  values: Record<string, Record<string, Record<string, unknown>>>,
+  userId: string
+): string | undefined {
+  return readString(values[authorBlockId(userId)]?.value?.value);
+}
+
+function authorBlockId(userId: string): string {
+  return `author__${userId}`;
+}
+
+function describeSlackUser(
+  identity: {
+    readonly userId: string;
+    readonly displayName?: string | undefined;
+    readonly realName?: string | undefined;
+    readonly username?: string | undefined;
+    readonly email?: string | undefined;
+  } | null | undefined,
+  fallbackUserId: string
+): string {
+  const label = identity?.realName || identity?.displayName || identity?.username || fallbackUserId;
+  if (identity?.email) {
+    return `${label} (${identity.email})`;
+  }
+  return label;
+}

--- a/src/services/slack/slack-codex-bridge.ts
+++ b/src/services/slack/slack-codex-bridge.ts
@@ -7,6 +7,7 @@ import type {
   SlackUserIdentity
 } from "../../types.js";
 import { CodexBroker } from "../codex/codex-broker.js";
+import { GitHubAuthorMappingService } from "../github-author-mapping-service.js";
 import { SessionManager } from "../session-manager.js";
 import {
   type ParsedSlackEvent,
@@ -14,6 +15,7 @@ import {
   parseSlackEvent
 } from "./slack-event-parser.js";
 import { SlackApi } from "./slack-api.js";
+import { SlackCoauthorService } from "./slack-coauthor-service.js";
 import { SlackConversationService } from "./slack-conversation-service.js";
 import { SlackSelfMessageFilter } from "./slack-self-filter.js";
 import { SlackSocketModeClient } from "./socket-mode-client.js";
@@ -25,6 +27,7 @@ export class SlackCodexBridge {
   readonly #slackApi: SlackApi;
   readonly #slackSocket: SlackSocketModeClient;
   readonly #selfMessageFilter = new SlackSelfMessageFilter();
+  readonly #coauthors: SlackCoauthorService;
   readonly #conversations: SlackConversationService;
   #botUserId = "";
   #botIdentity: SlackUserIdentity | null = null;
@@ -33,6 +36,7 @@ export class SlackCodexBridge {
     readonly config: AppConfig;
     readonly sessions: SessionManager;
     readonly codex: CodexBroker;
+    readonly mappings: GitHubAuthorMappingService;
   }) {
     this.#config = options.config;
     this.#sessions = options.sessions;
@@ -46,12 +50,18 @@ export class SlackCodexBridge {
       api: this.#slackApi,
       socketOpenPath: this.#config.slackSocketOpenUrl
     });
+    this.#coauthors = new SlackCoauthorService({
+      sessions: this.#sessions,
+      slackApi: this.#slackApi,
+      mappings: options.mappings
+    });
     this.#conversations = new SlackConversationService({
       config: this.#config,
       sessions: this.#sessions,
       codex: this.#codex,
       slackApi: this.#slackApi,
-      selfMessageFilter: this.#selfMessageFilter
+      selfMessageFilter: this.#selfMessageFilter,
+      coauthors: this.#coauthors
     });
   }
 
@@ -77,6 +87,9 @@ export class SlackCodexBridge {
         readonly event?: Record<string, any>;
         readonly event_id?: string;
       });
+    });
+    this.#slackSocket.on("interactive", (payload) => {
+      void this.#handleInteractive(payload as Record<string, unknown>);
     });
 
     await this.#slackSocket.start();
@@ -160,6 +173,29 @@ export class SlackCodexBridge {
     return await this.#conversations.postSlackFile(options);
   }
 
+  async listGitHubAuthorMappings() {
+    return await this.#coauthors.listMappings();
+  }
+
+  async upsertGitHubAuthorMapping(options: {
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+  }) {
+    return await this.#coauthors.upsertManualMapping(options);
+  }
+
+  async deleteGitHubAuthorMapping(slackUserId: string): Promise<void> {
+    await this.#coauthors.deleteMapping(slackUserId);
+  }
+
+  async resolveCommitCoauthors(options: {
+    readonly cwd: string;
+    readonly commitMessage: string;
+    readonly primaryAuthorEmail?: string | undefined;
+  }) {
+    return await this.#coauthors.resolveCommitCoauthors(options);
+  }
+
   async #handleEventsApi(payload: {
     readonly event?: Record<string, any>;
     readonly event_id?: string;
@@ -178,6 +214,16 @@ export class SlackCodexBridge {
     } catch (error) {
       logger.error("Failed to process Slack event", {
         eventId: payload.event_id,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  async #handleInteractive(payload: Record<string, unknown>): Promise<void> {
+    try {
+      await this.#coauthors.handleInteractivePayload(payload);
+    } catch (error) {
+      logger.error("Failed to process Slack interactive payload", {
         error: error instanceof Error ? error.message : String(error)
       });
     }

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -48,6 +48,7 @@ import {
 } from "./slack-message-format.js";
 import { markdownishToMrkdwn } from "./slack-mrkdwn.js";
 import { SlackSelfMessageFilter } from "./slack-self-filter.js";
+import { SlackCoauthorService } from "./slack-coauthor-service.js";
 import { SlackTurnReconciler } from "./slack-turn-reconciler.js";
 import { SlackTurnRunner } from "./slack-turn-runner.js";
 
@@ -76,6 +77,12 @@ export class SlackConversationService {
   readonly #codex: CodexBroker;
   readonly #slackApi: SlackApi;
   readonly #selfMessageFilter: SlackSelfMessageFilter;
+  readonly #coauthors: {
+    readonly noteIncomingSlackInput: (
+      session: SlackSessionRecord,
+      item: SlackInputMessage
+    ) => Promise<SlackSessionRecord>;
+  };
   readonly #runtimeSessions = new Map<string, RuntimeSessionState>();
   readonly #statusControllers = new Map<string, SlackAssistantStatusController>();
   readonly #inboundStore: SlackInboundStore;
@@ -93,12 +100,16 @@ export class SlackConversationService {
     readonly codex: CodexBroker;
     readonly slackApi: SlackApi;
     readonly selfMessageFilter: SlackSelfMessageFilter;
+    readonly coauthors?: SlackCoauthorService | undefined;
   }) {
     this.#config = options.config;
     this.#sessions = options.sessions;
     this.#codex = options.codex;
     this.#slackApi = options.slackApi;
     this.#selfMessageFilter = options.selfMessageFilter;
+    this.#coauthors = options.coauthors ?? {
+      noteIncomingSlackInput: async (session) => session
+    };
     this.#inboundStore = new SlackInboundStore({
       sessions: this.#sessions,
       slackApi: this.#slackApi
@@ -554,7 +565,8 @@ export class SlackConversationService {
     }
 
     this.#clearDispatchFailureBlock(session.key);
-    const recordedSession = await this.#inboundStore.recordInboundMessage(session, item);
+    const coauthoredSession = await this.#coauthors.noteIncomingSlackInput(session, item);
+    const recordedSession = await this.#inboundStore.recordInboundMessage(coauthoredSession, item);
     this.#setAssistantThinking(recordedSession);
     await this.#dispatchPersistedMessage(recordedSession, item.messageTs);
   }

--- a/src/services/slack/socket-mode-client.ts
+++ b/src/services/slack/socket-mode-client.ts
@@ -200,6 +200,11 @@ export class SlackSocketModeClient extends EventEmitter {
 
     if (envelope.type === "events_api" && envelope.payload) {
       this.emit("events_api", envelope.payload);
+      return;
+    }
+
+    if (envelope.type === "interactive" && envelope.payload) {
+      this.emit("interactive", envelope.payload);
     }
   }
 
@@ -230,7 +235,7 @@ function buildSlackEnvelopeMeta(envelope: SlackSocketEnvelope): Record<string, u
     envelopeId: envelope.envelope_id,
     envelopeType: envelope.type,
     eventId: envelope.payload?.event_id,
-    eventType: event?.type,
+    eventType: event?.type ?? envelope.payload?.type,
     channelId,
     rootThreadTs
   };

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -416,7 +416,14 @@ export class StateStore {
       lastTurnSignalTurnId: session.lastTurnSignalTurnId,
       lastTurnSignalKind: session.lastTurnSignalKind,
       lastTurnSignalReason: session.lastTurnSignalReason,
-      lastTurnSignalAt: session.lastTurnSignalAt
+      lastTurnSignalAt: session.lastTurnSignalAt,
+      coAuthorCandidateUserIds: normalizeStringArray(session.coAuthorCandidateUserIds),
+      coAuthorCandidateRevision: normalizeFiniteNumber(session.coAuthorCandidateRevision),
+      coAuthorConfirmedUserIds: normalizeStringArray(session.coAuthorConfirmedUserIds),
+      coAuthorConfirmedRevision: normalizeFiniteNumber(session.coAuthorConfirmedRevision),
+      coAuthorPromptRevision: normalizeFiniteNumber(session.coAuthorPromptRevision),
+      coAuthorPromptedAt:
+        typeof session.coAuthorPromptedAt === "string" ? session.coAuthorPromptedAt : undefined
     };
   }
 
@@ -506,4 +513,30 @@ function normalizeSessionDirectoryName(channelId: string, rootThreadTs: string):
 
 function encodeKey(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function normalizeStringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
 }

--- a/src/tools/git-coauthor.ts
+++ b/src/tools/git-coauthor.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+interface ParsedArgs {
+  readonly action: "commit-msg";
+  readonly commitMessagePath: string;
+}
+
+export async function runCommitMsgHook(options: {
+  readonly brokerApiBase: string;
+  readonly cwd: string;
+  readonly commitMessagePath: string;
+}): Promise<void> {
+  const commitMessage = await fs.readFile(options.commitMessagePath, "utf8");
+  const primaryAuthorEmail =
+    normalizeOptionalString(process.env.GIT_AUTHOR_EMAIL) ??
+    readGitConfig(options.cwd, "user.email") ??
+    undefined;
+
+  const response = await fetch(`${options.brokerApiBase}/slack/git-coauthors/resolve-commit-message`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      cwd: options.cwd,
+      commit_message: commitMessage,
+      primary_author_email: primaryAuthorEmail
+    })
+  });
+  const payload = await response.json().catch(() => ({})) as {
+    ok?: boolean;
+    error?: string;
+    message?: string;
+    status?: string;
+    commitMessage?: string;
+    commit_message?: string;
+  };
+
+  if (!response.ok) {
+    throw new Error(payload.message || payload.error || `co-author helper failed (${response.status})`);
+  }
+
+  const nextCommitMessage = normalizeOptionalString(payload.commitMessage) ?? normalizeOptionalString(payload.commit_message);
+  if (!nextCommitMessage || nextCommitMessage === commitMessage) {
+    return;
+  }
+
+  await fs.writeFile(options.commitMessagePath, `${nextCommitMessage.replace(/\s+$/u, "")}\n`);
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs(process.argv.slice(2));
+  const brokerApiBase = normalizeOptionalString(process.env.BROKER_API_BASE);
+  if (!brokerApiBase) {
+    return;
+  }
+
+  if (parsed.action === "commit-msg") {
+    await runCommitMsgHook({
+      brokerApiBase,
+      cwd: process.cwd(),
+      commitMessagePath: path.resolve(parsed.commitMessagePath)
+    });
+  }
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const action = argv[0];
+  const commitMessagePath = argv[1];
+  if (action !== "commit-msg" || !commitMessagePath) {
+    throw new Error("usage: git-coauthor commit-msg <commit-message-path>");
+  }
+
+  return {
+    action,
+    commitMessagePath
+  };
+}
+
+function readGitConfig(cwd: string, key: string): string | null {
+  const result = spawnSync("git", ["config", "--get", key], {
+    cwd,
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+
+  return normalizeOptionalString(result.stdout) ?? null;
+}
+
+function normalizeOptionalString(value: string | undefined | null): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,12 @@ export interface SlackSessionRecord {
   readonly lastTurnSignalKind?: SlackTurnSignalKind | undefined;
   readonly lastTurnSignalReason?: string | undefined;
   readonly lastTurnSignalAt?: string | undefined;
+  readonly coAuthorCandidateUserIds?: readonly string[] | undefined;
+  readonly coAuthorCandidateRevision?: number | undefined;
+  readonly coAuthorConfirmedUserIds?: readonly string[] | undefined;
+  readonly coAuthorConfirmedRevision?: number | undefined;
+  readonly coAuthorPromptRevision?: number | undefined;
+  readonly coAuthorPromptedAt?: string | undefined;
 }
 
 export type JsonLike =
@@ -141,6 +147,17 @@ export interface SlackUserIdentity {
   readonly username?: string | undefined;
   readonly displayName?: string | undefined;
   readonly realName?: string | undefined;
+  readonly email?: string | undefined;
+}
+
+export type GitHubAuthorMappingSource = "manual" | "slack_inferred";
+
+export interface GitHubAuthorMappingRecord {
+  readonly slackUserId: string;
+  readonly githubAuthor: string;
+  readonly source: GitHubAuthorMappingSource;
+  readonly slackIdentity: SlackUserIdentity;
+  readonly updatedAt: string;
 }
 
 export interface SlackBatchInputMessage {

--- a/src/worker-index.ts
+++ b/src/worker-index.ts
@@ -5,6 +5,7 @@ import { createHttpHandler } from "./http/router.js";
 import { configureLogger, logger } from "./logger.js";
 import { CodexBroker } from "./services/codex/codex-broker.js";
 import { IsolatedMcpService } from "./services/codex/isolated-mcp-service.js";
+import { GitHubAuthorMappingService } from "./services/github-author-mapping-service.js";
 import { JobManager } from "./services/job-manager.js";
 import { SessionManager } from "./services/session-manager.js";
 import { SlackCodexBridge } from "./services/slack/slack-codex-bridge.js";
@@ -27,6 +28,10 @@ export async function startWorkerService(): Promise<{
     stateStore,
     sessionsRoot: config.sessionsRoot
   });
+  const githubAuthorMappings = new GitHubAuthorMappingService({
+    stateDir: config.stateDir
+  });
+  await githubAuthorMappings.load();
   const codexBroker = new CodexBroker({
     serviceName: config.serviceName,
     brokerHttpBaseUrl: config.brokerHttpBaseUrl,
@@ -47,7 +52,8 @@ export async function startWorkerService(): Promise<{
   const bridge = new SlackCodexBridge({
     config,
     sessions: sessionManager,
-    codex: codexBroker
+    codex: codexBroker,
+    mappings: githubAuthorMappings
   });
   const isolatedMcp = new IsolatedMcpService({
     codexHome: config.codexHome,

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -24,6 +24,8 @@ describe("admin routes", () => {
     const adminService = {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
@@ -81,6 +83,8 @@ describe("admin routes", () => {
     const adminService = {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
@@ -121,6 +125,8 @@ describe("admin routes", () => {
     expect(html).toContain("open-add-profile-dialog");
     expect(html).toContain("auth-profiles-panel");
     expect(html).toContain("Auth Profiles");
+    expect(html).toContain("github-authors-panel");
+    expect(html).toContain("GitHub Authors");
     expect(html).toContain("Deploy");
     expect(html).toContain("deploy-release-button");
     expect(html).toContain("Runtime Info");
@@ -146,6 +152,8 @@ describe("admin routes", () => {
         calls.push(payload);
         return { ok: true, status: { ok: true } };
       },
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
@@ -197,6 +205,72 @@ describe("admin routes", () => {
     ]);
   });
 
+  it("forwards GitHub author mapping upserts to the admin service", async () => {
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv);
+    const calls: Array<Record<string, unknown>> = [];
+    const adminService = {
+      getStatus: async () => ({ ok: true }),
+      addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async (payload: Record<string, unknown>) => {
+        calls.push(payload);
+        return { ok: true, status: { ok: true } };
+      },
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      activateAuthProfile: async () => ({ ok: true }),
+      deployWorker: async () => ({ ok: true }),
+      rollbackWorker: async () => ({ ok: true })
+    };
+
+    const server = http.createServer(
+      createHttpHandler({
+        adminService: adminService as never,
+        bridge: {} as never,
+        isolatedMcp: {} as never,
+        jobManager: {} as never,
+        config
+      })
+    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start test server");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/admin/api/github-authors`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        slack_user_id: "U123",
+        github_author: "Alice Example <alice@example.com>"
+      })
+    });
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([
+      {
+        slackUserId: "U123",
+        githubAuthor: "Alice Example <alice@example.com>"
+      }
+    ]);
+  });
+
   it("emits admin page inline script without syntax errors", async () => {
     const config = loadConfig({
       SLACK_APP_TOKEN: "xapp-test",
@@ -205,6 +279,8 @@ describe("admin routes", () => {
     const adminService = {
       getStatus: async () => ({ ok: true, status: "admin-ok" }),
       addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),
@@ -258,6 +334,8 @@ describe("admin routes", () => {
     const adminService = {
       getStatus: async () => ({ ok: true }),
       addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async (payload: Record<string, unknown>) => {
@@ -319,6 +397,8 @@ describe("admin routes", () => {
     const adminService = {
       getStatus: async () => ({ ok: true }),
       addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
       deleteAuthProfile: async () => ({ ok: true }),
       activateAuthProfile: async () => ({ ok: true }),
       deployWorker: async () => ({ ok: true }),

--- a/test/admin-service.test.ts
+++ b/test/admin-service.test.ts
@@ -54,6 +54,10 @@ describe("AdminService", () => {
           profiles: []
         })
       } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => []
+      } as never,
       runtime: {
         restartRuntime: async () => {},
         readAccountSummary: async () => ({
@@ -178,6 +182,10 @@ describe("AdminService", () => {
           activeAuthPath: path.join(config.codexHome, "auth.json"),
           profiles: []
         })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => []
       } as never,
       runtime: {
         restartRuntime: async () => {},

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -144,6 +144,68 @@ describe("AppServerClient disconnect handling", () => {
     await expect(started.completion).rejects.toThrow(/closed/i);
   });
 
+  it("buffers turn events that arrive before startTurn finishes registering the turn", async () => {
+    const server = await createServer((socket, message) => {
+      if (message.method === "initialize") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { ok: true }
+        }));
+        return;
+      }
+
+      if (message.method === "turn/start") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: {
+            turn: {
+              id: "turn-1"
+            }
+          }
+        }));
+        socket.send(JSON.stringify({
+          method: "item/agentMessage/delta",
+          params: {
+            turnId: "turn-1",
+            delta: "done"
+          }
+        }));
+        socket.send(JSON.stringify({
+          method: "turn/completed",
+          params: {
+            turn: {
+              id: "turn-1"
+            }
+          }
+        }));
+      }
+    });
+    servers.push(server);
+
+    const client = new AppServerClient({
+      url: server.url,
+      serviceName: "test",
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      reposRoot: "/tmp/repos"
+    });
+
+    await client.connect();
+    const started = await client.startTurn("thread-1", "/tmp", [
+      {
+        type: "text",
+        text: "hello",
+        text_elements: []
+      }
+    ]);
+
+    await expect(started.completion).resolves.toEqual({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      finalMessage: "done",
+      aborted: false
+    });
+  });
+
   it("can recover a completed turn result from thread/read", async () => {
     const server = await createServer((socket, message) => {
       if (message.method === "initialize") {

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -724,6 +724,15 @@ describe("AppServerClient disconnect handling", () => {
     expect(threadStartParams?.baseInstructions).toEqual(
       expect.stringContaining("shared_repos_root: /tmp/repos")
     );
+    expect(threadStartParams?.baseInstructions).toEqual(
+      expect.stringContaining("Git commit co-author contract")
+    );
+    expect(threadStartParams?.baseInstructions).toEqual(
+      expect.stringContaining("Do not bypass git hooks")
+    );
+    expect(threadStartParams?.baseInstructions).toEqual(
+      expect.stringContaining("The broker may append `Co-authored-by:` trailers automatically")
+    );
     expect(String(threadStartParams?.baseInstructions)).toContain("node \\\"$BROKER_JOB_HELPER\\\" event");
     expect(threadStartParams?.baseInstructions).toEqual(
       expect.stringContaining("Identity and instruction boundaries")

--- a/test/git-coauthor-helper.test.ts
+++ b/test/git-coauthor-helper.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { appendCoAuthorTrailers } from "../src/services/git/github-author-utils.js";
+import { runCommitMsgHook } from "../src/tools/git-coauthor.js";
+
+describe("git coauthor helper", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, {
+      recursive: true,
+      force: true
+    })));
+  });
+
+  it("appends co-author trailers idempotently and skips the primary author email", () => {
+    const message = appendCoAuthorTrailers("feat(test): demo\n", {
+      primaryAuthorEmail: "alice@example.com",
+      coAuthors: [
+        "Alice Example <alice@example.com>",
+        "Bob Example <bob@example.com>",
+        "Bob Example <bob@example.com>"
+      ]
+    });
+
+    expect(message).not.toContain("Alice Example <alice@example.com>");
+    expect(message).toContain("Co-authored-by: Bob Example <bob@example.com>");
+    expect(message.match(/Co-authored-by:/g)).toHaveLength(1);
+  });
+
+  it("rewrites the commit message file with the broker-resolved trailers", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-coauthor-helper-"));
+    tempDirs.push(tempDir);
+    const messagePath = path.join(tempDir, "COMMIT_EDITMSG");
+    await fs.writeFile(messagePath, "feat(test): demo\n");
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      return new Response(JSON.stringify({
+        ok: true,
+        status: "resolved",
+        commitMessage: "feat(test): demo\n\nCo-authored-by: Bob Example <bob@example.com>\n"
+      }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json"
+        }
+      });
+    }));
+
+    await runCommitMsgHook({
+      brokerApiBase: "http://127.0.0.1:3000",
+      cwd: tempDir,
+      commitMessagePath: messagePath
+    });
+
+    await expect(fs.readFile(messagePath, "utf8")).resolves.toContain(
+      "Co-authored-by: Bob Example <bob@example.com>"
+    );
+  });
+});

--- a/test/github-author-mapping-service.test.ts
+++ b/test/github-author-mapping-service.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GitHubAuthorMappingService } from "../src/services/github-author-mapping-service.js";
+
+describe("GitHubAuthorMappingService", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, {
+      recursive: true,
+      force: true
+    })));
+  });
+
+  it("infers mappings from Slack profile email and preserves manual overrides", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-author-mappings-"));
+    tempDirs.push(stateDir);
+
+    const service = new GitHubAuthorMappingService({
+      stateDir
+    });
+    await service.load();
+
+    const inferred = await service.recordObservedIdentity({
+      userId: "U123",
+      mention: "<@U123>",
+      username: "alice",
+      displayName: "Alice Slack",
+      realName: "Alice Example",
+      email: "alice@example.com"
+    });
+    expect(inferred).toMatchObject({
+      slackUserId: "U123",
+      githubAuthor: "Alice Example <alice@example.com>",
+      source: "slack_inferred"
+    });
+
+    const manual = await service.upsertManualMapping({
+      slackUserId: "U123",
+      githubAuthor: "Alice Manual <manual@example.com>"
+    });
+    expect(manual).toMatchObject({
+      slackUserId: "U123",
+      githubAuthor: "Alice Manual <manual@example.com>",
+      source: "manual"
+    });
+
+    const afterManual = await service.recordObservedIdentity({
+      userId: "U123",
+      mention: "<@U123>",
+      username: "alice-updated",
+      displayName: "Alice Updated",
+      realName: "Alice Updated",
+      email: "alice-updated@example.com"
+    });
+    expect(afterManual).toMatchObject({
+      githubAuthor: "Alice Manual <manual@example.com>",
+      source: "manual",
+      slackIdentity: {
+        userId: "U123",
+        email: "alice-updated@example.com"
+      }
+    });
+  });
+});

--- a/test/manual/run-real-codex-smoke.ts
+++ b/test/manual/run-real-codex-smoke.ts
@@ -7,6 +7,7 @@ import { AppServerClient } from "../../src/services/codex/app-server-client.js";
 async function main(): Promise<void> {
   const codexHome = path.join(os.tmpdir(), `codex-smoke-${Date.now()}`);
   const processManager = new AppServerProcess({
+    brokerHttpBaseUrl: "http://127.0.0.1:3300",
     codexHome,
     port: 4599,
     authJsonPath: path.join(os.homedir(), ".codex", "auth.json")

--- a/test/runtime-paths.test.ts
+++ b/test/runtime-paths.test.ts
@@ -12,5 +12,8 @@ describe("resolveRuntimeToolPath", () => {
     expect(resolveRuntimeToolPath("job-callback.js")).toBe(
       path.resolve(process.cwd(), "src", "tools", "job-callback.js")
     );
+    expect(resolveRuntimeToolPath("git-coauthor.js")).toBe(
+      path.resolve(process.cwd(), "src", "tools", "git-coauthor.js")
+    );
   });
 });

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -179,4 +179,51 @@ describe("SessionManager", () => {
       lastTurnSignalAt: "2026-03-18T10:00:00.000Z"
     });
   });
+
+  it("persists co-author candidate and confirmed revision state", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));
+    const store = new StateStore(stateDir, sessionsRoot);
+    const manager = new SessionManager({
+      stateStore: store,
+      sessionsRoot
+    });
+
+    await manager.load();
+    await manager.ensureSession("C123", "999.000");
+    let session = await manager.addCoAuthorCandidates("C123", "999.000", ["U1"]);
+    expect(session).toMatchObject({
+      coAuthorCandidateUserIds: ["U1"],
+      coAuthorCandidateRevision: 1
+    });
+
+    session = await manager.confirmCoAuthors("C123", "999.000", {
+      userIds: ["U1"],
+      candidateRevision: 1
+    });
+    expect(session).toMatchObject({
+      coAuthorConfirmedUserIds: ["U1"],
+      coAuthorConfirmedRevision: 1
+    });
+
+    session = await manager.addCoAuthorCandidates("C123", "999.000", ["U2"]);
+    expect(session).toMatchObject({
+      coAuthorCandidateUserIds: ["U1", "U2"],
+      coAuthorCandidateRevision: 2,
+      coAuthorConfirmedRevision: 1
+    });
+
+    const reloadedStore = new StateStore(stateDir, sessionsRoot);
+    const reloadedManager = new SessionManager({
+      stateStore: reloadedStore,
+      sessionsRoot
+    });
+    await reloadedManager.load();
+    expect(reloadedManager.getSession("C123", "999.000")).toMatchObject({
+      coAuthorCandidateUserIds: ["U1", "U2"],
+      coAuthorCandidateRevision: 2,
+      coAuthorConfirmedUserIds: ["U1"],
+      coAuthorConfirmedRevision: 1
+    });
+  });
 });

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -270,3 +270,96 @@ describe("SlackApi.listThreadMessages", () => {
     ]);
   });
 });
+
+describe("SlackApi.getUserIdentity", () => {
+  it("parses Slack profile email for inferred co-author mapping", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (!url.endsWith("/users.info")) {
+        throw new Error(`Unexpected fetch ${url}`);
+      }
+
+      return new Response(JSON.stringify({
+        ok: true,
+        user: {
+          id: "U123",
+          name: "alice",
+          real_name: "Alice Example",
+          profile: {
+            display_name: "Alice Slack",
+            email: "alice@example.com"
+          }
+        }
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new SlackApi({
+      baseUrl: "https://slack.test/api",
+      appToken: "xapp-test",
+      botToken: "xoxb-test"
+    });
+
+    await expect(api.getUserIdentity("U123")).resolves.toEqual({
+      userId: "U123",
+      mention: "<@U123>",
+      username: "alice",
+      displayName: "Alice Slack",
+      realName: "Alice Example",
+      email: "alice@example.com"
+    });
+  });
+});
+
+describe("SlackApi interactivity helpers", () => {
+  it("posts ephemeral thread prompts and opens views", async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith("/chat.postEphemeral")) {
+        expect(String(init?.body)).toContain("channel=C123");
+        expect(String(init?.body)).toContain("user=U123");
+        expect(String(init?.body)).toContain("thread_ts=111.222");
+        expect(String(init?.body)).toContain("blocks=");
+        return new Response(JSON.stringify({ ok: true, message_ts: "111.333" }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+
+      if (url.endsWith("/views.open")) {
+        expect(String(init?.body)).toContain("trigger_id=trigger-1");
+        expect(String(init?.body)).toContain("view=");
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new SlackApi({
+      baseUrl: "https://slack.test/api",
+      appToken: "xapp-test",
+      botToken: "xoxb-test"
+    });
+
+    await expect(api.postEphemeral({
+      channelId: "C123",
+      threadTs: "111.222",
+      userId: "U123",
+      text: "Configure co-authors",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "hello" } }]
+    })).resolves.toBe("111.333");
+
+    await expect(api.openView({
+      triggerId: "trigger-1",
+      view: { type: "modal", title: { type: "plain_text", text: "Demo" } }
+    })).resolves.toBeUndefined();
+  });
+});

--- a/test/slack-coauthor-service.test.ts
+++ b/test/slack-coauthor-service.test.ts
@@ -156,6 +156,13 @@ describe("SlackCoauthorService", () => {
     expect(modalView).toMatchObject({
       callback_id: "coauthor_confirm"
     });
+    expect((modalView.blocks as Array<Record<string, unknown>>).filter((block) => String(block.block_id || "").startsWith("author__"))).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          optional: true
+        })
+      ])
+    );
 
     await service.handleInteractivePayload({
       type: "view_submission",

--- a/test/slack-coauthor-service.test.ts
+++ b/test/slack-coauthor-service.test.ts
@@ -1,0 +1,202 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SessionManager } from "../src/services/session-manager.js";
+import { GitHubAuthorMappingService } from "../src/services/github-author-mapping-service.js";
+import { SlackCoauthorService } from "../src/services/slack/slack-coauthor-service.js";
+import { StateStore } from "../src/store/state-store.js";
+
+describe("SlackCoauthorService", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, {
+      recursive: true,
+      force: true
+    })));
+  });
+
+  it("prompts once per candidate revision when commit confirmation is still missing", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
+    tempDirs.push(stateDir, sessionsRoot);
+
+    const sessions = new SessionManager({
+      stateStore: new StateStore(stateDir, sessionsRoot),
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C123", "111.222");
+
+    const postEphemeral = vi.fn(async () => "111.333");
+    const service = new SlackCoauthorService({
+      sessions,
+      mappings: new GitHubAuthorMappingService({ stateDir }),
+      slackApi: {
+        getUserIdentity: vi.fn(async () => ({
+          userId: "U123",
+          mention: "<@U123>",
+          realName: "Alice Example",
+          email: "alice@example.com"
+        })),
+        postEphemeral,
+        openView: vi.fn()
+      } as never
+    });
+
+    await service.noteIncomingSlackInput(session, {
+      source: "thread_reply",
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "111.223",
+      userId: "U123",
+      senderKind: "user",
+      text: "please commit this"
+    });
+
+    const first = await service.resolveCommitCoauthors({
+      cwd: session.workspacePath,
+      commitMessage: "feat(test): demo"
+    });
+    expect(first).toMatchObject({
+      status: "blocked",
+      errorCode: "coauthor_confirmation_required"
+    });
+    expect(postEphemeral).toHaveBeenCalledTimes(1);
+
+    const second = await service.resolveCommitCoauthors({
+      cwd: session.workspacePath,
+      commitMessage: "feat(test): demo"
+    });
+    expect(second).toMatchObject({
+      status: "blocked",
+      errorCode: "coauthor_confirmation_required"
+    });
+    expect(postEphemeral).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the Slack modal, stores manual mappings, and resolves commit trailers", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
+    tempDirs.push(stateDir, sessionsRoot);
+
+    const sessions = new SessionManager({
+      stateStore: new StateStore(stateDir, sessionsRoot),
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C555", "222.333");
+    const mappings = new GitHubAuthorMappingService({ stateDir });
+    await mappings.load();
+
+    const identities = new Map([
+      ["U1", {
+        userId: "U1",
+        mention: "<@U1>",
+        realName: "Alice Example",
+        email: "alice@example.com"
+      }],
+      ["U2", {
+        userId: "U2",
+        mention: "<@U2>",
+        displayName: "Bob Example",
+        email: "bob@example.com"
+      }]
+    ]);
+    const openView = vi.fn(async () => {});
+    const service = new SlackCoauthorService({
+      sessions,
+      mappings,
+      slackApi: {
+        getUserIdentity: vi.fn(async (userId: string) => identities.get(userId) ?? null),
+        postEphemeral: vi.fn(async () => "111.444"),
+        openView
+      } as never
+    });
+
+    let latestSession = await service.noteIncomingSlackInput(session, {
+      source: "thread_reply",
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "222.334",
+      userId: "U1",
+      senderKind: "user",
+      text: "first request"
+    });
+    latestSession = await service.noteIncomingSlackInput(latestSession, {
+      source: "thread_reply",
+      channelId: latestSession.channelId,
+      rootThreadTs: latestSession.rootThreadTs,
+      messageTs: "222.335",
+      userId: "U2",
+      senderKind: "user",
+      text: "second request"
+    });
+
+    await service.handleInteractivePayload({
+      type: "block_actions",
+      trigger_id: "trigger-1",
+      actions: [
+        {
+          action_id: "coauthor_configure",
+          value: JSON.stringify({
+            session_key: latestSession.key,
+            candidate_revision: latestSession.coAuthorCandidateRevision
+          })
+        }
+      ]
+    });
+
+    expect(openView).toHaveBeenCalledTimes(1);
+    const modalView = (openView.mock.calls[0] as unknown as [Record<string, unknown>])?.[0]?.view as Record<string, unknown>;
+    expect(modalView).toMatchObject({
+      callback_id: "coauthor_confirm"
+    });
+
+    await service.handleInteractivePayload({
+      type: "view_submission",
+      user: { id: "U1" },
+      view: {
+        private_metadata: JSON.stringify({
+          session_key: latestSession.key,
+          candidate_revision: latestSession.coAuthorCandidateRevision
+        }),
+        state: {
+          values: {
+            contributors: {
+              selected: {
+                selected_options: [
+                  { value: "U1" },
+                  { value: "U2" }
+                ]
+              }
+            },
+            author__U1: {
+              value: {
+                value: "Alice Example <alice@example.com>"
+              }
+            },
+            author__U2: {
+              value: {
+                value: "Bob Example <bob@example.com>"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const resolved = await service.resolveCommitCoauthors({
+      cwd: latestSession.workspacePath,
+      commitMessage: "feat(slack): add coauthors",
+      primaryAuthorEmail: "broker@example.com"
+    });
+    expect(resolved.status).toBe("resolved");
+    expect(resolved.commitMessage).toContain("Co-authored-by: Alice Example <alice@example.com>");
+    expect(resolved.commitMessage).toContain("Co-authored-by: Bob Example <bob@example.com>");
+  });
+});

--- a/test/socket-mode-client.test.ts
+++ b/test/socket-mode-client.test.ts
@@ -1,4 +1,7 @@
+import { once } from "node:events";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
 
 import { SlackSocketModeClient } from "../src/services/slack/socket-mode-client.js";
 
@@ -25,5 +28,56 @@ describe("SlackSocketModeClient", () => {
     expect(api.openSocketConnection).toHaveBeenCalledTimes(2);
 
     await client.stop();
+  });
+
+  it("emits interactive payloads from Socket Mode envelopes", async () => {
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start websocket server");
+    }
+
+    const interactivePromise = new Promise<Record<string, unknown>>((resolve) => {
+      const api = {
+        openSocketConnection: vi.fn().mockResolvedValue(`ws://127.0.0.1:${address.port}`)
+      };
+      const client = new SlackSocketModeClient({
+        api: api as never,
+        socketOpenPath: "apps.connections.open"
+      });
+      client.on("interactive", (payload) => {
+        resolve(payload as Record<string, unknown>);
+        void client.stop();
+      });
+
+      void client.start();
+    });
+
+    const [socket] = await once(server, "connection") as [WebSocket];
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    socket.send(JSON.stringify({
+      envelope_id: "env-1",
+      type: "interactive",
+      payload: {
+        type: "block_actions",
+        trigger_id: "trigger-1"
+      }
+    }));
+
+    await expect(interactivePromise).resolves.toMatchObject({
+      type: "block_actions",
+      trigger_id: "trigger-1"
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Context

- 现在 Slack 发起的 Codex 会话里，实际 `git commit` 仍然总是由运行时绑定的 GitHub 账号完成，Slack 发起人和协作者只能体现在对话上下文里，不能稳定体现在 commit metadata。
- 这次改动的目标是把“Slack 协作者归属”收回到 broker 控制面里：commit 继续由当前运行时账号执行，但 broker 在提交前统一校验 co-author 状态，并按确认结果追加 `Co-authored-by:` trailers。
- 本期范围明确排除了“按 Slack 用户真实签名 commit”。没有引入用户级私钥、签名切换或 verified identity 伪装，目标是先把归属和流程控制做对。

## 协作过程

```mermaid
sequenceDiagram
    participant User as User
    participant Codex as Codex
    participant Slack as Slack thread
    participant Broker as Broker runtime
    participant Admin as Web admin
    participant Hook as commit-msg hook

    User->>Codex: 先讨论 co-author 归属和签名边界
    Note right of User: 明确要求“不做用户级签名”
    User->>Codex: 补充 web admin 也要能维护 mapping
    Codex->>Broker: 梳理 Slack session / admin / git 提交流程
    Codex->>Broker: 设计 session candidate contributors + confirmed contributors
    Codex->>Slack: 设计 thread ephemeral + modal 的确认流程
    Codex->>Admin: 增加 GitHub author mapping 管理面板与 CRUD
    Codex->>Hook: 增加 commit-msg gate，统一在提交前校验 co-author 状态
    Hook->>Slack: 未确认或缺 mapping 时反向触发 Slack 配置流程
    Slack-->>Hook: modal 提交后持久化 mapping + confirmed contributors
    Hook->>Broker: 读取 session co-author 状态并追加 trailers
```

Note:
关键转折有三个。第一，co-author 候选集合不能直接等于“线程里所有人”，而是先收集 broker 实际看到并送进 Codex 的真人候选人，再由 Slack modal 做最终确认。第二，真正的强约束不能只靠 prompt 提醒模型，而是要落在 `commit-msg` hook。第三，admin 手工 mapping 和 Slack 自动推断必须共享同一份持久化数据，并且 manual 要覆盖 auto。

## 方案讨论

### 方案一：只在 admin 里手工维护 mapping，提交时静默追加 trailers

- 实现成本最低，也不需要 Slack interactivity。
- 问题是它无法解决“本次到底谁算 co-author”的会话级确认问题，最后会退化成一张静态映射表，无法反映线程里的真实参与者。
- 这个方案也不能在缺少 mapping 时及时把问题抛回 Slack 发起人，因此没有采用。

### 方案二：按 Slack 用户真实 author / signer 去切换 git 身份

- 这在语义上最“像真人提交”，但需要用户级 auth profile、签名 key 托管、切换与审计机制。
- 本次讨论里已经明确排除签名范围；如果现在硬上，会把问题从“归属”升级成“密钥和身份管理”。
- 这个方案留到后续独立设计，不纳入本次实现。

### 方案三：broker 管理 co-author 状态，Slack modal 确认，commit-msg hook 强制执行

- 这是本次采用的方案。
- Slack 用户资料先做自动推断：`realName > displayName > username` 作为 name，`email` 作为 email；推断失败时不猜 GitHub username，而是阻止提交并要求补录。
- broker 保存两层状态：全局 `Slack user -> GitHub author` mapping，以及 session 级 candidate / confirmed contributors。
- `commit-msg` hook 在真正提交前按 `cwd` 反查 session：未命中 session 则 no-op；命中但未确认或缺 mapping 则失败；满足条件时再幂等追加 `Co-authored-by:` trailers。

## 最终方案

- 新增全局 `GitHubAuthorMappingService`，独立持久化 `Slack user id -> GitHub author`，支持 `manual` / `slack_inferred` 两种来源，manual 永远覆盖 auto。
- 扩展 `SlackUserIdentity` 和 session state：session 现在会记录 co-author candidates、candidate revision、confirmed contributors、confirmed revision，以及 prompt 节流信息。
- 扩展 Slack API / Socket Mode：增加 `users.info.email` 解析、`chat.postEphemeral`、`views.open`，并支持 `interactive` Socket Mode envelope。
- 引入 `SlackCoauthorService` 统一处理三件事：收集候选 contributor、处理 Slack modal 交互、为 git hook 解析可写入的 co-authors。
- admin 页面新增 `GitHub Authors` panel，支持搜索、查看来源、手工新增/编辑/删除 mapping；和 Slack 补录共用同一份持久化数据。
- runtime 启动时安装全局 `commit-msg` hook，并注入 `BROKER_GIT_COAUTHOR_HELPER`；base instructions 只补轻提示，真正 gate 由 hook 执行。

```mermaid
flowchart TD
    A[Slack human message] --> B[Session candidate contributor collection]
    B --> C{Mapping inferred?}
    C -->|yes| D[Store slack_inferred mapping]
    C -->|no| E[Wait for manual entry]
    B --> F[Slack ephemeral prompt]
    F --> G[Slack modal confirm contributors]
    G --> H[Persist confirmed contributors + manual mappings]
    H --> I[git commit]
    I --> J[commit-msg hook]
    J --> K{session confirmed and mapped?}
    K -->|no| L[Reject commit and point back to Slack]
    K -->|yes| M[Append Co-authored-by trailers]
```

## 验证情况

- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vitest run test/github-author-mapping-service.test.ts test/slack-coauthor-service.test.ts test/admin-routes.test.ts test/app-server-client.test.ts test/slack-api.test.ts test/session-manager.test.ts test/git-coauthor-helper.test.ts test/socket-mode-client.test.ts test/admin-service.test.ts test/runtime-paths.test.ts`
- `<!-- 请补充 CC 之外的验证 -->`

## 已知局限 / 后续工作

- 本期不支持按 Slack 用户真实 author / signer 切换 git 身份，也不会提供 verified signing；co-author 只通过 commit trailers 体现。
- `commit-msg` hook 目前是 broker 运行时级别的统一约束，针对的是 broker 管理的 session workspace；如果未来要覆盖更多提交入口，可能还需要继续扩展 helper 或配套文档。
- 目前 candidate contributors 仍然基于 broker 实际看到并送进 Codex 的真人消息收集，最终裁决依赖 Slack modal；如果后续想进一步细化“谁算明确提需求的人”，还需要额外的交互或规则。
