### PR TITLE
fix: narrow slack missed-message recovery lookback

### DIFF
--- a/src/services/slack/slack-conversation-utils.ts
+++ b/src/services/slack/slack-conversation-utils.ts
@@ -6,7 +6,7 @@ import type {
   SlackTurnSignalKind
 } from "../../types.js";
 
-const AUTO_RECOVERY_SESSION_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1_000;
+const AUTO_RECOVERY_SESSION_LOOKBACK_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_FAILURE_NOTIFICATION_COOLDOWN_MS = 5 * 60 * 1_000;
 
 export function chunkSlackMessage(text: string, chunkSize = 3_500): string[] {

--- a/test/slack-conversation-utils.test.ts
+++ b/test/slack-conversation-utils.test.ts
@@ -6,6 +6,7 @@ import {
   isMissingCodexThreadError,
   isMissingActiveTurnSteerError,
   parseActiveTurnMismatch,
+  shouldAutoRecoverSession,
   shouldPostSlackRunFailure,
   shouldNotifySlackFailure
 } from "../src/services/slack/slack-conversation-utils.js";
@@ -89,4 +90,29 @@ describe("slack conversation utils", () => {
       })
     ).toBe(false);
   });
+
+  it("only auto-recovers sessions updated within the last day", () => {
+    const nowMs = Date.parse("2026-04-08T12:00:00.000Z");
+    const baseSession = {
+      key: "C123:1.23",
+      channelId: "C123",
+      rootThreadTs: "1.23",
+      workspacePath: "/tmp/workspace",
+      createdAt: "2026-04-07T00:00:00.000Z",
+      updatedAt: "2026-04-08T00:00:01.000Z",
+      lastObservedMessageTs: "1775621831.247979"
+    };
+
+    expect(shouldAutoRecoverSession(baseSession, nowMs)).toBe(true);
+    expect(
+      shouldAutoRecoverSession(
+        {
+          ...baseSession,
+          updatedAt: "2026-04-07T11:59:59.000Z"
+        },
+        nowMs
+      )
+    ).toBe(false);
+  });
+
 });


### PR DESCRIPTION
## Summary
- narrow Slack missed-message recovery eligibility from 14 days to 1 day
- add a regression test covering the 1-day cutoff

## Testing
- pnpm test -- test/slack-conversation-utils.test.ts
- pnpm build
- manual: replayed the current `.data/state/sessions` snapshot and confirmed eligible recovery sessions would drop from 162 to 38
