### PR TITLE
Keep draining Codex app-server logs after startup

### DIFF
--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -422,8 +422,11 @@ async function waitForAppServerListen(
   return await new Promise<void>((resolve, reject) => {
     let stdoutTail = "";
     let stderrTail = "";
+    let startupComplete = false;
     const timeout = setTimeout(() => {
-      cleanup();
+      cleanup({
+        removeStreamListeners: true
+      });
       reject(
         new Error(
           `Timed out waiting for codex app-server to start${formatStartupDetails(stdoutTail, stderrTail)}`
@@ -431,11 +434,30 @@ async function waitForAppServerListen(
       );
     }, 15_000);
 
-    const cleanup = () => {
+    const cleanup = (options?: {
+      readonly removeStreamListeners?: boolean;
+    }) => {
       clearTimeout(timeout);
-      child.stdout.off("data", onStdout);
-      child.stderr.off("data", onStderr);
-      child.off("exit", onExit);
+      child.off("exit", onStartupExit);
+
+      if (options?.removeStreamListeners) {
+        child.stdout.off("data", onStdout);
+        child.stderr.off("data", onStderr);
+      }
+    };
+
+    const finishStartup = () => {
+      if (startupComplete) {
+        return;
+      }
+
+      startupComplete = true;
+      // Keep draining stdout/stderr after the startup banner so later app-server
+      // transport warnings (for example websocket disconnect reasons) are not
+      // lost and the child cannot block on a full pipe.
+      cleanup();
+      child.once("exit", onPostStartupExit);
+      resolve();
     };
 
     const onStdout = (chunk: Buffer): void => {
@@ -443,8 +465,7 @@ async function waitForAppServerListen(
       stdoutTail = `${stdoutTail}${text}`.slice(-8_000);
       logger.debug("codex app-server stdout", { text });
       if (text.includes("listening on:")) {
-        cleanup();
-        resolve();
+        finishStartup();
       }
     };
 
@@ -453,13 +474,20 @@ async function waitForAppServerListen(
       stderrTail = `${stderrTail}${text}`.slice(-8_000);
       logger.warn("codex app-server stderr", { text });
       if (text.includes("listening on:")) {
-        cleanup();
-        resolve();
+        finishStartup();
       }
     };
 
-    const onExit = (code: number | null) => {
-      cleanup();
+    const onPostStartupExit = () => {
+      child.stdout.off("data", onStdout);
+      child.stderr.off("data", onStderr);
+      child.off("exit", onPostStartupExit);
+    };
+
+    const onStartupExit = (code: number | null) => {
+      cleanup({
+        removeStreamListeners: true
+      });
       reject(
         new Error(
           `codex app-server exited early with code ${code ?? "null"}${formatStartupDetails(stdoutTail, stderrTail)}`
@@ -469,7 +497,7 @@ async function waitForAppServerListen(
 
     child.stdout.on("data", onStdout);
     child.stderr.on("data", onStderr);
-    child.once("exit", onExit);
+    child.once("exit", onStartupExit);
   });
 }
 

--- a/test/app-server-process.test.ts
+++ b/test/app-server-process.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppServerProcess } from "../src/services/codex/app-server-process.js";
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function startHealthyHttpServer(): Promise<{
+  readonly close: () => Promise<void>;
+  readonly url: string;
+}> {
+  const server = http.createServer((_request, response) => {
+    response.statusCode = 200;
+    response.end("ok");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine tempad test server address");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      })
+  };
+}
+
+describe("AppServerProcess", () => {
+  let originalPath = process.env.PATH;
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    vi.restoreAllMocks();
+  });
+
+  it("continues draining app-server stderr after startup", async () => {
+    originalPath = process.env.PATH;
+
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-app-server-process-"));
+    const tempadServer = await startHealthyHttpServer();
+    const fakeBinDir = path.join(tempRoot, "bin");
+    const fakeCodexPath = path.join(fakeBinDir, "codex");
+    const hostCodexHomePath = path.join(tempRoot, "host-codex-home");
+    const hostGeminiHomePath = path.join(tempRoot, "host-gemini-home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const observedWrites: string[] = [];
+
+    await fs.mkdir(fakeBinDir, {
+      recursive: true
+    });
+    await fs.mkdir(hostCodexHomePath, {
+      recursive: true
+    });
+    await fs.mkdir(hostGeminiHomePath, {
+      recursive: true
+    });
+
+    await fs.writeFile(
+      fakeCodexPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "if [ \"${1:-}\" = \"app-server\" ]; then",
+        "  printf '%s\\n' 'codex app-server (WebSockets)' >&2",
+        "  printf '%s\\n' '  listening on: ws://127.0.0.1:4590' >&2",
+        "  sleep 0.1",
+        "  printf '%s\\n' 'disconnecting slow connection after outbound queue filled: ConnectionId(1)' >&2",
+        "  while true; do",
+        "    sleep 1",
+        "  done",
+        "fi",
+        "printf 'unexpected fake codex args: %s\\n' \"$*\" >&2",
+        "exit 1",
+        ""
+      ].join("\n"),
+      {
+        mode: 0o755
+      }
+    );
+    await fs.chmod(fakeCodexPath, 0o755);
+
+    process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      observedWrites.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write);
+
+    const processManager = new AppServerProcess({
+      brokerHttpBaseUrl: "http://127.0.0.1:3001",
+      codexHome,
+      port: 4590,
+      hostCodexHomePath,
+      hostGeminiHomePath,
+      tempadLinkServiceUrl: tempadServer.url
+    });
+
+    try {
+      await processManager.start();
+      await delay(300);
+    } finally {
+      await processManager.stop().catch(() => {});
+      await tempadServer.close().catch(() => {});
+      await fs.rm(tempRoot, {
+        force: true,
+        recursive: true
+      });
+    }
+
+    expect(observedWrites.join("")).toContain(
+      "disconnecting slow connection after outbound queue filled: ConnectionId(1)"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep draining the spawned Codex app-server stdout/stderr streams after the startup banner instead of detaching immediately
- preserve startup failure behavior while continuing to capture later transport warnings and disconnect reasons
- add a focused test that uses a fake `codex app-server` to verify post-start stderr still reaches broker logging

## Testing
- pnpm test test/app-server-process.test.ts
- pnpm build
- manual: ran a one-off Node harness against the built broker with a fake `codex app-server`; confirmed a post-start `disconnecting slow connection...` stderr line was captured (`manual_log_seen=true`)
