### PR TITLE
Handle EPIPE reconnects and improve co-author hints

### DIFF
--- a/src/services/codex/codex-broker.ts
+++ b/src/services/codex/codex-broker.ts
@@ -326,7 +326,7 @@ export class CodexBroker extends EventEmitter {
   }
 }
 
-function isRecoverableCodexConnectionError(error: unknown): boolean {
+export function isRecoverableCodexConnectionError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return [
     "Codex app-server websocket is not connected",
@@ -334,6 +334,7 @@ function isRecoverableCodexConnectionError(error: unknown): boolean {
     "readyState 3",
     "socket hang up",
     "ECONNREFUSED",
+    "EPIPE",
     "closed"
   ].some((pattern) => message.includes(pattern));
 }

--- a/src/services/slack/slack-coauthor-service.ts
+++ b/src/services/slack/slack-coauthor-service.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "../session-manager.js";
 import { GitHubAuthorMappingService } from "../github-author-mapping-service.js";
 import {
   appendCoAuthorTrailers,
+  inferGitHubAuthorFromSlackIdentity,
   isValidGitHubAuthor,
   normalizeEmail
 } from "../git/github-author-utils.js";
@@ -249,10 +250,16 @@ export class SlackCoauthorService {
     }
 
     if (invalidUserIds.length > 0) {
+      const invalidLabels = await Promise.all(
+        invalidUserIds.map(async (invalidUserId) => describeSlackUser(
+          await this.#slackApi.getUserIdentity(invalidUserId),
+          invalidUserId
+        ))
+      );
       await this.#postSubmitResult(
         userId,
         session.key,
-        "Some selected co-authors still have an invalid `Name <email>` value. Re-open the Slack prompt and fix them."
+        `These selected co-authors need a valid GitHub author in \`Name <email>\` format: ${invalidLabels.join(", ")}. If Slack cannot infer an email for someone, enter it manually.`
       );
       return;
     }
@@ -397,7 +404,10 @@ export class SlackCoauthorService {
         },
         ...candidateUserIds.map((userId, index) => {
           const identity = identities[index];
-          const initialValue = this.#mappings.getMapping(userId)?.githubAuthor ?? "";
+          const initialValue =
+            this.#mappings.getMapping(userId)?.githubAuthor ??
+            (identity ? inferGitHubAuthorFromSlackIdentity(identity) : undefined) ??
+            "";
           return {
             type: "input",
             block_id: authorBlockId(userId),
@@ -405,6 +415,10 @@ export class SlackCoauthorService {
             label: {
               type: "plain_text",
               text: `${describeSlackUser(identity, userId)} GitHub author`
+            },
+            hint: {
+              type: "plain_text",
+              text: buildGitHubAuthorHint(identity, Boolean(initialValue))
             },
             element: {
               type: "plain_text_input",
@@ -537,4 +551,21 @@ function describeSlackUser(
     return `${label} (${identity.email})`;
   }
   return label;
+}
+
+function buildGitHubAuthorHint(
+  identity: {
+    readonly email?: string | undefined;
+  } | null | undefined,
+  hasInitialValue: boolean
+): string {
+  if (hasInitialValue) {
+    return "Used when this person is checked as a co-author.";
+  }
+
+  if (!normalizeEmail(identity?.email)) {
+    return "Slack could not infer an email for this person. If checked, enter Name <email@example.com> manually.";
+  }
+
+  return "If checked, enter a GitHub author in the form Name <email@example.com>.";
 }

--- a/src/services/slack/slack-conversation-utils.ts
+++ b/src/services/slack/slack-conversation-utils.ts
@@ -96,6 +96,7 @@ export function isRecoverableCodexTurnFailure(error: unknown): boolean {
     "readyState 3",
     "socket hang up",
     "ECONNREFUSED",
+    "EPIPE",
     "closed"
   ].some((pattern) => message.includes(pattern));
 }

--- a/test/codex-broker.test.ts
+++ b/test/codex-broker.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { isRecoverableCodexConnectionError } from "../src/services/codex/codex-broker.js";
+
+describe("codex broker", () => {
+  it("treats EPIPE websocket writes as recoverable connection failures", () => {
+    expect(isRecoverableCodexConnectionError(new Error("write EPIPE"))).toBe(true);
+  });
+});

--- a/test/slack-coauthor-service.test.ts
+++ b/test/slack-coauthor-service.test.ts
@@ -206,4 +206,111 @@ describe("SlackCoauthorService", () => {
     expect(resolved.commitMessage).toContain("Co-authored-by: Alice Example <alice@example.com>");
     expect(resolved.commitMessage).toContain("Co-authored-by: Bob Example <bob@example.com>");
   });
+
+  it("adds a manual-entry hint when Slack cannot infer an email and reports which user is invalid", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
+    tempDirs.push(stateDir, sessionsRoot);
+
+    const sessions = new SessionManager({
+      stateStore: new StateStore(stateDir, sessionsRoot),
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C777", "333.444");
+    const mappings = new GitHubAuthorMappingService({ stateDir });
+    await mappings.load();
+
+    const postEphemeral = vi.fn(async () => "111.555");
+    const openView = vi.fn(async () => {});
+    const service = new SlackCoauthorService({
+      sessions,
+      mappings,
+      slackApi: {
+        getUserIdentity: vi.fn(async (userId: string) => {
+          if (userId !== "U1") {
+            return null;
+          }
+
+          return {
+            userId: "U1",
+            mention: "<@U1>",
+            realName: "Kewei Hua"
+          };
+        }),
+        postEphemeral,
+        openView
+      } as never
+    });
+
+    const latestSession = await service.noteIncomingSlackInput(session, {
+      source: "thread_reply",
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "333.445",
+      userId: "U1",
+      senderKind: "user",
+      text: "please commit this"
+    });
+
+    await service.handleInteractivePayload({
+      type: "block_actions",
+      trigger_id: "trigger-2",
+      actions: [
+        {
+          action_id: "coauthor_configure",
+          value: JSON.stringify({
+            session_key: latestSession.key,
+            candidate_revision: latestSession.coAuthorCandidateRevision
+          })
+        }
+      ]
+    });
+
+    const modalView = (openView.mock.calls[0] as unknown as [Record<string, unknown>])?.[0]?.view as Record<string, unknown>;
+    expect((modalView.blocks as Array<Record<string, unknown>>)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          block_id: "author__U1",
+          hint: {
+            type: "plain_text",
+            text: "Slack could not infer an email for this person. If checked, enter Name <email@example.com> manually."
+          }
+        })
+      ])
+    );
+
+    await service.handleInteractivePayload({
+      type: "view_submission",
+      user: { id: "U1" },
+      view: {
+        private_metadata: JSON.stringify({
+          session_key: latestSession.key,
+          candidate_revision: latestSession.coAuthorCandidateRevision
+        }),
+        state: {
+          values: {
+            contributors: {
+              selected: {
+                selected_options: [
+                  { value: "U1" }
+                ]
+              }
+            },
+            author__U1: {
+              value: {
+                value: ""
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(postEphemeral).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        text: "These selected co-authors need a valid GitHub author in `Name <email>` format: Kewei Hua. If Slack cannot infer an email for someone, enter it manually."
+      })
+    );
+  });
 });

--- a/test/slack-conversation-utils.test.ts
+++ b/test/slack-conversation-utils.test.ts
@@ -49,6 +49,13 @@ describe("slack conversation utils", () => {
     expect(shouldPostSlackRunFailure(new Error("Codex app-server websocket closed"))).toBe(false);
   });
 
+  it("treats EPIPE transport failures as recoverable", () => {
+    expect(formatSlackRunFailureMessage(new Error("write EPIPE"))).toBe(
+      "I lost my connection while working on this thread. I will resume as soon as the connection comes back."
+    );
+    expect(shouldPostSlackRunFailure(new Error("write EPIPE"))).toBe(false);
+  });
+
   it("formats active turn mismatches for Slack users", () => {
     expect(
       formatSlackRunFailureMessage(


### PR DESCRIPTION
## Summary
- treat app-server `write EPIPE` failures as recoverable reconnects instead of generic internal errors
- improve co-author modal guidance when Slack cannot infer an email
- make the invalid co-author error name the affected Slack user(s)

## Testing
- pnpm test test/slack-conversation-utils.test.ts test/codex-broker.test.ts test/slack-coauthor-service.test.ts
- pnpm build
- manual built-code check for `write EPIPE` classification
- manual built-code check for co-author hint and invalid-user message