### PR TITLE
Make Slack co-author flow non-blocking

### DIFF
--- a/src/http/slack-routes.ts
+++ b/src/http/slack-routes.ts
@@ -5,8 +5,10 @@ import type { AppConfig } from "../config.js";
 import { logger } from "../logger.js";
 import type { SlackCodexBridge } from "../services/slack/slack-codex-bridge.js";
 import {
+  readBoolean,
   readJsonBody,
   readFormBody,
+  readString,
   respondJson
 } from "./common.js";
 
@@ -52,6 +54,16 @@ export async function handleSlackRequest(
 
   if (method === "POST" && url.pathname === "/slack/git-coauthors/resolve-commit-message") {
     await handleResolveCommitCoauthorsRequest(request, response, options);
+    return true;
+  }
+
+  if (method === "GET" && url.pathname === "/slack/git-coauthors/session-status") {
+    await handleGetCommitCoauthorStatusRequest(url, response, options);
+    return true;
+  }
+
+  if (method === "POST" && url.pathname === "/slack/git-coauthors/configure-session") {
+    await handleConfigureCommitCoauthorsRequest(request, response, options);
     return true;
   }
 
@@ -489,16 +501,6 @@ async function handleResolveCommitCoauthorsRequest(
       primaryAuthorEmail
     });
 
-    if (result.status === "blocked") {
-      respondJson(response, 409, {
-        ok: false,
-        error: result.errorCode ?? "coauthor_resolution_blocked",
-        message: result.message,
-        sessionKey: result.sessionKey
-      });
-      return;
-    }
-
     respondJson(response, 200, {
       ok: true,
       ...result
@@ -509,4 +511,136 @@ async function handleResolveCommitCoauthorsRequest(
       error: error instanceof Error ? error.message : String(error)
     });
   }
+}
+
+async function handleGetCommitCoauthorStatusRequest(
+  url: URL,
+  response: http.ServerResponse,
+  options: {
+    readonly bridge: SlackCodexBridge;
+  }
+): Promise<void> {
+  const cwd = url.searchParams.get("cwd")?.trim();
+  if (!cwd) {
+    respondJson(response, 400, {
+      ok: false,
+      error: "missing_required_query",
+      required: ["cwd"]
+    });
+    return;
+  }
+
+  try {
+    const status = await options.bridge.getCommitCoauthorStatus(cwd);
+    if (!status) {
+      respondJson(response, 404, {
+        ok: false,
+        error: "session_not_found"
+      });
+      return;
+    }
+
+    respondJson(response, 200, {
+      ok: true,
+      status
+    });
+  } catch (error) {
+    respondJson(response, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+async function handleConfigureCommitCoauthorsRequest(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  options: {
+    readonly bridge: SlackCodexBridge;
+  }
+): Promise<void> {
+  try {
+    const body = await readJsonBody(request);
+    const cwd = readString(body.cwd);
+    if (!cwd) {
+      respondJson(response, 400, {
+        ok: false,
+        error: "missing_required_body",
+        required: ["cwd"]
+      });
+      return;
+    }
+
+    const coauthors = normalizeStringArray(body.coauthors);
+    const userIds = normalizeStringArray(body.user_ids);
+    const mappings = normalizeMappings(body.mappings);
+    const ignoreMissing =
+      Object.prototype.hasOwnProperty.call(body, "ignore_missing") ||
+      Object.prototype.hasOwnProperty.call(body, "ignoreMissing")
+        ? readBoolean(body.ignore_missing ?? body.ignoreMissing, false)
+        : undefined;
+    const status = await options.bridge.configureSessionCoauthors({
+      cwd,
+      coauthors,
+      userIds,
+      ignoreMissing,
+      mappings
+    });
+
+    if (!status) {
+      respondJson(response, 404, {
+        ok: false,
+        error: "session_not_found"
+      });
+      return;
+    }
+
+    respondJson(response, 200, {
+      ok: true,
+      status
+    });
+  } catch (error) {
+    respondJson(response, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : [];
+}
+
+function normalizeMappings(value: unknown):
+  | Array<{
+      slackUserId?: string | undefined;
+      slackUser?: string | undefined;
+      githubAuthor: string;
+    }>
+  | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object")
+    .map((entry) => {
+      const githubAuthor = readString(entry.github_author ?? entry.githubAuthor);
+      if (!githubAuthor) {
+        throw new Error("Each co-author mapping requires github_author.");
+      }
+
+      return {
+        slackUserId: readString(entry.slack_user_id ?? entry.slackUserId),
+        slackUser: readString(entry.slack_user ?? entry.slackUser),
+        githubAuthor
+      };
+    });
 }

--- a/src/http/slack-routes.ts
+++ b/src/http/slack-routes.ts
@@ -615,7 +615,7 @@ function normalizeStringArray(value: unknown): string[] | undefined {
   const normalized = value
     .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
     .filter(Boolean);
-  return normalized.length > 0 ? normalized : [];
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function normalizeMappings(value: unknown):

--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -21,6 +21,9 @@ Slack broker API usage for this session:
 - Upload a local image or file with: {{post_file_command}}
 - Read earlier thread context with: {{thread_history_command}}
 - Register a broker-managed background job with: {{register_job_command}}
+- Inspect the current session's co-author status with: {{coauthor_status_command}}
+- Configure the current session's co-authors/mappings with: {{coauthor_configure_command}}
+- The co-author configure endpoint accepts current-session contributors by Slack user id, @mention, display name, real name, username, or email, plus optional GitHub author mappings.
 - Prefer absolute file_path values when uploading local artifacts.
 - Registered background jobs receive environment variables including BROKER_JOB_ID, BROKER_JOB_TOKEN, BROKER_API_BASE, BROKER_JOB_HELPER, SLACK_CHANNEL_ID, SLACK_THREAD_TS, SESSION_KEY, SESSION_WORKSPACE, and REPOS_ROOT.
 - Inside a background job script, prefer `node "$BROKER_JOB_HELPER" ...` for heartbeat/event/complete/fail/cancel callbacks instead of hand-writing nested curl JSON payloads.
@@ -67,9 +70,11 @@ Repository workflow contract:
 - Do not treat {{shared_repos_root}} as the default development workspace. Use it as shared repo storage, not as the main place for edits.
 
 Git commit co-author contract:
-- Commits created from this Slack session may be blocked by a broker-managed co-author gate.
+- Use the broker-managed co-author status/configure APIs to inspect or update session co-author state when needed; the agent can operate these directly.
 - Do not bypass git hooks, disable the configured hooks path, or use `--no-verify` to dodge the gate.
-- If `git commit` fails because co-authors still need confirmation or mapping, pause there, wait for the Slack co-author flow to finish, and retry the same commit.
+- Commits from this Slack session should remain non-blocking: if known co-author identities are already mapped, commit directly without an extra registration step.
+- If co-author information is missing and the commit would benefit from it, proactively ask in Slack or call the configure API yourself before committing.
+- If the user explicitly authorizes proceeding without unresolved co-authors, set the session to ignore missing co-authors and continue; unresolved co-authors may be skipped for that commit.
 - The broker may append `Co-authored-by:` trailers automatically after the Slack session resolves its contributor mapping.
 
 Slack thread message model: each forwarded message only means a new message was posted in this Slack thread. Do not assume it is addressed to you. Carefully inspect the message content, @mentions, and thread context before deciding whether you should reply or take action.

--- a/src/services/codex/slack-thread-base-instructions.ts
+++ b/src/services/codex/slack-thread-base-instructions.ts
@@ -55,6 +55,17 @@ export async function buildSlackThreadBaseInstructions(
     file_path: "/absolute/path/to/file.png",
     initial_comment: "replace with your Slack file caption"
   });
+  const coauthorConfigurePayload = JSON.stringify({
+    cwd: options.workspacePath,
+    coauthors: ["Alice Example"],
+    ignore_missing: true,
+    mappings: [
+      {
+        slack_user: "Alice Example",
+        github_author: "Alice Example <alice@example.com>"
+      }
+    ]
+  });
   const linearCallPayload = JSON.stringify({
     server: "linear",
     name: "replace_with_linear_tool_name",
@@ -93,6 +104,10 @@ export async function buildSlackThreadBaseInstructions(
       `curl -sS -X POST ${options.brokerHttpBaseUrl}/slack/post-state -H 'content-type: application/json' -d '${blockStatePayload}'`,
     post_file_command:
       `curl -sS -X POST ${options.brokerHttpBaseUrl}/slack/post-file -H 'content-type: application/json' -d '${filePayload}'`,
+    coauthor_status_command:
+      `curl -sS '${options.brokerHttpBaseUrl}/slack/git-coauthors/session-status?cwd=${encodeURIComponent(options.workspacePath)}'`,
+    coauthor_configure_command:
+      `curl -sS -X POST ${options.brokerHttpBaseUrl}/slack/git-coauthors/configure-session -H 'content-type: application/json' -d '${coauthorConfigurePayload}'`,
     thread_history_command:
       `curl -sS '${options.brokerHttpBaseUrl}/slack/thread-history?channel_id=${encodeURIComponent(options.channelId)}&thread_ts=${encodeURIComponent(options.rootThreadTs)}&before_ts=older-message-ts&limit=20&format=text'`,
     register_job_command:

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -189,6 +189,7 @@ export class SessionManager {
     return await this.#patchSession(channelId, rootThreadTs, {
       coAuthorCandidateUserIds: [...(session.coAuthorCandidateUserIds ?? []), ...additions],
       coAuthorCandidateRevision: (session.coAuthorCandidateRevision ?? 0) + 1,
+      coAuthorIgnoreMissingRevision: undefined,
       coAuthorPromptRevision: undefined,
       coAuthorPromptedAt: undefined
     });
@@ -200,6 +201,7 @@ export class SessionManager {
     options: {
       readonly userIds: readonly string[];
       readonly candidateRevision: number;
+      readonly ignoreMissing?: boolean | undefined;
     }
   ): Promise<SlackSessionRecord> {
     const session = this.#requireSession(channelId, rootThreadTs);
@@ -209,7 +211,20 @@ export class SessionManager {
     return await this.#patchSession(channelId, rootThreadTs, {
       coAuthorConfirmedUserIds: confirmedUserIds,
       coAuthorConfirmedRevision: options.candidateRevision,
+      coAuthorIgnoreMissingRevision: options.ignoreMissing ? options.candidateRevision : undefined,
       coAuthorPromptRevision: options.candidateRevision,
+      coAuthorPromptedAt: undefined
+    });
+  }
+
+  async allowMissingCoAuthors(
+    channelId: string,
+    rootThreadTs: string,
+    candidateRevision: number
+  ): Promise<SlackSessionRecord> {
+    return await this.#patchSession(channelId, rootThreadTs, {
+      coAuthorIgnoreMissingRevision: candidateRevision,
+      coAuthorPromptRevision: candidateRevision,
       coAuthorPromptedAt: undefined
     });
   }

--- a/src/services/slack/slack-coauthor-service.ts
+++ b/src/services/slack/slack-coauthor-service.ts
@@ -146,26 +146,22 @@ export class SlackCoauthorService {
     }
 
     let status = await this.#buildCommitCoauthorStatus(session);
+    const requestedMappings = this.#resolveRequestedMappings(status, options.mappings);
+    const selectedUserIds = this.#resolveRequestedUserIds(status, {
+      coauthors: options.coauthors,
+      userIds: options.userIds
+    });
 
-    for (const entry of options.mappings ?? []) {
-      const slackUserId = entry.slackUserId?.trim() || this.#resolveUserReference(status, entry.slackUser);
-      if (!slackUserId) {
-        throw new Error(`Unable to resolve co-author mapping target: ${entry.slackUser ?? entry.slackUserId ?? "unknown"}`);
-      }
-
-      const slackIdentity = await this.#slackApi.getUserIdentity(slackUserId);
+    for (const entry of requestedMappings) {
+      const slackIdentity = await this.#slackApi.getUserIdentity(entry.slackUserId);
       await this.#mappings.upsertManualMapping({
-        slackUserId,
+        slackUserId: entry.slackUserId,
         githubAuthor: entry.githubAuthor,
         slackIdentity: slackIdentity ?? undefined
       });
     }
 
     status = await this.#buildCommitCoauthorStatus(session);
-    const selectedUserIds = this.#resolveRequestedUserIds(status, {
-      coauthors: options.coauthors,
-      userIds: options.userIds
-    });
 
     if (selectedUserIds !== undefined || options.ignoreMissing !== undefined) {
       session = await this.#sessions.confirmCoAuthors(session.channelId, session.rootThreadTs, {
@@ -658,6 +654,42 @@ export class SlackCoauthorService {
       missingSelectedUserIds,
       candidates
     };
+  }
+
+  #resolveRequestedMappings(
+    status: CommitCoauthorStatus,
+    mappings: ReadonlyArray<{
+      readonly slackUserId?: string | undefined;
+      readonly slackUser?: string | undefined;
+      readonly githubAuthor: string;
+    }> | undefined
+  ): Array<{
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+  }> {
+    return (mappings ?? []).map((entry) => {
+      const directUserId = entry.slackUserId?.trim();
+      if (directUserId) {
+        if (!status.candidates.some((candidate) => candidate.userId === directUserId)) {
+          throw new Error(`Unknown co-author candidate: ${entry.slackUserId}`);
+        }
+
+        return {
+          slackUserId: directUserId,
+          githubAuthor: entry.githubAuthor
+        };
+      }
+
+      const slackUserId = this.#resolveUserReference(status, entry.slackUser);
+      if (!slackUserId) {
+        throw new Error(`Unable to resolve co-author mapping target: ${entry.slackUser ?? entry.slackUserId ?? "unknown"}`);
+      }
+
+      return {
+        slackUserId,
+        githubAuthor: entry.githubAuthor
+      };
+    });
   }
 
   #resolveRequestedUserIds(

--- a/src/services/slack/slack-coauthor-service.ts
+++ b/src/services/slack/slack-coauthor-service.ts
@@ -20,6 +20,9 @@ const COAUTHOR_CONFIGURE_ACTION_ID = "coauthor_configure";
 const COAUTHOR_MODAL_CALLBACK_ID = "coauthor_confirm";
 const CONTRIBUTOR_BLOCK_ID = "contributors";
 const CONTRIBUTOR_ACTION_ID = "selected";
+const COMMIT_BEHAVIOR_BLOCK_ID = "commit_behavior";
+const COMMIT_BEHAVIOR_ACTION_ID = "selected";
+const IGNORE_MISSING_OPTION_VALUE = "ignore_missing";
 
 export interface ResolveCommitCoauthorsResult {
   readonly status: "noop" | "blocked" | "resolved";
@@ -27,6 +30,34 @@ export interface ResolveCommitCoauthorsResult {
   readonly message?: string | undefined;
   readonly errorCode?: string | undefined;
   readonly coAuthors?: readonly string[] | undefined;
+}
+
+interface CommitCoauthorCandidateStatus {
+  readonly userId: string;
+  readonly mention: string;
+  readonly username?: string | undefined;
+  readonly displayName?: string | undefined;
+  readonly realName?: string | undefined;
+  readonly email?: string | undefined;
+  readonly githubAuthor?: string | undefined;
+  readonly githubAuthorSource?: "manual" | "slack_inferred" | undefined;
+  readonly selected: boolean;
+}
+
+interface CommitCoauthorStatus {
+  readonly sessionKey: string;
+  readonly channelId: string;
+  readonly rootThreadTs: string;
+  readonly workspacePath: string;
+  readonly candidateRevision?: number | undefined;
+  readonly selectionMode: "default_all_candidates" | "explicit";
+  readonly ignoreMissing: boolean;
+  readonly needsUserInput: boolean;
+  readonly canCommitDirectly: boolean;
+  readonly selectedUserIds: readonly string[];
+  readonly resolvedCoAuthors: readonly string[];
+  readonly missingSelectedUserIds: readonly string[];
+  readonly candidates: readonly CommitCoauthorCandidateStatus[];
 }
 
 export class SlackCoauthorService {
@@ -87,6 +118,67 @@ export class SlackCoauthorService {
     await this.#mappings.deleteMapping(slackUserId);
   }
 
+  async getCommitCoauthorStatus(cwd: string): Promise<CommitCoauthorStatus | null> {
+    await this.#mappings.load();
+    const session = this.#sessions.findSessionByWorkspace(cwd);
+    if (!session) {
+      return null;
+    }
+
+    return await this.#buildCommitCoauthorStatus(session);
+  }
+
+  async configureSessionCoauthors(options: {
+    readonly cwd: string;
+    readonly coauthors?: readonly string[] | undefined;
+    readonly userIds?: readonly string[] | undefined;
+    readonly ignoreMissing?: boolean | undefined;
+    readonly mappings?: ReadonlyArray<{
+      readonly slackUserId?: string | undefined;
+      readonly slackUser?: string | undefined;
+      readonly githubAuthor: string;
+    }> | undefined;
+  }): Promise<CommitCoauthorStatus | null> {
+    await this.#mappings.load();
+    let session = this.#sessions.findSessionByWorkspace(options.cwd);
+    if (!session) {
+      return null;
+    }
+
+    let status = await this.#buildCommitCoauthorStatus(session);
+
+    for (const entry of options.mappings ?? []) {
+      const slackUserId = entry.slackUserId?.trim() || this.#resolveUserReference(status, entry.slackUser);
+      if (!slackUserId) {
+        throw new Error(`Unable to resolve co-author mapping target: ${entry.slackUser ?? entry.slackUserId ?? "unknown"}`);
+      }
+
+      const slackIdentity = await this.#slackApi.getUserIdentity(slackUserId);
+      await this.#mappings.upsertManualMapping({
+        slackUserId,
+        githubAuthor: entry.githubAuthor,
+        slackIdentity: slackIdentity ?? undefined
+      });
+    }
+
+    status = await this.#buildCommitCoauthorStatus(session);
+    const selectedUserIds = this.#resolveRequestedUserIds(status, {
+      coauthors: options.coauthors,
+      userIds: options.userIds
+    });
+
+    if (selectedUserIds !== undefined || options.ignoreMissing !== undefined) {
+      session = await this.#sessions.confirmCoAuthors(session.channelId, session.rootThreadTs, {
+        userIds: selectedUserIds ?? status.selectedUserIds,
+        candidateRevision: session.coAuthorCandidateRevision ?? 0,
+        ignoreMissing: options.ignoreMissing ?? status.ignoreMissing
+      });
+      status = await this.#buildCommitCoauthorStatus(session);
+    }
+
+    return status;
+  }
+
   async handleInteractivePayload(payload: Record<string, unknown>): Promise<void> {
     const type = typeof payload.type === "string" ? payload.type : undefined;
     if (type === "block_actions") {
@@ -114,52 +206,19 @@ export class SlackCoauthorService {
       };
     }
 
-    const candidateUserIds = session.coAuthorCandidateUserIds ?? [];
-    if (candidateUserIds.length === 0) {
+    const status = await this.#buildCommitCoauthorStatus(session);
+    if (status.selectedUserIds.length === 0) {
       return {
         status: "noop",
         sessionKey: session.key
       };
     }
 
-    if (session.coAuthorConfirmedRevision !== session.coAuthorCandidateRevision) {
-      await this.#ensurePrompt(session);
-      return {
-        status: "blocked",
-        sessionKey: session.key,
-        errorCode: "coauthor_confirmation_required",
-        message: "Commit blocked by Slack co-author gate. Open the Slack thread and confirm co-authors, then retry the commit."
-      };
+    if (status.needsUserInput) {
+      await this.#ensurePrompt(session, status);
     }
 
-    const confirmedUserIds = session.coAuthorConfirmedUserIds ?? [];
-    const mappings = await Promise.all(
-      confirmedUserIds.map(async (userId) => {
-        let mapping = this.#mappings.getMapping(userId);
-        if (!mapping) {
-          const identity = await this.#slackApi.getUserIdentity(userId);
-          if (identity) {
-            mapping = await this.#mappings.recordObservedIdentity(identity) ?? undefined;
-          }
-        }
-        return mapping ?? null;
-      })
-    );
-
-    const missingUserIds = confirmedUserIds.filter((userId, index) => !mappings[index]);
-    if (missingUserIds.length > 0) {
-      await this.#ensurePrompt(session);
-      return {
-        status: "blocked",
-        sessionKey: session.key,
-        errorCode: "coauthor_mapping_required",
-        message: "Commit blocked by Slack co-author gate. At least one confirmed Slack contributor is still missing a GitHub author mapping."
-      };
-    }
-
-    const coAuthors = mappings
-      .filter((mapping): mapping is GitHubAuthorMappingRecord => mapping !== null)
-      .map((mapping) => mapping.githubAuthor);
+    const coAuthors = status.resolvedCoAuthors;
     const commitMessage = appendCoAuthorTrailers(options.commitMessage, {
       coAuthors,
       primaryAuthorEmail: options.primaryAuthorEmail
@@ -169,7 +228,11 @@ export class SlackCoauthorService {
       return {
         status: "noop",
         sessionKey: session.key,
-        coAuthors
+        coAuthors,
+        message:
+          status.missingSelectedUserIds.length > 0
+            ? "Some selected co-authors are still missing GitHub author info and were skipped for this commit."
+            : undefined
       };
     }
 
@@ -177,7 +240,11 @@ export class SlackCoauthorService {
       status: "resolved",
       sessionKey: session.key,
       coAuthors,
-      commitMessage
+      commitMessage,
+      message:
+        status.missingSelectedUserIds.length > 0
+          ? "Known co-authors were appended. Unresolved co-authors were skipped for this commit."
+          : undefined
     };
   }
 
@@ -231,12 +298,21 @@ export class SlackCoauthorService {
 
     const values = view?.state?.values ?? {};
     const selectedUserIds = readSelectedContributorUserIds(values);
+    const ignoreMissing = readIgnoreMissingSelection(values);
     const invalidUserIds: string[] = [];
 
     await this.#mappings.load();
     for (const userId of selectedUserIds) {
       const githubAuthor = readGitHubAuthorInput(values, userId);
-      if (!githubAuthor || !isValidGitHubAuthor(githubAuthor)) {
+      if (!githubAuthor) {
+        if (ignoreMissing) {
+          continue;
+        }
+        invalidUserIds.push(userId);
+        continue;
+      }
+
+      if (!isValidGitHubAuthor(githubAuthor)) {
         invalidUserIds.push(userId);
         continue;
       }
@@ -266,12 +342,19 @@ export class SlackCoauthorService {
 
     await this.#sessions.confirmCoAuthors(session.channelId, session.rootThreadTs, {
       userIds: selectedUserIds,
-      candidateRevision: metadata.candidateRevision
+      candidateRevision: metadata.candidateRevision,
+      ignoreMissing
     });
-    await this.#postSubmitResult(userId, session.key, "Co-author mapping saved. The next commit retry can continue.");
+    await this.#postSubmitResult(
+      userId,
+      session.key,
+      ignoreMissing
+        ? "Co-author settings saved. Commits can continue and any unresolved co-authors will be skipped."
+        : "Co-author mapping saved. The next commit retry can continue."
+    );
   }
 
-  async #ensurePrompt(session: SlackSessionRecord): Promise<void> {
+  async #ensurePrompt(session: SlackSessionRecord, status?: CommitCoauthorStatus): Promise<void> {
     const candidateRevision = session.coAuthorCandidateRevision;
     if (!candidateRevision || (session.coAuthorCandidateUserIds ?? []).length === 0) {
       return;
@@ -286,12 +369,21 @@ export class SlackCoauthorService {
       return;
     }
 
+    const currentStatus = status ?? await this.#buildCommitCoauthorStatus(session);
+    const missingNames = currentStatus.missingSelectedUserIds
+      .map((userId) => currentStatus.candidates.find((candidate) => candidate.userId === userId))
+      .filter((candidate): candidate is CommitCoauthorCandidateStatus => candidate !== undefined)
+      .map((candidate) => describeSlackUser(candidate, candidate.userId));
+
     const blocks = [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: "*Git commit paused:* this Slack session needs co-author confirmation before the commit can go through."
+          text:
+            missingNames.length > 0
+              ? `*Co-author info is incomplete:* commits can continue, but these co-authors are currently unresolved and will be skipped: ${missingNames.join(", ")}.`
+              : "*Co-author review available:* known Slack identities will be appended automatically for this session's commits."
         }
       },
       {
@@ -320,7 +412,7 @@ export class SlackCoauthorService {
           channelId: session.channelId,
           threadTs: session.rootThreadTs,
           userId,
-          text: "This commit is waiting on Slack co-author confirmation.",
+          text: "Review Slack co-author settings for this session.",
           blocks
         });
         delivered = true;
@@ -385,7 +477,7 @@ export class SlackCoauthorService {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: "Choose which Slack participants should be written as GitHub co-authors for commits from this session."
+            text: "Choose which Slack participants should be written as GitHub co-authors for commits from this session. Known identities are used automatically; unresolved selections can be ignored if you want commits to continue without them."
           }
         },
         {
@@ -400,6 +492,40 @@ export class SlackCoauthorService {
             action_id: CONTRIBUTOR_ACTION_ID,
             options: contributorOptions,
             initial_options: contributorOptions.filter((entry) => selectedUserIds.includes(String(entry.value)))
+          }
+        },
+        {
+          type: "input",
+          block_id: COMMIT_BEHAVIOR_BLOCK_ID,
+          optional: true,
+          label: {
+            type: "plain_text",
+            text: "Commit behavior"
+          },
+          element: {
+            type: "checkboxes",
+            action_id: COMMIT_BEHAVIOR_ACTION_ID,
+            options: [
+              {
+                text: {
+                  type: "plain_text",
+                  text: "Allow commits to continue without unresolved co-authors"
+                },
+                value: IGNORE_MISSING_OPTION_VALUE
+              }
+            ],
+            initial_options:
+              session.coAuthorIgnoreMissingRevision === session.coAuthorCandidateRevision
+                ? [
+                    {
+                      text: {
+                        type: "plain_text",
+                        text: "Allow commits to continue without unresolved co-authors"
+                      },
+                      value: IGNORE_MISSING_OPTION_VALUE
+                    }
+                  ]
+                : []
           }
         },
         ...candidateUserIds.map((userId, index) => {
@@ -481,6 +607,119 @@ export class SlackCoauthorService {
       });
     });
   }
+
+  async #buildCommitCoauthorStatus(session: SlackSessionRecord): Promise<CommitCoauthorStatus> {
+    const candidateUserIds = session.coAuthorCandidateUserIds ?? [];
+    const explicitSelection = session.coAuthorConfirmedRevision === session.coAuthorCandidateRevision;
+    const selectedUserIds = explicitSelection
+      ? (session.coAuthorConfirmedUserIds ?? [])
+      : candidateUserIds;
+    const ignoreMissing = session.coAuthorIgnoreMissingRevision === session.coAuthorCandidateRevision;
+    const candidates = await Promise.all(candidateUserIds.map(async (userId) => {
+      const identity = await this.#slackApi.getUserIdentity(userId);
+      let mapping = this.#mappings.getMapping(userId);
+      if (!mapping && identity) {
+        mapping = await this.#mappings.recordObservedIdentity(identity) ?? undefined;
+      }
+
+      return {
+        userId,
+        mention: identity?.mention ?? `<@${userId}>`,
+        username: identity?.username,
+        displayName: identity?.displayName,
+        realName: identity?.realName,
+        email: identity?.email,
+        githubAuthor: mapping?.githubAuthor,
+        githubAuthorSource: mapping?.source,
+        selected: selectedUserIds.includes(userId)
+      } satisfies CommitCoauthorCandidateStatus;
+    }));
+
+    const selectedCandidates = candidates.filter((candidate) => candidate.selected);
+    const missingSelectedUserIds = selectedCandidates
+      .filter((candidate) => !candidate.githubAuthor)
+      .map((candidate) => candidate.userId);
+    const resolvedCoAuthors = selectedCandidates
+      .map((candidate) => candidate.githubAuthor)
+      .filter((value): value is string => Boolean(value));
+
+    return {
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      workspacePath: session.workspacePath,
+      candidateRevision: session.coAuthorCandidateRevision,
+      selectionMode: explicitSelection ? "explicit" : "default_all_candidates",
+      ignoreMissing,
+      needsUserInput: missingSelectedUserIds.length > 0 && !ignoreMissing,
+      canCommitDirectly: missingSelectedUserIds.length === 0,
+      selectedUserIds,
+      resolvedCoAuthors,
+      missingSelectedUserIds,
+      candidates
+    };
+  }
+
+  #resolveRequestedUserIds(
+    status: CommitCoauthorStatus,
+    options: {
+      readonly coauthors?: readonly string[] | undefined;
+      readonly userIds?: readonly string[] | undefined;
+    }
+  ): string[] | undefined {
+    const resolved = new Set<string>();
+
+    for (const userId of options.userIds ?? []) {
+      const trimmed = userId.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      if (!status.candidates.some((candidate) => candidate.userId === trimmed)) {
+        throw new Error(`Unknown co-author candidate: ${userId}`);
+      }
+      resolved.add(trimmed);
+    }
+
+    for (const reference of options.coauthors ?? []) {
+      const userId = this.#resolveUserReference(status, reference);
+      if (!userId) {
+        throw new Error(`Unable to resolve co-author candidate: ${reference}`);
+      }
+      resolved.add(userId);
+    }
+
+    if ((options.userIds?.length ?? 0) === 0 && (options.coauthors?.length ?? 0) === 0) {
+      return undefined;
+    }
+
+    return [...resolved];
+  }
+
+  #resolveUserReference(status: CommitCoauthorStatus, reference: string | undefined): string | undefined {
+    const normalized = normalizeUserReference(reference);
+    if (!normalized) {
+      return undefined;
+    }
+
+    const matches = status.candidates.filter((candidate) => {
+      const fields = [
+        candidate.userId,
+        candidate.mention,
+        candidate.username,
+        candidate.displayName,
+        candidate.realName,
+        candidate.email
+      ];
+      return fields.some((value) => normalizeUserReference(value) === normalized);
+    });
+
+    if (matches.length > 1) {
+      throw new Error(`Ambiguous co-author reference: ${reference}`);
+    }
+
+    return matches[0]?.userId;
+  }
 }
 
 function readString(value: unknown): string | undefined {
@@ -523,6 +762,19 @@ function readSelectedContributorUserIds(
   return selectedOptions
     .map((entry) => readString((entry as { value?: string } | undefined)?.value))
     .filter((value): value is string => Boolean(value));
+}
+
+function readIgnoreMissingSelection(
+  values: Record<string, Record<string, Record<string, unknown>>>
+): boolean {
+  const selectedOptions = values[COMMIT_BEHAVIOR_BLOCK_ID]?.[COMMIT_BEHAVIOR_ACTION_ID]?.selected_options;
+  if (!Array.isArray(selectedOptions)) {
+    return false;
+  }
+
+  return selectedOptions.some((entry) => {
+    return readString((entry as { value?: string } | undefined)?.value) === IGNORE_MISSING_OPTION_VALUE;
+  });
 }
 
 function readGitHubAuthorInput(
@@ -568,4 +820,9 @@ function buildGitHubAuthorHint(
   }
 
   return "If checked, enter a GitHub author in the form Name <email@example.com>.";
+}
+
+function normalizeUserReference(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
 }

--- a/src/services/slack/slack-codex-bridge.ts
+++ b/src/services/slack/slack-codex-bridge.ts
@@ -188,6 +188,24 @@ export class SlackCodexBridge {
     await this.#coauthors.deleteMapping(slackUserId);
   }
 
+  async getCommitCoauthorStatus(cwd: string) {
+    return await this.#coauthors.getCommitCoauthorStatus(cwd);
+  }
+
+  async configureSessionCoauthors(options: {
+    readonly cwd: string;
+    readonly coauthors?: readonly string[] | undefined;
+    readonly userIds?: readonly string[] | undefined;
+    readonly ignoreMissing?: boolean | undefined;
+    readonly mappings?: ReadonlyArray<{
+      readonly slackUserId?: string | undefined;
+      readonly slackUser?: string | undefined;
+      readonly githubAuthor: string;
+    }> | undefined;
+  }) {
+    return await this.#coauthors.configureSessionCoauthors(options);
+  }
+
   async resolveCommitCoauthors(options: {
     readonly cwd: string;
     readonly commitMessage: string;

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -421,6 +421,7 @@ export class StateStore {
       coAuthorCandidateRevision: normalizeFiniteNumber(session.coAuthorCandidateRevision),
       coAuthorConfirmedUserIds: normalizeStringArray(session.coAuthorConfirmedUserIds),
       coAuthorConfirmedRevision: normalizeFiniteNumber(session.coAuthorConfirmedRevision),
+      coAuthorIgnoreMissingRevision: normalizeFiniteNumber(session.coAuthorIgnoreMissingRevision),
       coAuthorPromptRevision: normalizeFiniteNumber(session.coAuthorPromptRevision),
       coAuthorPromptedAt:
         typeof session.coAuthorPromptedAt === "string" ? session.coAuthorPromptedAt : undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface SlackSessionRecord {
   readonly coAuthorCandidateRevision?: number | undefined;
   readonly coAuthorConfirmedUserIds?: readonly string[] | undefined;
   readonly coAuthorConfirmedRevision?: number | undefined;
+  readonly coAuthorIgnoreMissingRevision?: number | undefined;
   readonly coAuthorPromptRevision?: number | undefined;
   readonly coAuthorPromptedAt?: string | undefined;
 }

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -199,18 +199,21 @@ describe("SessionManager", () => {
 
     session = await manager.confirmCoAuthors("C123", "999.000", {
       userIds: ["U1"],
-      candidateRevision: 1
+      candidateRevision: 1,
+      ignoreMissing: true
     });
     expect(session).toMatchObject({
       coAuthorConfirmedUserIds: ["U1"],
-      coAuthorConfirmedRevision: 1
+      coAuthorConfirmedRevision: 1,
+      coAuthorIgnoreMissingRevision: 1
     });
 
     session = await manager.addCoAuthorCandidates("C123", "999.000", ["U2"]);
     expect(session).toMatchObject({
       coAuthorCandidateUserIds: ["U1", "U2"],
       coAuthorCandidateRevision: 2,
-      coAuthorConfirmedRevision: 1
+      coAuthorConfirmedRevision: 1,
+      coAuthorIgnoreMissingRevision: undefined
     });
 
     const reloadedStore = new StateStore(stateDir, sessionsRoot);
@@ -223,7 +226,8 @@ describe("SessionManager", () => {
       coAuthorCandidateUserIds: ["U1", "U2"],
       coAuthorCandidateRevision: 2,
       coAuthorConfirmedUserIds: ["U1"],
-      coAuthorConfirmedRevision: 1
+      coAuthorConfirmedRevision: 1,
+      coAuthorIgnoreMissingRevision: undefined
     });
   });
 });

--- a/test/slack-coauthor-service.test.ts
+++ b/test/slack-coauthor-service.test.ts
@@ -389,4 +389,69 @@ describe("SlackCoauthorService", () => {
     expect(resolved.status).toBe("noop");
     expect(resolved.message).toContain("skipped for this commit");
   });
+
+  it("validates configure-session mapping targets before writing any mappings", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
+    tempDirs.push(stateDir, sessionsRoot);
+
+    const sessions = new SessionManager({
+      stateStore: new StateStore(stateDir, sessionsRoot),
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C777", "222.333");
+    const mappings = new GitHubAuthorMappingService({ stateDir });
+    await mappings.load();
+
+    const service = new SlackCoauthorService({
+      sessions,
+      mappings,
+      slackApi: {
+        getUserIdentity: vi.fn(async (userId: string) => ({
+          userId,
+          mention: `<@${userId}>`,
+          realName: userId === "U1" ? "Alice Example" : "Bob Example"
+        })),
+        postEphemeral: vi.fn(),
+        openView: vi.fn()
+      } as never
+    });
+
+    await service.noteIncomingSlackInput(session, {
+      source: "thread_reply",
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "222.334",
+      userId: "U1",
+      senderKind: "user",
+      text: "first contributor"
+    });
+    await service.noteIncomingSlackInput(session, {
+      source: "thread_reply",
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "222.335",
+      userId: "U2",
+      senderKind: "user",
+      text: "second contributor"
+    });
+
+    await expect(service.configureSessionCoauthors({
+      cwd: session.workspacePath,
+      mappings: [
+        {
+          slackUser: "Alice Example",
+          githubAuthor: "Alice Example <alice@example.com>"
+        },
+        {
+          slackUser: "Unknown Person",
+          githubAuthor: "Unknown Person <unknown@example.com>"
+        }
+      ]
+    })).rejects.toThrow("Unable to resolve co-author mapping target: Unknown Person");
+
+    expect(mappings.getMapping("U1")).toBeUndefined();
+    expect(mappings.getMapping("U2")).toBeUndefined();
+  });
 });

--- a/test/slack-coauthor-service.test.ts
+++ b/test/slack-coauthor-service.test.ts
@@ -20,7 +20,7 @@ describe("SlackCoauthorService", () => {
     })));
   });
 
-  it("prompts once per candidate revision when commit confirmation is still missing", async () => {
+  it("prompts once per candidate revision when selected co-authors are still unresolved, without blocking commits", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
     const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
     tempDirs.push(stateDir, sessionsRoot);
@@ -40,8 +40,7 @@ describe("SlackCoauthorService", () => {
         getUserIdentity: vi.fn(async () => ({
           userId: "U123",
           mention: "<@U123>",
-          realName: "Alice Example",
-          email: "alice@example.com"
+          realName: "Alice Example"
         })),
         postEphemeral,
         openView: vi.fn()
@@ -62,20 +61,16 @@ describe("SlackCoauthorService", () => {
       cwd: session.workspacePath,
       commitMessage: "feat(test): demo"
     });
-    expect(first).toMatchObject({
-      status: "blocked",
-      errorCode: "coauthor_confirmation_required"
-    });
+    expect(first.status).toBe("noop");
+    expect(first.message).toContain("missing GitHub author info");
     expect(postEphemeral).toHaveBeenCalledTimes(1);
 
     const second = await service.resolveCommitCoauthors({
       cwd: session.workspacePath,
       commitMessage: "feat(test): demo"
     });
-    expect(second).toMatchObject({
-      status: "blocked",
-      errorCode: "coauthor_confirmation_required"
-    });
+    expect(second.status).toBe("noop");
+    expect(second.message).toContain("missing GitHub author info");
     expect(postEphemeral).toHaveBeenCalledTimes(1);
   });
 
@@ -312,5 +307,86 @@ describe("SlackCoauthorService", () => {
         text: "These selected co-authors need a valid GitHub author in `Name <email>` format: Kewei Hua. If Slack cannot infer an email for someone, enter it manually."
       })
     );
+  });
+
+  it("allows unresolved co-authors to be ignored when explicitly authorized", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
+    tempDirs.push(stateDir, sessionsRoot);
+
+    const sessions = new SessionManager({
+      stateStore: new StateStore(stateDir, sessionsRoot),
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C888", "444.555");
+    const mappings = new GitHubAuthorMappingService({ stateDir });
+    await mappings.load();
+
+    const postEphemeral = vi.fn(async () => "111.666");
+    const service = new SlackCoauthorService({
+      sessions,
+      mappings,
+      slackApi: {
+        getUserIdentity: vi.fn(async () => ({
+          userId: "U1",
+          mention: "<@U1>",
+          realName: "Alice Example"
+        })),
+        postEphemeral,
+        openView: vi.fn(async () => {})
+      } as never
+    });
+
+    const latestSession = await service.noteIncomingSlackInput(session, {
+      source: "thread_reply",
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "444.556",
+      userId: "U1",
+      senderKind: "user",
+      text: "please commit this"
+    });
+
+    await service.handleInteractivePayload({
+      type: "view_submission",
+      user: { id: "U1" },
+      view: {
+        private_metadata: JSON.stringify({
+          session_key: latestSession.key,
+          candidate_revision: latestSession.coAuthorCandidateRevision
+        }),
+        state: {
+          values: {
+            contributors: {
+              selected: {
+                selected_options: [
+                  { value: "U1" }
+                ]
+              }
+            },
+            commit_behavior: {
+              selected: {
+                selected_options: [
+                  { value: "ignore_missing" }
+                ]
+              }
+            },
+            author__U1: {
+              value: {
+                value: ""
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const resolved = await service.resolveCommitCoauthors({
+      cwd: latestSession.workspacePath,
+      commitMessage: "feat(slack): ignore unresolved"
+    });
+    expect(resolved.status).toBe("noop");
+    expect(resolved.message).toContain("skipped for this commit");
   });
 });

--- a/test/slack-routes.test.ts
+++ b/test/slack-routes.test.ts
@@ -1,0 +1,96 @@
+import { PassThrough, Writable } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { handleSlackRequest } from "../src/http/slack-routes.js";
+
+function createJsonRequest(body: unknown) {
+  const request = new PassThrough() as PassThrough & {
+    headers: Record<string, string>;
+  };
+  request.headers = {
+    "content-type": "application/json"
+  };
+  request.end(JSON.stringify(body));
+  return request;
+}
+
+function createResponse() {
+  const chunks: Buffer[] = [];
+
+  const response = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      callback();
+    }
+  }) as Writable & {
+    statusCode: number;
+    writeHead: (code: number) => typeof response;
+    end: (chunk?: string | Uint8Array) => typeof response;
+    bodyText?: string;
+  };
+
+  response.statusCode = 200;
+  response.writeHead = (code) => {
+    response.statusCode = code;
+    return response;
+  };
+  response.end = (chunk) => {
+    if (chunk) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk));
+    }
+    response.bodyText = Buffer.concat(chunks).toString("utf8");
+    return response;
+  };
+
+  return response;
+}
+
+describe("handleSlackRequest", () => {
+  it("treats blank co-author arrays as omitted in configure-session", async () => {
+    const configureSessionCoauthors = vi.fn(async () => ({
+      sessionKey: "session-key",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      workspacePath: "/tmp/workspace",
+      selectionMode: "default_all_candidates",
+      ignoreMissing: false,
+      needsUserInput: false,
+      canCommitDirectly: true,
+      selectedUserIds: [],
+      resolvedCoAuthors: [],
+      missingSelectedUserIds: [],
+      candidates: []
+    }));
+
+    const request = createJsonRequest({
+      cwd: "/tmp/workspace",
+      coauthors: ["   "],
+      user_ids: [""]
+    });
+    const response = createResponse();
+
+    const handled = await handleSlackRequest(
+      "POST",
+      new URL("http://localhost/slack/git-coauthors/configure-session"),
+      request as never,
+      response as never,
+      {
+        bridge: {
+          configureSessionCoauthors
+        } as never,
+        config: {} as never
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(configureSessionCoauthors).toHaveBeenCalledWith({
+      cwd: "/tmp/workspace",
+      coauthors: undefined,
+      userIds: undefined,
+      ignoreMissing: undefined,
+      mappings: undefined
+    });
+    expect(response.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- make commit-time co-author resolution non-blocking and skip unresolved co-authors instead of hard-failing
- add broker endpoints/bridge methods so agents can inspect and configure session co-authors directly, including natural-language participant references
- update session/prompt behavior so known identities commit directly, missing identities prompt proactively, and explicit ignore-missing authorization is supported

## Validation
- `pnpm exec vitest run test/slack-coauthor-service.test.ts test/session-manager.test.ts test/git-coauthor-helper.test.ts test/app-server-client.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- manual validation with `pnpm exec tsx` scripts covering:
  - known mapped co-authors commit directly without registration
  - unresolved co-authors no longer block commit and are skipped
  - explicit ignore-missing session config continues commit while skipping unresolved co-authors
