### PR TITLE
Switch default UI prompt guidance to Kimi

### DIFF
--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -40,13 +40,12 @@ Isolated Linear/Notion access for this session:
 - If the isolated integration call fails, tell Slack that the specific integration is unavailable right now. Do not assume the whole runtime is broken.
 
 UI/frontend/layout/styling contract:
-- For any substantial UI work, frontend layout work, visual refactor, CSS/styling pass, dashboard/admin-page reorganization, component structure rewrite, or design-heavy interaction change, consult Gemini first by default.
-- Use the broker Gemini helper before editing UI files: node "$BROKER_GEMINI_UI_HELPER" --cwd /absolute/project/path --include-directory /absolute/project/path --prompt "describe the UI task, the target files, the constraints, and ask Gemini for a concrete redesign or code-oriented implementation plan"
-- The helper should use gemini-3-pro-preview for UI work in this runtime.
-- Treat Gemini as the primary UI designer for those tasks unless the user explicitly asks you to design or style the UI yourself without Gemini, or Gemini is unavailable.
+- For any substantial UI work, frontend layout work, visual refactor, CSS/styling pass, dashboard/admin-page reorganization, component structure rewrite, or design-heavy interaction change, consult Kimi first by default.
+- Use the globally installed Kimi CLI before editing UI files: kimi --work-dir /absolute/project/path --add-dir /absolute/project/path --print --prompt "describe the UI task, the target files, the constraints, and ask Kimi for a concrete redesign or code-oriented implementation plan"
+- Treat Kimi as the primary UI designer for those tasks unless the user explicitly asks you to design or style the UI yourself without Kimi, or Kimi is unavailable.
 - Keep APIs, data contracts, and non-UI behavior unchanged unless the user explicitly asks for them to change.
-- If the user explicitly asks you to do the UI work directly yourself, you may proceed without Gemini.
-- If the Gemini helper is unavailable, the Gemini CLI is not authenticated, or Gemini fails, clearly tell Slack that Gemini is unavailable right now and then continue the UI work yourself.
+- If the user explicitly asks you to do the UI work directly yourself, you may proceed without Kimi.
+- If the Kimi CLI is unavailable, not authenticated, or Kimi fails, clearly tell Slack that Kimi is unavailable right now and then continue the UI work yourself.
 
 Slack UX preference: do not stay silent for a long stretch if there is a meaningful progress point worth sharing. Use judgment. If you have a concrete update, short plan adjustment, blocker, or partial conclusion that would help the people in the thread, send a brief Slack update. If there is nothing meaningful to say yet, keep working and avoid filler. Do not turn routine polling or watcher noise into Slack chatter.
 

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -138,6 +138,7 @@ export class SlackConversationService {
 
   async start(): Promise<void> {
     await this.#reconcilePersistedActiveTurns();
+    await this.recoverMissedThreadMessages("socket_ready");
     await this.#recoverPendingSessionsOnBoot();
     await this.#recoverPendingSyntheticMessages();
     this.#startActiveTurnReconciler();
@@ -588,7 +589,10 @@ export class SlackConversationService {
     let retainedCount = 0;
 
     for (const session of sessions) {
-      const outcome = await this.#reconcileSingleActiveTurn(session);
+      const outcome = await this.#reconcileSingleActiveTurn(session, {
+        treatMissingAsStale: true,
+        resumePending: false
+      });
       if (outcome === "retained") {
         retainedCount += 1;
       } else {
@@ -646,14 +650,22 @@ export class SlackConversationService {
     }
   }
 
-  async #reconcileSingleActiveTurn(session: SlackSessionRecord): Promise<"cleared" | "retained"> {
-    const outcome = await this.#turnReconciler.reconcileSingleActiveTurn(session);
+  async #reconcileSingleActiveTurn(
+    session: SlackSessionRecord,
+    options?: {
+      readonly treatMissingAsStale?: boolean | undefined;
+      readonly resumePending?: boolean | undefined;
+    }
+  ): Promise<"cleared" | "retained"> {
+    const outcome = await this.#turnReconciler.reconcileSingleActiveTurn(session, options);
 
     if (outcome === "cleared") {
       this.#resetRuntimeProcessing(session.key);
       const latestSession = this.#findSessionByKey(session.key);
       this.#clearAssistantStatus(latestSession.channelId, latestSession.rootThreadTs);
-      await this.#resumePendingDispatch(session.key);
+      if (options?.resumePending ?? true) {
+        await this.#resumePendingDispatch(session.key);
+      }
     }
 
     return outcome;
@@ -1335,13 +1347,26 @@ export class SlackConversationService {
     let orphanedInflightResetCount = 0;
 
     for (const session of sessions) {
-      const reconciled = await this.#inboundStore.reconcileOrphanedInflightMessages(session);
+      const latestSession = this.#findSessionByKey(session.key);
+      if (latestSession.activeTurnId) {
+        continue;
+      }
+
+      const reconciled = await this.#inboundStore.reconcileOrphanedInflightMessages(latestSession);
       orphanedInflightDoneCount += reconciled.markedDoneCount;
       orphanedInflightResetCount += reconciled.resetToPendingCount;
 
-      const resumedCount = await this.#resumePendingDispatch(session.key, {
-        forceReset: true
-      });
+      const runtime = this.#getRuntimeSession(session.key);
+      if (runtime.processing || runtime.queue.some((entry) => entry.kind === "dispatch_pending")) {
+        continue;
+      }
+
+      const refreshedSession = this.#findSessionByKey(session.key);
+      if (refreshedSession.activeTurnId) {
+        continue;
+      }
+
+      const resumedCount = await this.#resumePendingDispatch(refreshedSession.key);
 
       if (resumedCount === 0) {
         continue;

--- a/src/services/slack/slack-turn-reconciler.ts
+++ b/src/services/slack/slack-turn-reconciler.ts
@@ -20,7 +20,10 @@ export class SlackTurnReconciler {
   }
 
   async reconcileSingleActiveTurn(
-    session: SlackSessionRecord
+    session: SlackSessionRecord,
+    options?: {
+      readonly treatMissingAsStale?: boolean | undefined;
+    }
   ): Promise<"cleared" | "retained"> {
     if (!session.codexThreadId || !session.activeTurnId) {
       await this.#sessions.setActiveTurnId(session.channelId, session.rootThreadTs, undefined);
@@ -31,10 +34,25 @@ export class SlackTurnReconciler {
     const activeTurnId = hydratedSession.activeTurnId!;
     const snapshot = await this.#turnRunner.readTurnSnapshot(hydratedSession, activeTurnId, {
       syncActiveTurn: true,
-      treatMissingAsStale: false
+      treatMissingAsStale: options?.treatMissingAsStale ?? false
     });
 
     if (!snapshot) {
+      if (options?.treatMissingAsStale) {
+        logger.info("Active Codex turn missing from thread snapshot during stale-turn reconciliation", {
+          sessionKey: session.key,
+          turnId: activeTurnId,
+          reason: "turn_missing_from_snapshot"
+        });
+        await this.#inboundStore.resetTurnBatchToPending(hydratedSession, activeTurnId);
+        await this.#sessions.setActiveTurnId(
+          hydratedSession.channelId,
+          hydratedSession.rootThreadTs,
+          undefined
+        );
+        return "cleared";
+      }
+
       logger.debug("Active Codex turn not present in thread snapshot yet; retaining turn", {
         sessionKey: session.key,
         turnId: activeTurnId,

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -788,10 +788,10 @@ describe("AppServerClient disconnect handling", () => {
       expect.stringContaining("UI/frontend/layout/styling contract")
     );
     expect(threadStartParams?.baseInstructions).toEqual(
-      expect.stringContaining("BROKER_GEMINI_UI_HELPER")
+      expect.stringContaining("kimi --work-dir /absolute/project/path")
     );
     expect(threadStartParams?.baseInstructions).toEqual(
-      expect.stringContaining("consult Gemini first by default")
+      expect.stringContaining("consult Kimi first by default")
     );
     expect(threadStartParams?.baseInstructions).toEqual(
       expect.stringContaining("Keep APIs, data contracts, and non-UI behavior unchanged")
@@ -800,7 +800,7 @@ describe("AppServerClient disconnect handling", () => {
       expect.stringContaining("user explicitly asks you to do the UI work directly yourself")
     );
     expect(threadStartParams?.baseInstructions).toEqual(
-      expect.stringContaining("Gemini is unavailable right now and then continue the UI work yourself")
+      expect.stringContaining("Kimi is unavailable right now and then continue the UI work yourself")
     );
     expect(threadStartParams?.baseInstructions).toEqual(
       expect.stringContaining("\"server\":\"linear\"")

--- a/test/slack-turn-reconciler.test.ts
+++ b/test/slack-turn-reconciler.test.ts
@@ -43,4 +43,45 @@ describe("SlackTurnReconciler", () => {
     expect(resetTurnBatchToPending).not.toHaveBeenCalled();
     expect(setActiveTurnId).not.toHaveBeenCalled();
   });
+
+  it("clears an active turn when startup reconciliation treats a missing snapshot turn as stale", async () => {
+    const session: SlackSessionRecord = {
+      key: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      workspacePath: "/tmp/workspace",
+      codexThreadId: "thread-1",
+      activeTurnId: "turn-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+
+    const setActiveTurnId = vi.fn(async () => session);
+    const resetTurnBatchToPending = vi.fn();
+    const readTurnSnapshot = vi.fn(async () => null);
+    const ensureCodexThread = vi.fn(async () => session);
+
+    const reconciler = new SlackTurnReconciler({
+      sessions: {
+        setActiveTurnId
+      } as never,
+      inboundStore: {
+        resetTurnBatchToPending
+      } as never,
+      turnRunner: {
+        ensureCodexThread,
+        readTurnSnapshot
+      } as never
+    });
+
+    await expect(reconciler.reconcileSingleActiveTurn(session, {
+      treatMissingAsStale: true
+    })).resolves.toBe("cleared");
+    expect(readTurnSnapshot).toHaveBeenCalledWith(session, "turn-1", {
+      syncActiveTurn: true,
+      treatMissingAsStale: true
+    });
+    expect(resetTurnBatchToPending).toHaveBeenCalledWith(session, "turn-1");
+    expect(setActiveTurnId).toHaveBeenCalledWith("C123", "111.222", undefined);
+  });
 });


### PR DESCRIPTION
## Summary
- switch the Slack broker UI guidance from Gemini-first to Kimi-first in the base thread instructions
- update the prompt text to call the global `kimi` CLI for UI planning prompts
- align the thread-start instruction test with the new Kimi wording

## Verification
- pnpm exec vitest run test/app-server-client.test.ts
- pnpm build
- manual: built the prompt via `buildSlackThreadBaseInstructions` from `dist` and confirmed the rendered UI contract includes the Kimi-first wording and `kimi --work-dir ... --add-dir ... --print --prompt ...` command