### PR TITLE
Keep generated Codex images on disk for manual Slack uploads

### DIFF
--- a/src/services/codex/app-server-client.ts
+++ b/src/services/codex/app-server-client.ts
@@ -4,7 +4,11 @@ import fs from "node:fs/promises";
 import WebSocket from "ws";
 
 import { logger } from "../../logger.js";
-import type { CodexTurnResult, SlackUserIdentity } from "../../types.js";
+import type {
+  CodexTurnResult,
+  GeneratedImageArtifact,
+  SlackUserIdentity
+} from "../../types.js";
 import { buildSlackThreadBaseInstructions } from "./slack-thread-base-instructions.js";
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
@@ -39,6 +43,7 @@ interface ActiveTurn {
   readonly threadId: string;
   readonly turnId: string;
   text: string;
+  generatedImages: GeneratedImageArtifact[];
   resolve: (result: CodexTurnResult) => void;
   reject: (error: Error) => void;
 }
@@ -46,6 +51,7 @@ interface ActiveTurn {
 interface BufferedTurnEvents {
   text: string;
   terminalState: "completed" | "aborted" | null;
+  generatedImages: GeneratedImageArtifact[];
 }
 
 export interface StartedTurn {
@@ -76,6 +82,7 @@ export interface ReadTurnResult {
   readonly status: "completed" | "failed" | "interrupted" | "inProgress" | "unknown";
   readonly finalMessage: string;
   readonly errorMessage?: string | undefined;
+  readonly generatedImages: readonly GeneratedImageArtifact[];
 }
 
 export interface ReadTurnResultOptions {
@@ -136,6 +143,7 @@ export class AppServerClient extends EventEmitter {
       readonly serviceName: string;
       readonly brokerHttpBaseUrl: string;
       readonly reposRoot: string;
+      readonly codexGeneratedImagesRoot?: string | undefined;
       readonly openAiApiKey?: string | undefined;
       readonly personalMemoryFilePath?: string | undefined;
       readonly heartbeatIntervalMs?: number | undefined;
@@ -354,6 +362,7 @@ export class AppServerClient extends EventEmitter {
         threadId,
         turnId: result.turn.id,
         text: "",
+        generatedImages: [],
         resolve,
         reject
       });
@@ -415,6 +424,7 @@ export class AppServerClient extends EventEmitter {
       rootThreadTs: session.rootThreadTs,
       workspacePath: session.workspacePath,
       reposRoot: this.options.reposRoot,
+      codexGeneratedImagesRoot: this.options.codexGeneratedImagesRoot ?? "$CODEX_HOME/generated_images",
       slackBotIdentity: this.#slackBotIdentity,
       personalMemory
     });
@@ -449,7 +459,14 @@ export class AppServerClient extends EventEmitter {
           } | null;
           items?: Array<{
             type?: string;
+            id?: string;
             text?: string;
+            status?: string;
+            result?: string;
+            savedPath?: string | null;
+            saved_path?: string | null;
+            revisedPrompt?: string | null;
+            revised_prompt?: string | null;
           }>;
         }>;
       };
@@ -466,11 +483,15 @@ export class AppServerClient extends EventEmitter {
 
     const agentMessages = (turn.items ?? []).filter((item) => item.type === "agentMessage");
     const lastAgentMessage = agentMessages.at(-1);
+    const generatedImages = (turn.items ?? [])
+      .map((item, index) => normalizeGeneratedImageArtifact(item, index))
+      .filter((item): item is GeneratedImageArtifact => item !== null);
     const status = normalizeTurnStatus(turn.status);
 
     const normalizedResult = {
       status,
       finalMessage: String(lastAgentMessage?.text ?? "").trim(),
+      generatedImages,
       errorMessage:
         turn.error?.additionalDetails ??
         turn.error?.message ??
@@ -587,6 +608,26 @@ export class AppServerClient extends EventEmitter {
       return;
     }
 
+    if (method === "item/completed") {
+      const turnId = params.turnId as string | undefined;
+      if (!turnId) {
+        return;
+      }
+
+      const image = normalizeGeneratedImageArtifact(params.item as Record<string, unknown> | undefined);
+      if (!image) {
+        return;
+      }
+
+      const turn = this.#activeTurns.get(turnId);
+      if (turn) {
+        upsertGeneratedImage(turn.generatedImages, image);
+      } else {
+        this.#bufferGeneratedImage(turnId, image);
+      }
+      return;
+    }
+
     if (method === "turn/completed") {
       const turnId = params.turn?.id as string | undefined;
       if (!turnId) {
@@ -661,7 +702,8 @@ export class AppServerClient extends EventEmitter {
         threadId: turn.threadId,
         turnId,
         finalMessage: result.finalMessage,
-        aborted: false
+        aborted: false,
+        generatedImages: result.generatedImages
       });
       return;
     }
@@ -671,7 +713,8 @@ export class AppServerClient extends EventEmitter {
         threadId: turn.threadId,
         turnId,
         finalMessage: result.finalMessage,
-        aborted: true
+        aborted: true,
+        generatedImages: result.generatedImages
       });
       return;
     }
@@ -693,7 +736,8 @@ export class AppServerClient extends EventEmitter {
   #bufferTurnText(turnId: string, delta: string): void {
     const buffered = this.#bufferedTurnEvents.get(turnId) ?? {
       text: "",
-      terminalState: null
+      terminalState: null,
+      generatedImages: []
     };
     buffered.text += delta;
     this.#bufferedTurnEvents.set(turnId, buffered);
@@ -702,9 +746,20 @@ export class AppServerClient extends EventEmitter {
   #bufferTurnTerminalState(turnId: string, terminalState: "completed" | "aborted"): void {
     const buffered = this.#bufferedTurnEvents.get(turnId) ?? {
       text: "",
-      terminalState: null
+      terminalState: null,
+      generatedImages: []
     };
     buffered.terminalState = terminalState;
+    this.#bufferedTurnEvents.set(turnId, buffered);
+  }
+
+  #bufferGeneratedImage(turnId: string, image: GeneratedImageArtifact): void {
+    const buffered = this.#bufferedTurnEvents.get(turnId) ?? {
+      text: "",
+      terminalState: null,
+      generatedImages: []
+    };
+    upsertGeneratedImage(buffered.generatedImages, image);
     this.#bufferedTurnEvents.set(turnId, buffered);
   }
 
@@ -722,6 +777,9 @@ export class AppServerClient extends EventEmitter {
     this.#bufferedTurnEvents.delete(turnId);
     if (buffered.text) {
       turn.text += buffered.text;
+    }
+    for (const image of buffered.generatedImages) {
+      upsertGeneratedImage(turn.generatedImages, image);
     }
 
     if (buffered.terminalState === "completed") {
@@ -741,7 +799,8 @@ export class AppServerClient extends EventEmitter {
       threadId: turn.threadId,
       turnId: turn.turnId,
       finalMessage: turn.text.trim(),
-      aborted
+      aborted,
+      generatedImages: [...turn.generatedImages]
     });
   }
 
@@ -830,5 +889,83 @@ function normalizeCreditsSnapshot(credits: RawCreditsSnapshot | null | undefined
     hasCredits: Boolean(credits.hasCredits),
     unlimited: Boolean(credits.unlimited),
     balance: credits.balance ?? null
+  };
+}
+
+function normalizeGeneratedImageArtifact(
+  item: Record<string, unknown> | undefined,
+  index = 0
+): GeneratedImageArtifact | null {
+  if (!item) {
+    return null;
+  }
+
+  const type = normalizeOptionalString(item.type);
+  if (type !== "imageGeneration" && type !== "image_generation_call") {
+    return null;
+  }
+
+  const savedPath = normalizeOptionalString(item.savedPath) ?? normalizeOptionalString(item.saved_path);
+  const result = normalizeOptionalString(item.result);
+  const { contentBase64, contentType } = normalizeImageResult(result);
+  const id = normalizeOptionalString(item.id) ?? savedPath ?? `generated-image-${index + 1}`;
+  const revisedPrompt = normalizeOptionalString(item.revisedPrompt) ?? normalizeOptionalString(item.revised_prompt);
+
+  if (!savedPath && !contentBase64) {
+    return null;
+  }
+
+  return {
+    id,
+    contentBase64,
+    contentType,
+    savedPath,
+    revisedPrompt
+  };
+}
+
+function normalizeImageResult(
+  value: string | undefined
+): {
+  readonly contentBase64?: string;
+  readonly contentType?: string;
+} {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return {};
+  }
+
+  const dataUrlMatch = normalized.match(/^data:(image\/[^;]+);base64,(.+)$/i);
+  if (dataUrlMatch) {
+    return {
+      contentType: dataUrlMatch[1]!,
+      contentBase64: dataUrlMatch[2]!.replace(/\s+/g, "")
+    };
+  }
+
+  if (!/^[A-Za-z0-9+/=\s]+$/.test(normalized)) {
+    return {};
+  }
+
+  return {
+    contentType: "image/png",
+    contentBase64: normalized.replace(/\s+/g, "")
+  };
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function upsertGeneratedImage(target: GeneratedImageArtifact[], image: GeneratedImageArtifact): void {
+  const existingIndex = target.findIndex((entry) => entry.id === image.id);
+  if (existingIndex === -1) {
+    target.push(image);
+    return;
+  }
+
+  target[existingIndex] = {
+    ...target[existingIndex],
+    ...image
   };
 }

--- a/src/services/codex/codex-broker.ts
+++ b/src/services/codex/codex-broker.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import path from "node:path";
 
 import { AppServerClient } from "./app-server-client.js";
 import { AppServerProcess } from "./app-server-process.js";
@@ -24,6 +25,7 @@ export class CodexBroker extends EventEmitter {
   readonly #codexAppServerUrl?: string | undefined;
   readonly #personalMemoryFilePath: string;
   readonly #reposRoot: string;
+  readonly #codexGeneratedImagesRoot: string;
   #slackBotIdentity: SlackUserIdentity | null = null;
   #reconnectPromise: Promise<void> | undefined;
   #connectQueue: Promise<void> = Promise.resolve();
@@ -54,6 +56,7 @@ export class CodexBroker extends EventEmitter {
     this.#codexAppServerUrl = options.codexAppServerUrl;
     this.#personalMemoryFilePath = getPersonalMemoryPath(options.codexHome);
     this.#reposRoot = options.reposRoot;
+    this.#codexGeneratedImagesRoot = path.join(options.codexHome, "generated_images");
 
     if (options.codexAppServerUrl) {
       this.#client = this.#createClient(options.codexAppServerUrl);
@@ -177,7 +180,8 @@ export class CodexBroker extends EventEmitter {
       brokerHttpBaseUrl: this.#brokerHttpBaseUrl,
       openAiApiKey: this.#openAiApiKey,
       personalMemoryFilePath: this.#personalMemoryFilePath,
-      reposRoot: this.#reposRoot
+      reposRoot: this.#reposRoot,
+      codexGeneratedImagesRoot: this.#codexGeneratedImagesRoot
     });
     client.setSlackBotIdentity(this.#slackBotIdentity);
     return client;

--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -19,6 +19,7 @@ Slack broker API usage for this session:
 - Record a silent wait state without posting to Slack with: {{post_state_wait_command}}
 - Record a silent block state without posting a second Slack message with: {{post_state_block_command}}
 - Upload a local image or file with: {{post_file_command}}
+- Built-in Codex image-generation outputs are saved under `{{codex_generated_images_root}}/<thread-id>/...`. When you want to share one in Slack, upload it yourself with `/slack/post-file` and an absolute `file_path`.
 - Read earlier thread context with: {{thread_history_command}}
 - Register a broker-managed background job with: {{register_job_command}}
 - Inspect the current session's co-author status with: {{coauthor_status_command}}

--- a/src/services/codex/slack-thread-base-instructions.ts
+++ b/src/services/codex/slack-thread-base-instructions.ts
@@ -16,6 +16,7 @@ export interface BuildSlackThreadBaseInstructionsOptions {
   readonly rootThreadTs: string;
   readonly workspacePath: string;
   readonly reposRoot: string;
+  readonly codexGeneratedImagesRoot: string;
   readonly slackBotIdentity: SlackUserIdentity | null;
   readonly personalMemory?: string | undefined;
 }
@@ -92,6 +93,7 @@ export async function buildSlackThreadBaseInstructions(
     execution_environment_section: await buildExecutionEnvironmentSection(),
     session_workspace: options.workspacePath,
     shared_repos_root: options.reposRoot,
+    codex_generated_images_root: options.codexGeneratedImagesRoot,
     channel_id: options.channelId,
     thread_ts: options.rootThreadTs,
     post_message_command:

--- a/src/services/slack/slack-turn-runner.ts
+++ b/src/services/slack/slack-turn-runner.ts
@@ -272,7 +272,8 @@ export class SlackTurnRunner {
           threadId: session.codexThreadId ?? "",
           turnId,
           finalMessage: snapshot.finalMessage,
-          aborted: false
+          aborted: false,
+          generatedImages: snapshot.generatedImages
         };
       }
 
@@ -281,7 +282,8 @@ export class SlackTurnRunner {
           threadId: session.codexThreadId ?? "",
           turnId,
           finalMessage: snapshot.finalMessage,
-          aborted: true
+          aborted: true,
+          generatedImages: snapshot.generatedImages
         };
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,4 +217,13 @@ export interface CodexTurnResult {
   readonly turnId: string;
   readonly finalMessage: string;
   readonly aborted: boolean;
+  readonly generatedImages?: readonly GeneratedImageArtifact[] | undefined;
+}
+
+export interface GeneratedImageArtifact {
+  readonly id: string;
+  readonly contentBase64?: string | undefined;
+  readonly contentType?: string | undefined;
+  readonly savedPath?: string | undefined;
+  readonly revisedPrompt?: string | undefined;
 }

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -202,7 +202,8 @@ describe("AppServerClient disconnect handling", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       finalMessage: "done",
-      aborted: false
+      aborted: false,
+      generatedImages: []
     });
   });
 
@@ -309,7 +310,150 @@ describe("AppServerClient disconnect handling", () => {
     await expect(client.readTurnResult("thread-1", "turn-1")).resolves.toEqual({
       status: "completed",
       finalMessage: "done",
-      errorMessage: undefined
+      errorMessage: undefined,
+      generatedImages: []
+    });
+  });
+
+  it("parses generated images from thread/read results", async () => {
+    const server = await createServer((socket, message) => {
+      if (message.method === "initialize") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { ok: true }
+        }));
+        return;
+      }
+
+      if (message.method === "thread/read") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: {
+            thread: {
+              turns: [
+                {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [
+                    {
+                      type: "agentMessage",
+                      text: "done"
+                    },
+                    {
+                      type: "image_generation_call",
+                      id: "ig-1",
+                      revised_prompt: "blue cat",
+                      result: "QUJDREVGRw==",
+                      saved_path: "/tmp/ig-1.png"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }));
+      }
+    });
+    servers.push(server);
+
+    const client = new AppServerClient({
+      url: server.url,
+      serviceName: "test",
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      reposRoot: "/tmp/repos"
+    });
+
+    await client.connect();
+    await expect(client.readTurnResult("thread-1", "turn-1")).resolves.toEqual({
+      status: "completed",
+      finalMessage: "done",
+      errorMessage: undefined,
+      generatedImages: [
+        {
+          id: "ig-1",
+          contentBase64: "QUJDREVGRw==",
+          contentType: "image/png",
+          savedPath: "/tmp/ig-1.png",
+          revisedPrompt: "blue cat"
+        }
+      ]
+    });
+  });
+
+  it("captures image generation results from live turn notifications", async () => {
+    const server = await createServer((socket, message) => {
+      if (message.method === "initialize") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { ok: true }
+        }));
+        return;
+      }
+
+      if (message.method === "turn/start") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: {
+            turn: {
+              id: "turn-1"
+            }
+          }
+        }));
+        socket.send(JSON.stringify({
+          method: "item/completed",
+          params: {
+            turnId: "turn-1",
+            item: {
+              type: "imageGeneration",
+              id: "ig-1",
+              revisedPrompt: "blue cat",
+              result: "QUJDREVGRw==",
+              savedPath: "/tmp/ig-1.png"
+            }
+          }
+        }));
+        socket.send(JSON.stringify({
+          method: "turn/completed",
+          params: {
+            turn: {
+              id: "turn-1"
+            }
+          }
+        }));
+      }
+    });
+    servers.push(server);
+
+    const client = new AppServerClient({
+      url: server.url,
+      serviceName: "test",
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      reposRoot: "/tmp/repos"
+    });
+
+    await client.connect();
+    const started = await client.startTurn("thread-1", "/tmp", [
+      {
+        type: "text",
+        text: "hello",
+        text_elements: []
+      }
+    ]);
+
+    await expect(started.completion).resolves.toEqual({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      finalMessage: "",
+      aborted: false,
+      generatedImages: [
+        {
+          id: "ig-1",
+          contentBase64: "QUJDREVGRw==",
+          contentType: "image/png",
+          savedPath: "/tmp/ig-1.png",
+          revisedPrompt: "blue cat"
+        }
+      ]
     });
   });
 
@@ -499,13 +643,15 @@ describe("AppServerClient disconnect handling", () => {
     ).resolves.toEqual({
       status: "completed",
       finalMessage: "done",
-      errorMessage: undefined
+      errorMessage: undefined,
+      generatedImages: []
     });
     await expect(started.completion).resolves.toEqual({
       threadId: "thread-1",
       turnId: "turn-1",
       finalMessage: "done",
-      aborted: false
+      aborted: false,
+      generatedImages: []
     });
   });
 


### PR DESCRIPTION
## Summary
- keep built-in Codex image outputs on disk instead of auto-posting them back into Slack
- tell the Slack-thread agent exactly where generated images are saved so it can choose when to upload with `/slack/post-file`
- keep coverage for parsing generated image artifacts from app-server turn events and snapshots

## Validation
- `pnpm test`
- `pnpm build`
- Manual: probed a real `codex app-server` session and confirmed `imageGeneration` items plus saved PNG files under `$CODEX_HOME/generated_images/...`
- Manual: rendered the Slack thread base instructions and verified they now point the agent at the generated-images directory plus manual `/slack/post-file` upload flow