### PR TITLE
Refresh ChatGPT auth before usage probes

### DIFF
--- a/src/services/codex/chatgpt-usage-api.ts
+++ b/src/services/codex/chatgpt-usage-api.ts
@@ -1,15 +1,20 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 
 import type { AppServerRateLimitsResponse, AppServerRateLimitSnapshot } from "./app-server-client.js";
 
 interface StoredAuthTokens {
+  readonly id_token?: string | undefined;
   readonly access_token?: string | undefined;
+  readonly refresh_token?: string | undefined;
   readonly account_id?: string | undefined;
 }
 
 interface StoredAuthJson {
   readonly auth_mode?: string | undefined;
+  readonly OPENAI_API_KEY?: string | null | undefined;
   readonly tokens?: StoredAuthTokens | undefined;
+  readonly last_refresh?: string | null | undefined;
 }
 
 interface UsageWindowPayload {
@@ -47,27 +52,30 @@ export interface ChatGptUsageSnapshot {
   readonly rateLimits: AppServerRateLimitsResponse;
 }
 
+interface RefreshResponsePayload {
+  readonly id_token?: string | undefined;
+  readonly access_token?: string | undefined;
+  readonly refresh_token?: string | undefined;
+}
+
+type FetchLike = typeof fetch;
+
+const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const TOKEN_REFRESH_URL = "https://auth.openai.com/oauth/token";
+const TOKEN_REFRESH_URL_OVERRIDE_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+const CODEX_CHATGPT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+
+const refreshInflight = new Map<string, Promise<StoredAuthJson>>();
+
 export async function readChatGptUsageSnapshot(authJsonPath: string): Promise<ChatGptUsageSnapshot> {
-  const auth = await readStoredAuthJson(authJsonPath);
-  const accessToken = auth.tokens?.access_token?.trim();
-  const accountId = auth.tokens?.account_id?.trim();
+  let auth = await refreshAuthIfNeeded(authJsonPath, await readStoredAuthJson(authJsonPath));
+  let response = await fetchUsage(auth);
 
-  if (!accessToken) {
-    throw new Error(`Missing access_token in ${authJsonPath}`);
+  if (response.status === 401 && auth.tokens?.refresh_token) {
+    auth = await refreshAuthJson(authJsonPath, auth);
+    response = await fetchUsage(auth);
   }
-
-  if (!accountId) {
-    throw new Error(`Missing account_id in ${authJsonPath}`);
-  }
-
-  const response = await fetch("https://chatgpt.com/backend-api/wham/usage", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "ChatGPT-Account-Id": accountId,
-      "User-Agent": "codex-cli"
-    },
-    signal: AbortSignal.timeout(20_000)
-  });
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");
@@ -116,9 +124,161 @@ export async function readChatGptUsageSnapshot(authJsonPath: string): Promise<Ch
   };
 }
 
+async function fetchUsage(auth: StoredAuthJson, fetchImpl: FetchLike = fetch): Promise<Response> {
+  const accessToken = auth.tokens?.access_token?.trim();
+  const accountId = auth.tokens?.account_id?.trim();
+
+  if (!accessToken) {
+    throw new Error("Missing access_token in auth.json");
+  }
+
+  if (!accountId) {
+    throw new Error("Missing account_id in auth.json");
+  }
+
+  return await fetchImpl(CHATGPT_USAGE_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "ChatGPT-Account-Id": accountId,
+      "User-Agent": "codex-cli"
+    },
+    signal: AbortSignal.timeout(20_000)
+  });
+}
+
+async function refreshAuthIfNeeded(authJsonPath: string, auth: StoredAuthJson): Promise<StoredAuthJson> {
+  if (!auth.tokens?.refresh_token) {
+    return auth;
+  }
+
+  const accessToken = auth.tokens.access_token;
+  if (accessToken && !isAccessTokenNearExpiry(accessToken)) {
+    return auth;
+  }
+
+  return await refreshAuthJson(authJsonPath, auth);
+}
+
+async function refreshAuthJson(
+  authJsonPath: string,
+  authBeforeRefresh: StoredAuthJson,
+  fetchImpl: FetchLike = fetch
+): Promise<StoredAuthJson> {
+  const writePath = await resolveWritableAuthPath(authJsonPath);
+  const inflight = refreshInflight.get(writePath);
+  if (inflight) {
+    return await inflight;
+  }
+
+  const refreshPromise = (async () => {
+    const latest = await readStoredAuthJson(writePath);
+    if (
+      latest.tokens?.access_token &&
+      latest.tokens.access_token !== authBeforeRefresh.tokens?.access_token &&
+      !isAccessTokenNearExpiry(latest.tokens.access_token)
+    ) {
+      return latest;
+    }
+
+    const refreshToken = latest.tokens?.refresh_token?.trim();
+    if (!refreshToken) {
+      throw new Error("Missing refresh_token in auth.json");
+    }
+
+    const refreshResponse = await requestTokenRefresh(refreshToken, fetchImpl);
+    const nextAuth: StoredAuthJson = {
+      ...latest,
+      tokens: {
+        ...latest.tokens,
+        ...(refreshResponse.id_token ? { id_token: refreshResponse.id_token } : {}),
+        ...(refreshResponse.access_token ? { access_token: refreshResponse.access_token } : {}),
+        ...(refreshResponse.refresh_token ? { refresh_token: refreshResponse.refresh_token } : {})
+      },
+      last_refresh: new Date().toISOString()
+    };
+    await writeStoredAuthJson(writePath, nextAuth);
+    return nextAuth;
+  })();
+  refreshInflight.set(writePath, refreshPromise);
+
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshInflight.delete(writePath);
+  }
+}
+
+async function requestTokenRefresh(refreshToken: string, fetchImpl: FetchLike): Promise<RefreshResponsePayload> {
+  const response = await fetchImpl(process.env[TOKEN_REFRESH_URL_OVERRIDE_ENV] ?? TOKEN_REFRESH_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      client_id: CODEX_CHATGPT_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken
+    }),
+    signal: AbortSignal.timeout(20_000)
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`ChatGPT token refresh failed (${response.status}): ${body || response.statusText}`);
+  }
+
+  return (await response.json()) as RefreshResponsePayload;
+}
+
+function isAccessTokenNearExpiry(accessToken: string): boolean {
+  const expiresAt = parseJwtExpiration(accessToken);
+  return typeof expiresAt === "number" && expiresAt <= Date.now() + REFRESH_LEEWAY_MS;
+}
+
+function parseJwtExpiration(jwt: string): number | null {
+  const payload = jwt.split(".")[1];
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      readonly exp?: unknown;
+    };
+    return typeof parsed.exp === "number" ? parsed.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveWritableAuthPath(authJsonPath: string): Promise<string> {
+  try {
+    return await fs.realpath(authJsonPath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return authJsonPath;
+    }
+
+    throw error;
+  }
+}
+
 async function readStoredAuthJson(authJsonPath: string): Promise<StoredAuthJson> {
   const raw = await fs.readFile(authJsonPath, "utf8");
   return JSON.parse(raw) as StoredAuthJson;
+}
+
+async function writeStoredAuthJson(authJsonPath: string, auth: StoredAuthJson): Promise<void> {
+  const stat = await fs.stat(authJsonPath).catch(() => null);
+  const tempPath = path.join(
+    path.dirname(authJsonPath),
+    `.${path.basename(authJsonPath)}.${process.pid}.${Date.now()}.tmp`
+  );
+  await fs.writeFile(tempPath, `${JSON.stringify(auth, null, 2)}\n`, {
+    mode: stat ? stat.mode & 0o777 : 0o600
+  });
+
+  await fs.rename(tempPath, authJsonPath);
 }
 
 function normalizeRateLimitSnapshot(

--- a/test/chatgpt-usage-api.test.ts
+++ b/test/chatgpt-usage-api.test.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readChatGptUsageSnapshot } from "../src/services/codex/chatgpt-usage-api.js";
+
+describe("readChatGptUsageSnapshot", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await Promise.all(
+      tempDirs.splice(0).map((directory) =>
+        fs.rm(directory, {
+          recursive: true,
+          force: true
+        })
+      )
+    );
+  });
+
+  it("refreshes before usage when the access token is expired", async () => {
+    const authJsonPath = await writeAuthJson({
+      tokens: {
+        access_token: jwtWithExpiration(Math.floor(Date.now() / 1000) - 60),
+        refresh_token: "old-refresh",
+        account_id: "account-1"
+      }
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://auth.openai.com/oauth/token") {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+          grant_type: "refresh_token",
+          refresh_token: "old-refresh"
+        });
+        return jsonResponse({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          id_token: "new-id"
+        });
+      }
+
+      expect(url).toBe("https://chatgpt.com/backend-api/wham/usage");
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer new-access");
+      return jsonResponse(usagePayload());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const snapshot = await readChatGptUsageSnapshot(authJsonPath);
+
+    expect(snapshot.account.email).toBe("bot@example.com");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const written = JSON.parse(await fs.readFile(authJsonPath, "utf8")) as {
+      readonly tokens: Record<string, string>;
+      readonly last_refresh?: string;
+    };
+    expect(written.tokens).toMatchObject({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+      id_token: "new-id",
+      account_id: "account-1"
+    });
+    expect(written.last_refresh).toEqual(expect.any(String));
+  });
+
+  it("falls back to one forced refresh on a usage 401", async () => {
+    const authJsonPath = await writeAuthJson({
+      tokens: {
+        access_token: "old-access",
+        refresh_token: "old-refresh",
+        account_id: "account-1"
+      }
+    });
+    let usageCalls = 0;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === "https://auth.openai.com/oauth/token") {
+        return jsonResponse({
+          access_token: "new-access",
+          refresh_token: "new-refresh"
+        });
+      }
+
+      usageCalls += 1;
+      if (usageCalls === 1) {
+        expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer old-access");
+        return new Response("expired", { status: 401 });
+      }
+
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer new-access");
+      return jsonResponse(usagePayload());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await readChatGptUsageSnapshot(authJsonPath);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const written = JSON.parse(await fs.readFile(authJsonPath, "utf8")) as {
+      readonly tokens: Record<string, string>;
+    };
+    expect(written.tokens.refresh_token).toBe("new-refresh");
+  });
+
+  it("preserves an active auth.json symlink when writing refreshed tokens", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "usage-auth-symlink-"));
+    tempDirs.push(directory);
+    const profilePath = path.join(directory, "profile.json");
+    const linkPath = path.join(directory, "auth.json");
+    await fs.writeFile(
+      profilePath,
+      JSON.stringify({
+        tokens: {
+          access_token: jwtWithExpiration(Math.floor(Date.now() / 1000) - 60),
+          refresh_token: "old-refresh",
+          account_id: "account-1"
+        }
+      }),
+      "utf8"
+    );
+    await fs.symlink(path.basename(profilePath), linkPath);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = input.toString();
+        if (url === "https://auth.openai.com/oauth/token") {
+          return jsonResponse({
+            access_token: "new-access",
+            refresh_token: "new-refresh"
+          });
+        }
+
+        return jsonResponse(usagePayload());
+      })
+    );
+
+    await readChatGptUsageSnapshot(linkPath);
+
+    expect((await fs.lstat(linkPath)).isSymbolicLink()).toBe(true);
+    const written = JSON.parse(await fs.readFile(profilePath, "utf8")) as {
+      readonly tokens: Record<string, string>;
+    };
+    expect(written.tokens.access_token).toBe("new-access");
+  });
+
+  async function writeAuthJson(content: Record<string, unknown>): Promise<string> {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "usage-auth-"));
+    tempDirs.push(directory);
+    const authJsonPath = path.join(directory, "auth.json");
+    await fs.writeFile(authJsonPath, JSON.stringify(content), "utf8");
+    return authJsonPath;
+  }
+});
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+}
+
+function usagePayload() {
+  return {
+    email: "bot@example.com",
+    plan_type: "pro",
+    rate_limit: {
+      primary_window: {
+        used_percent: 10,
+        limit_window_seconds: 18_000,
+        reset_at: 1_777_777_777
+      }
+    },
+    additional_rate_limits: []
+  };
+}
+
+function jwtWithExpiration(exp: number): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify({ exp })).toString("base64url"),
+    "signature"
+  ].join(".");
+}


### PR DESCRIPTION
## Summary
- proactively refresh ChatGPT auth.json tokens before usage probes when the access token JWT is expired or within a 5 minute leeway
- keep a 401 forced-refresh + retry-once fallback for stale tokens without usable exp metadata
- atomically write refreshed tokens to the real profile file so the active auth.json symlink is preserved

## Tests
- pnpm test -- test/chatgpt-usage-api.test.ts
- pnpm build