### PR TITLE
Add central auth pool load balancing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,12 @@ CODEX_APP_SERVER_PORT=4590
 # Auth mode B: reuse a Codex/ChatGPT auth.json mounted into the container
 # CODEX_AUTH_JSON_PATH=/auth/auth.json
 
+# Optional: centrally lease imported Auth Profiles to app-server sessions.
+# off: existing global active auth.json behavior
+# shadow: compute leases but continue the existing global behavior
+# on: inject leased ChatGPT access tokens with account/login/start(chatgptAuthTokens)
+AUTH_POOL_LB=off
+
 # Optional: override docker-side helpers that need to call a host-local service.
 # When unset, the broker probes common host-local tempad endpoints and picks the first
 # healthy one (currently 4318 / 4320 on host.docker.internal).

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export interface AppConfig {
   readonly codexHome: string;
   readonly codexHostHomePath?: string | undefined;
   readonly codexAuthJsonPath?: string | undefined;
+  readonly authPoolLbMode: "off" | "shadow" | "on";
   readonly geminiHostHomePath?: string | undefined;
   readonly geminiHttpProxy?: string | undefined;
   readonly geminiHttpsProxy?: string | undefined;
@@ -133,6 +134,19 @@ function getLogLevel(env: NodeJS.ProcessEnv, name: string, fallback: AppConfig["
   throw new Error(`Invalid log level environment variable: ${name}`);
 }
 
+function getAuthPoolLbMode(env: NodeJS.ProcessEnv): AppConfig["authPoolLbMode"] {
+  const value = env.AUTH_POOL_LB?.trim().toLowerCase();
+  if (!value) {
+    return "off";
+  }
+
+  if (value === "off" || value === "shadow" || value === "on") {
+    return value;
+  }
+
+  throw new Error("Invalid AUTH_POOL_LB value; expected off, shadow, or on");
+}
+
 export function loadConfig(env = process.env): AppConfig {
   const serviceRoot = env.SERVICE_ROOT ? path.resolve(env.SERVICE_ROOT) : undefined;
   const dataRoot = env.DATA_ROOT ? path.resolve(env.DATA_ROOT) : path.resolve(".data");
@@ -178,6 +192,7 @@ export function loadConfig(env = process.env): AppConfig {
     codexHome,
     codexHostHomePath: getOptional(env, "CODEX_HOST_HOME_PATH"),
     codexAuthJsonPath: getOptional(env, "CODEX_AUTH_JSON_PATH"),
+    authPoolLbMode: getAuthPoolLbMode(env),
     geminiHostHomePath: getOptional(env, "GEMINI_HOST_HOME_PATH"),
     geminiHttpProxy: getOptional(env, "GEMINI_HTTP_PROXY"),
     geminiHttpsProxy: getOptional(env, "GEMINI_HTTPS_PROXY"),

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -66,6 +66,48 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "POST" && url.pathname === "/admin/api/auth-profiles/oauth/start") {
+    const body = await readAdminBody(request, response);
+    if (!body) {
+      return true;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.startAuthProfileOAuth({
+        name: readString(body.name) ?? undefined
+      })
+    );
+    return true;
+  }
+
+  if (method === "GET" && url.pathname.startsWith("/admin/api/auth-profiles/oauth/")) {
+    const attemptId = decodeURIComponent(url.pathname.slice("/admin/api/auth-profiles/oauth/".length));
+    if (!attemptId || attemptId.includes("/")) {
+      return false;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.getAuthProfileOAuthAttempt({
+        id: attemptId
+      })
+    );
+    return true;
+  }
+
+  if (method === "POST" && url.pathname.startsWith("/admin/api/auth-profiles/oauth/") && url.pathname.endsWith("/cancel")) {
+    const attemptId = decodeURIComponent(url.pathname.slice("/admin/api/auth-profiles/oauth/".length, -"/cancel".length));
+    if (!attemptId || attemptId.includes("/")) {
+      return false;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.cancelAuthProfileOAuthAttempt({
+        id: attemptId
+      })
+    );
+    return true;
+  }
+
   if (method === "POST" && url.pathname === "/admin/api/github-authors") {
     const body = await readAdminBody(request, response);
     if (!body) {
@@ -523,7 +565,10 @@ function renderAdminPage(options: {
         <section>
           <div class="section-head">
             <div class="section-title">Auth Profiles</div>
-            <button id="open-add-profile-dialog">ADD</button>
+            <div style="display:flex; gap:8px;">
+              <button id="open-oauth-profile-dialog" class="secondary">OAUTH</button>
+              <button id="open-add-profile-dialog">ADD</button>
+            </div>
           </div>
           <div id="auth-profiles-panel" style="padding:12px; display:grid; gap:8px;"></div>
           <div id="replace-status" style="padding:8px; font-size:10px;"></div>
@@ -568,6 +613,7 @@ function renderAdminPage(options: {
 
   <dialog id="add-profile-dialog"><div class="modal-content">
     <div class="section-title">Add auth profile</div>
+    <input id="profile-auth-name" type="text" placeholder="OPTIONAL PROFILE NAME" />
     <input id="profile-auth-file" type="file" accept="application/json,.json" />
     <textarea id="profile-auth-text" placeholder="PASTE AUTH.JSON HERE..."></textarea>
     <div style="display:flex; gap:8px; justify-content:flex-end;">
@@ -575,6 +621,21 @@ function renderAdminPage(options: {
       <button id="submit-add-profile-dialog">SAVE</button>
     </div>
     <div id="add-profile-status" style="font-size:10px;"></div>
+  </div></dialog>
+
+  <dialog id="oauth-profile-dialog"><div class="modal-content">
+    <div class="section-title">OAuth device-code auth profile</div>
+    <input id="oauth-profile-name" type="text" placeholder="OPTIONAL PROFILE NAME" />
+    <div style="color:var(--muted); font-size:11px;">
+      Starts an isolated temporary Codex app-server on this VM, shows a device code, then imports the generated auth.json as a profile. It does not touch the worker CODEX_HOME.
+    </div>
+    <div id="oauth-profile-result" style="display:grid; gap:8px; font-size:12px;"></div>
+    <div style="display:flex; gap:8px; justify-content:flex-end;">
+      <button id="close-oauth-profile-dialog" class="secondary">CLOSE</button>
+      <button id="cancel-oauth-profile-dialog" class="danger" disabled>CANCEL LOGIN</button>
+      <button id="submit-oauth-profile-dialog">START LOGIN</button>
+    </div>
+    <div id="oauth-profile-status" style="font-size:10px;"></div>
   </div></dialog>
 
   <dialog id="github-author-dialog"><div class="modal-content">
@@ -598,6 +659,7 @@ function renderAdminPage(options: {
     const sessionFilter = document.getElementById("session-filter");
     const githubAuthorSearch = document.getElementById("github-author-search");
     const addProfileDialog = document.getElementById("add-profile-dialog");
+    const oauthProfileDialog = document.getElementById("oauth-profile-dialog");
     const githubAuthorDialog = document.getElementById("github-author-dialog");
     const deployRefInput = document.getElementById("deploy-ref-input");
     const uiStateStorageKey = "admin-ui-state:" + window.location.pathname;
@@ -605,6 +667,8 @@ function renderAdminPage(options: {
     let latestStatus = null;
     let uiState = loadUiState();
     let uiStatePersistTimer = null;
+    let oauthProfileAttemptId = null;
+    let oauthProfilePollTimer = null;
 
     function esc(value) {
       return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
@@ -1138,6 +1202,7 @@ function renderAdminPage(options: {
 
     async function submitAddProfile() {
       const status = document.getElementById("add-profile-status");
+      const nameInput = document.getElementById("profile-auth-name");
       const fileInput = document.getElementById("profile-auth-file");
       const textArea = document.getElementById("profile-auth-text");
       const submitButton = document.getElementById("submit-add-profile-dialog");
@@ -1152,6 +1217,7 @@ function renderAdminPage(options: {
           method: "POST",
           headers: authHeaders({ "content-type": "application/json" }),
           body: JSON.stringify({
+            name: nameInput.value.trim() || undefined,
             auth_json_content: content
           })
         });
@@ -1160,6 +1226,7 @@ function renderAdminPage(options: {
         replaceStatus.innerHTML = '<span style="color:var(--good)">PROFILE SAVED</span>';
         status.innerHTML = '<span style="color:var(--good)">PROFILE SAVED</span>';
         addProfileDialog.close();
+        nameInput.value = "";
         fileInput.value = "";
         textArea.value = "";
       } catch (error) {
@@ -1167,6 +1234,128 @@ function renderAdminPage(options: {
         status.innerHTML = '<span style="color:var(--danger)">' + esc(message) + "</span>";
       } finally {
         submitButton.disabled = false;
+      }
+    }
+
+    function clearOAuthProfilePoll() {
+      if (oauthProfilePollTimer == null) {
+        return;
+      }
+      window.clearInterval(oauthProfilePollTimer);
+      oauthProfilePollTimer = null;
+    }
+
+    function renderOAuthProfileAttempt(attempt) {
+      const result = document.getElementById("oauth-profile-result");
+      const status = document.getElementById("oauth-profile-status");
+      const cancelButton = document.getElementById("cancel-oauth-profile-dialog");
+      const submitButton = document.getElementById("submit-oauth-profile-dialog");
+      oauthProfileAttemptId = attempt?.id || oauthProfileAttemptId;
+      const state = attempt?.status || "idle";
+      cancelButton.disabled = !(state === "starting" || state === "waiting");
+      submitButton.disabled = state === "starting" || state === "waiting";
+
+      if (!attempt) {
+        result.innerHTML = "";
+        status.textContent = "";
+        return;
+      }
+
+      const code = attempt.userCode
+        ? '<div class="profile-row">' +
+            '<div class="summary-label">USER CODE</div>' +
+            '<div style="font-size:24px; color:var(--accent); letter-spacing:2px;">' + esc(attempt.userCode) + "</div>" +
+          "</div>"
+        : "";
+      const link = attempt.verificationUrl
+        ? '<div><a href="' + esc(attempt.verificationUrl) + '" target="_blank" rel="noopener" style="color:var(--accent);">' + esc(attempt.verificationUrl) + "</a></div>"
+        : "";
+      result.innerHTML =
+        '<div>' + renderBadge(state.toUpperCase(), statusTone(state)) + "</div>" +
+        link +
+        code +
+        (attempt.error ? '<div style="color:var(--danger)">' + esc(attempt.error) + "</div>" : "");
+
+      if (state === "waiting") {
+        status.innerHTML = "Open the link on your own machine, enter the code, and finish ChatGPT login.";
+      } else if (state === "succeeded") {
+        status.innerHTML = '<span style="color:var(--good)">PROFILE IMPORTED</span>';
+      } else if (state === "failed" || state === "cancelled") {
+        status.innerHTML = '<span style="color:var(--danger)">' + esc(state.toUpperCase()) + "</span>";
+      } else {
+        status.textContent = state.toUpperCase();
+      }
+    }
+
+    async function startOAuthProfileLogin() {
+      const nameInput = document.getElementById("oauth-profile-name");
+      const status = document.getElementById("oauth-profile-status");
+      const submitButton = document.getElementById("submit-oauth-profile-dialog");
+      status.textContent = "STARTING DEVICE-CODE LOGIN...";
+      submitButton.disabled = true;
+      clearOAuthProfilePoll();
+      try {
+        const response = await fetch("/admin/api/auth-profiles/oauth/start", {
+          method: "POST",
+          headers: authHeaders({ "content-type": "application/json" }),
+          body: JSON.stringify({
+            name: nameInput.value.trim() || undefined
+          })
+        });
+        const payload = await parseResponse(response);
+        renderOAuthProfileAttempt(payload.attempt);
+        startOAuthProfilePoll(payload.attempt.id);
+      } catch (error) {
+        status.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+      } finally {
+        if (!oauthProfileAttemptId) {
+          submitButton.disabled = false;
+        }
+      }
+    }
+
+    function startOAuthProfilePoll(attemptId) {
+      oauthProfileAttemptId = attemptId;
+      clearOAuthProfilePoll();
+      oauthProfilePollTimer = window.setInterval(async () => {
+        try {
+          const response = await fetch("/admin/api/auth-profiles/oauth/" + encodeURIComponent(attemptId), {
+            headers: authHeaders()
+          });
+          const payload = await parseResponse(response);
+          renderOAuthProfileAttempt(payload.attempt);
+          if (["succeeded", "failed", "cancelled"].includes(payload.attempt?.status)) {
+            clearOAuthProfilePoll();
+            if (payload.attempt.status === "succeeded") {
+              await refresh();
+              replaceStatus.innerHTML = '<span style="color:var(--good)">OAUTH PROFILE IMPORTED</span>';
+            }
+          }
+        } catch (error) {
+          clearOAuthProfilePoll();
+          document.getElementById("oauth-profile-status").innerHTML =
+            '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        }
+      }, 2000);
+    }
+
+    async function cancelOAuthProfileLogin() {
+      if (!oauthProfileAttemptId) {
+        return;
+      }
+      const status = document.getElementById("oauth-profile-status");
+      status.textContent = "CANCELLING...";
+      try {
+        const response = await fetch("/admin/api/auth-profiles/oauth/" + encodeURIComponent(oauthProfileAttemptId) + "/cancel", {
+          method: "POST",
+          headers: authHeaders({ "content-type": "application/json" }),
+          body: "{}"
+        });
+        const payload = await parseResponse(response);
+        renderOAuthProfileAttempt(payload.attempt);
+        clearOAuthProfilePoll();
+      } catch (error) {
+        status.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
       }
     }
 
@@ -1303,6 +1492,16 @@ function renderAdminPage(options: {
       document.getElementById("add-profile-status").textContent = "";
       addProfileDialog.showModal();
     };
+    document.getElementById("open-oauth-profile-dialog").onclick = () => {
+      document.getElementById("oauth-profile-status").textContent = "";
+      document.getElementById("oauth-profile-result").innerHTML = "";
+      document.getElementById("oauth-profile-name").value = "";
+      document.getElementById("cancel-oauth-profile-dialog").disabled = true;
+      document.getElementById("submit-oauth-profile-dialog").disabled = false;
+      oauthProfileAttemptId = null;
+      clearOAuthProfilePoll();
+      oauthProfileDialog.showModal();
+    };
     document.getElementById("open-github-author-dialog").onclick = () => {
       document.getElementById("github-author-dialog-status").textContent = "";
       document.getElementById("github-author-slack-user-id").value = "";
@@ -1312,12 +1511,20 @@ function renderAdminPage(options: {
     document.getElementById("deploy-release-button").onclick = deployRelease;
     document.getElementById("rollback-release-button").onclick = rollbackRelease;
     document.getElementById("close-add-profile-dialog").onclick = () => addProfileDialog.close();
+    document.getElementById("close-oauth-profile-dialog").onclick = () => oauthProfileDialog.close();
     document.getElementById("close-github-author-dialog").onclick = () => githubAuthorDialog.close();
     document.getElementById("submit-add-profile-dialog").onclick = submitAddProfile;
+    document.getElementById("submit-oauth-profile-dialog").onclick = startOAuthProfileLogin;
+    document.getElementById("cancel-oauth-profile-dialog").onclick = cancelOAuthProfileLogin;
     document.getElementById("submit-github-author-dialog").onclick = submitGitHubAuthorMapping;
     addProfileDialog.onclick = (event) => {
       if (event.target === addProfileDialog) {
         addProfileDialog.close();
+      }
+    };
+    oauthProfileDialog.onclick = (event) => {
+      if (event.target === oauthProfileDialog) {
+        oauthProfileDialog.close();
       }
     };
     githubAuthorDialog.onclick = (event) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "./config.js";
 import { createHttpHandler } from "./http/router.js";
 import { configureLogger, logger } from "./logger.js";
 import { AdminService } from "./services/admin-service.js";
+import { AuthPoolService } from "./services/auth-pool-service.js";
 import { AuthProfileService } from "./services/auth-profile-service.js";
 import { CodexBroker } from "./services/codex/codex-broker.js";
 import { CodexRuntimeControl } from "./services/codex-runtime-control.js";
@@ -35,6 +36,9 @@ export async function startService(): Promise<{
     stateDir: config.stateDir
   });
   await githubAuthorMappings.load();
+  const authPool = new AuthPoolService({
+    config
+  });
   const codexBroker = new CodexBroker({
     serviceName: config.serviceName,
     brokerHttpBaseUrl: config.brokerHttpBaseUrl,
@@ -50,7 +54,8 @@ export async function startService(): Promise<{
     geminiHttpProxy: config.geminiHttpProxy,
     geminiHttpsProxy: config.geminiHttpsProxy,
     geminiAllProxy: config.geminiAllProxy,
-    openAiApiKey: config.codexOpenAiApiKey
+    openAiApiKey: config.codexOpenAiApiKey,
+    authPool
   });
   const bridge = new SlackCodexBridge({
     config,

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -1,12 +1,17 @@
 import fs from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 
 import type { AppConfig } from "../config.js";
 import type { PersistedBackgroundJob, PersistedInboundMessage, SlackSessionRecord } from "../types.js";
 import type { SessionManager } from "./session-manager.js";
-import type { AuthProfileService } from "./auth-profile-service.js";
+import type { AuthProfileService, AuthProfileSummary } from "./auth-profile-service.js";
 import type { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
 import type { RuntimeControl } from "./runtime-control.js";
+import { logger } from "../logger.js";
+import { AppServerClient } from "./codex/app-server-client.js";
+import { AppServerProcess } from "./codex/app-server-process.js";
 import type {
   DeployWorkerOptions,
   RollbackWorkerOptions,
@@ -28,7 +33,39 @@ interface FileInfo {
   readonly mtime?: string | undefined;
 }
 
+type AuthProfileOAuthStatus =
+  | "starting"
+  | "waiting"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+interface AuthProfileOAuthAttempt {
+  readonly id: string;
+  readonly createdAt: string;
+  readonly rootPath: string;
+  readonly codexHome: string;
+  readonly port: number;
+  readonly profileName?: string | undefined;
+  process?: AppServerProcess | undefined;
+  client?: AppServerClient | undefined;
+  loginId?: string | undefined;
+  verificationUrl?: string | undefined;
+  userCode?: string | undefined;
+  status: AuthProfileOAuthStatus;
+  updatedAt: string;
+  error?: string | undefined;
+  profile?: AuthProfileSummary | undefined;
+  notificationListener?: ((method: string, params: Record<string, any> | undefined) => void) | undefined;
+  timeout?: NodeJS.Timeout | undefined;
+}
+
+const AUTH_PROFILE_OAUTH_TIMEOUT_MS = 10 * 60 * 1000;
+const AUTH_PROFILE_OAUTH_ATTEMPT_RETENTION_MS = 30 * 60 * 1000;
+
 export class AdminService {
+  readonly #authProfileOAuthAttempts = new Map<string, AuthProfileOAuthAttempt>();
+
   constructor(
     private readonly options: {
       readonly config: AppConfig;
@@ -117,6 +154,7 @@ export class AdminService {
         configToml: await this.#fileInfo(path.join(this.options.config.codexHome, "config.toml"))
       },
       authProfiles,
+      authProfileOAuthAttempts: this.#listAuthProfileOAuthAttempts(),
       githubAuthorMappings: {
         count: this.options.githubAuthorMappings.listMappings().length,
         mappings: this.options.githubAuthorMappings.listMappings()
@@ -150,6 +188,114 @@ export class AdminService {
       ok: true,
       profile,
       status: await this.getStatus()
+    };
+  }
+
+  async startAuthProfileOAuth(options: {
+    readonly name?: string | undefined;
+  }): Promise<Record<string, unknown>> {
+    await this.#pruneAuthProfileOAuthAttempts();
+    const id = randomUUID();
+    const createdAt = new Date().toISOString();
+    const rootPath = path.join(path.dirname(this.options.config.stateDir), "auth-profile-oauth", id);
+    const codexHome = path.join(rootPath, "codex-home");
+    const port = await findFreeTcpPort();
+    const process = new AppServerProcess({
+      brokerHttpBaseUrl: this.options.config.brokerHttpBaseUrl,
+      codexHome,
+      hostCodexHomePath: this.options.config.codexHostHomePath,
+      hostGeminiHomePath: this.options.config.geminiHostHomePath,
+      port,
+      disabledMcpServers: this.options.config.codexDisabledMcpServers,
+      tempadLinkServiceUrl: this.options.config.tempadLinkServiceUrl,
+      geminiHttpProxy: this.options.config.geminiHttpProxy,
+      geminiHttpsProxy: this.options.config.geminiHttpsProxy,
+      geminiAllProxy: this.options.config.geminiAllProxy,
+      bootstrapAuth: false
+    });
+    const client = new AppServerClient({
+      url: process.url,
+      serviceName: `${this.options.config.serviceName}-admin-oauth`,
+      brokerHttpBaseUrl: this.options.config.brokerHttpBaseUrl,
+      reposRoot: this.options.config.reposRoot,
+      personalMemoryFilePath: path.join(codexHome, "AGENT.md")
+    });
+    const attempt: AuthProfileOAuthAttempt = {
+      id,
+      createdAt,
+      rootPath,
+      codexHome,
+      port,
+      profileName: options.name,
+      process,
+      client,
+      status: "starting",
+      updatedAt: createdAt
+    };
+    this.#authProfileOAuthAttempts.set(id, attempt);
+
+    try {
+      await process.start();
+      await client.connect();
+      const login = await client.loginWithChatGptDeviceCode();
+      attempt.loginId = login.loginId;
+      attempt.verificationUrl = login.verificationUrl;
+      attempt.userCode = login.userCode;
+      this.#setAuthProfileOAuthStatus(attempt, "waiting");
+      this.#watchAuthProfileOAuthAttempt(attempt);
+      return {
+        ok: true,
+        attempt: this.#serializeAuthProfileOAuthAttempt(attempt)
+      };
+    } catch (error) {
+      this.#setAuthProfileOAuthStatus(attempt, "failed", error);
+      await this.#cleanupAuthProfileOAuthRuntime(attempt, {
+        removeFiles: true
+      });
+      throw error;
+    }
+  }
+
+  async getAuthProfileOAuthAttempt(options: {
+    readonly id: string;
+  }): Promise<Record<string, unknown>> {
+    const attempt = this.#authProfileOAuthAttempts.get(options.id);
+    if (!attempt) {
+      throw new Error(`Auth OAuth attempt not found: ${options.id}`);
+    }
+
+    return {
+      ok: true,
+      attempt: this.#serializeAuthProfileOAuthAttempt(attempt)
+    };
+  }
+
+  async cancelAuthProfileOAuthAttempt(options: {
+    readonly id: string;
+  }): Promise<Record<string, unknown>> {
+    const attempt = this.#authProfileOAuthAttempts.get(options.id);
+    if (!attempt) {
+      throw new Error(`Auth OAuth attempt not found: ${options.id}`);
+    }
+
+    if (attempt.status === "starting" || attempt.status === "waiting") {
+      if (attempt.client && attempt.loginId) {
+        await attempt.client.cancelLogin(attempt.loginId).catch((error) => {
+          logger.warn("Failed to cancel admin auth profile OAuth login", {
+            attemptId: attempt.id,
+            error: error instanceof Error ? error.message : String(error)
+          });
+        });
+      }
+      this.#setAuthProfileOAuthStatus(attempt, "cancelled");
+      await this.#cleanupAuthProfileOAuthRuntime(attempt, {
+        removeFiles: true
+      });
+    }
+
+    return {
+      ok: true,
+      attempt: this.#serializeAuthProfileOAuthAttempt(attempt)
     };
   }
 
@@ -242,6 +388,171 @@ export class AdminService {
       slackUserId: options.slackUserId,
       status: await this.getStatus()
     };
+  }
+
+  #watchAuthProfileOAuthAttempt(attempt: AuthProfileOAuthAttempt): void {
+    const listener = (method: string, params: Record<string, any> | undefined) => {
+      if (method !== "account/login/completed") {
+        return;
+      }
+
+      const loginId = readUnknownString(params?.loginId) ?? readUnknownString(params?.login_id);
+      if (attempt.loginId && loginId && loginId !== attempt.loginId) {
+        return;
+      }
+
+      void this.#completeAuthProfileOAuthAttempt(attempt, params ?? {});
+    };
+    attempt.notificationListener = listener;
+    attempt.client?.on("notification", listener);
+    attempt.timeout = setTimeout(() => {
+      void this.#failAuthProfileOAuthAttempt(attempt, new Error("ChatGPT device-code login timed out"));
+    }, AUTH_PROFILE_OAUTH_TIMEOUT_MS);
+  }
+
+  async #completeAuthProfileOAuthAttempt(
+    attempt: AuthProfileOAuthAttempt,
+    params: Record<string, unknown>
+  ): Promise<void> {
+    if (attempt.status !== "waiting" && attempt.status !== "starting") {
+      return;
+    }
+
+    const success = params.success === true;
+    if (!success) {
+      await this.#failAuthProfileOAuthAttempt(
+        attempt,
+        new Error(readUnknownString(params.error) ?? "ChatGPT device-code login failed")
+      );
+      return;
+    }
+
+    try {
+      const authJsonPath = path.join(attempt.codexHome, "auth.json");
+      const authJsonContent = await fs.readFile(authJsonPath, "utf8");
+      const profile = await this.options.authProfiles.addProfile({
+        name: attempt.profileName,
+        authJsonContent
+      });
+      attempt.profile = profile;
+      this.#setAuthProfileOAuthStatus(attempt, "succeeded");
+      await this.#cleanupAuthProfileOAuthRuntime(attempt, {
+        removeFiles: true
+      });
+    } catch (error) {
+      await this.#failAuthProfileOAuthAttempt(attempt, error);
+    }
+  }
+
+  async #failAuthProfileOAuthAttempt(
+    attempt: AuthProfileOAuthAttempt,
+    error: unknown
+  ): Promise<void> {
+    if (attempt.status !== "starting" && attempt.status !== "waiting") {
+      return;
+    }
+
+    this.#setAuthProfileOAuthStatus(attempt, "failed", error);
+    await this.#cleanupAuthProfileOAuthRuntime(attempt, {
+      removeFiles: true
+    });
+  }
+
+  #setAuthProfileOAuthStatus(
+    attempt: AuthProfileOAuthAttempt,
+    status: AuthProfileOAuthStatus,
+    error?: unknown
+  ): void {
+    attempt.status = status;
+    attempt.updatedAt = new Date().toISOString();
+    if (error !== undefined) {
+      attempt.error = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  async #cleanupAuthProfileOAuthRuntime(
+    attempt: AuthProfileOAuthAttempt,
+    options: {
+      readonly removeFiles: boolean;
+    }
+  ): Promise<void> {
+    if (attempt.timeout) {
+      clearTimeout(attempt.timeout);
+      attempt.timeout = undefined;
+    }
+
+    if (attempt.client && attempt.notificationListener) {
+      attempt.client.off("notification", attempt.notificationListener);
+      attempt.notificationListener = undefined;
+    }
+
+    const client = attempt.client;
+    const process = attempt.process;
+    attempt.client = undefined;
+    attempt.process = undefined;
+
+    await client?.close().catch((error) => {
+      logger.warn("Failed to close admin auth profile OAuth app-server client", {
+        attemptId: attempt.id,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    });
+    await process?.stop().catch((error) => {
+      logger.warn("Failed to stop admin auth profile OAuth app-server process", {
+        attemptId: attempt.id,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    });
+
+    if (options.removeFiles) {
+      await fs.rm(attempt.rootPath, {
+        recursive: true,
+        force: true
+      }).catch((error) => {
+        logger.warn("Failed to remove admin auth profile OAuth temp directory", {
+          attemptId: attempt.id,
+          rootPath: attempt.rootPath,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      });
+    }
+  }
+
+  #serializeAuthProfileOAuthAttempt(attempt: AuthProfileOAuthAttempt): Record<string, unknown> {
+    return {
+      id: attempt.id,
+      status: attempt.status,
+      profileName: attempt.profileName ?? null,
+      loginId: attempt.loginId ?? null,
+      verificationUrl: attempt.verificationUrl ?? null,
+      userCode: attempt.userCode ?? null,
+      error: attempt.error ?? null,
+      profile: attempt.profile ?? null,
+      createdAt: attempt.createdAt,
+      updatedAt: attempt.updatedAt,
+      port: attempt.port
+    };
+  }
+
+  #listAuthProfileOAuthAttempts(): readonly Record<string, unknown>[] {
+    return [...this.#authProfileOAuthAttempts.values()]
+      .sort((left, right) => String(right.updatedAt).localeCompare(String(left.updatedAt)))
+      .map((attempt) => this.#serializeAuthProfileOAuthAttempt(attempt));
+  }
+
+  async #pruneAuthProfileOAuthAttempts(): Promise<void> {
+    const cutoff = Date.now() - AUTH_PROFILE_OAUTH_ATTEMPT_RETENTION_MS;
+    for (const attempt of this.#authProfileOAuthAttempts.values()) {
+      const updatedAtMs = Date.parse(attempt.updatedAt);
+      if (
+        Number.isFinite(updatedAtMs) &&
+        updatedAtMs < cutoff &&
+        attempt.status !== "starting" &&
+        attempt.status !== "waiting"
+      ) {
+        this.#authProfileOAuthAttempts.delete(attempt.id);
+      }
+    }
   }
 
   async #readAccountSummary(): Promise<SerializedAccountStatus> {
@@ -417,4 +728,37 @@ function isHumanInboundMessage(message: PersistedInboundMessage): boolean {
     message.source === "direct_message" ||
     message.source === "thread_reply"
   );
+}
+
+async function findFreeTcpPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : null;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        if (!port) {
+          reject(new Error("Failed to allocate a temporary TCP port"));
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+  });
+}
+
+function readUnknownString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
 }

--- a/src/services/auth-pool-service.ts
+++ b/src/services/auth-pool-service.ts
@@ -1,0 +1,471 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { AppConfig } from "../config.js";
+import { ensureDir, fileExists } from "../utils/fs.js";
+
+interface StoredAuthTokens {
+  readonly id_token?: string | undefined;
+  readonly access_token?: string | undefined;
+  readonly refresh_token?: string | undefined;
+  readonly account_id?: string | undefined;
+}
+
+interface StoredAuthJson {
+  readonly auth_mode?: string | undefined;
+  readonly OPENAI_API_KEY?: string | null | undefined;
+  readonly tokens?: StoredAuthTokens | undefined;
+  readonly last_refresh?: string | null | undefined;
+}
+
+interface RefreshResponsePayload {
+  readonly id_token?: string | undefined;
+  readonly access_token?: string | undefined;
+  readonly refresh_token?: string | undefined;
+}
+
+interface AuthPoolState {
+  readonly version: 1;
+  readonly assignments?: Record<string, string> | undefined;
+  readonly profiles?: Record<string, AuthPoolProfileState> | undefined;
+}
+
+interface AuthPoolProfileState {
+  readonly weight?: number | undefined;
+  readonly cooldownUntil?: string | undefined;
+  readonly lastError?: string | undefined;
+  readonly updatedAt?: string | undefined;
+}
+
+interface ProfileFile {
+  readonly name: string;
+  readonly path: string;
+}
+
+export interface AuthPoolTokenSet {
+  readonly profileName: string;
+  readonly accessToken: string;
+  readonly chatgptAccountId: string;
+  readonly chatgptPlanType: string | null;
+}
+
+export interface AuthPoolLease {
+  readonly tokens: AuthPoolTokenSet;
+  readonly release: () => void;
+}
+
+type FetchLike = typeof fetch;
+
+const TOKEN_REFRESH_URL = "https://auth.openai.com/oauth/token";
+const TOKEN_REFRESH_URL_OVERRIDE_ENV = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+const CODEX_CHATGPT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+
+export class AuthPoolService {
+  readonly #dataRoot: string;
+  readonly #profilesRoot: string;
+  readonly #statePath: string;
+  readonly #refreshInflight = new Map<string, Promise<AuthPoolTokenSet>>();
+  readonly #runtimeInflight = new Map<string, number>();
+  #stateWriteQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly options: {
+      readonly config: AppConfig;
+      readonly fetch?: FetchLike | undefined;
+    }
+  ) {
+    this.#dataRoot = path.dirname(options.config.stateDir);
+    this.#profilesRoot = path.join(this.#dataRoot, "auth-profiles", "docker", "profiles");
+    this.#statePath = path.join(options.config.stateDir, "auth-pool.json");
+  }
+
+  get enabled(): boolean {
+    return this.options.config.authPoolLbMode === "on" || this.options.config.authPoolLbMode === "shadow";
+  }
+
+  get mode(): AppConfig["authPoolLbMode"] {
+    return this.options.config.authPoolLbMode;
+  }
+
+  async leaseForSession(sessionKey: string): Promise<AuthPoolLease | null> {
+    if (this.mode === "off") {
+      return null;
+    }
+
+    const profile = await this.#selectProfile(sessionKey);
+    if (!profile) {
+      return null;
+    }
+
+    const tokens = await this.#refreshProfile(profile.name, {
+      force: false
+    });
+    this.#incrementInflight(profile.name);
+    let released = false;
+    return {
+      tokens,
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.#decrementInflight(profile.name);
+      }
+    };
+  }
+
+  async refreshForPreviousAccount(previousAccountId: string | null | undefined): Promise<AuthPoolTokenSet> {
+    const profiles = await this.#listProfiles();
+    if (profiles.length === 0) {
+      throw new Error("auth_pool_has_no_profiles");
+    }
+
+    if (previousAccountId) {
+      for (const profile of profiles) {
+        const auth = await this.#readAuth(profile.path).catch(() => null);
+        const accountId = auth?.tokens?.account_id?.trim();
+        if (accountId === previousAccountId) {
+          return await this.#refreshProfile(profile.name, {
+            force: true
+          });
+        }
+      }
+    }
+
+    const profile = await this.#selectProfile(previousAccountId ?? "external-refresh");
+    if (!profile) {
+      throw new Error("auth_pool_has_no_usable_profile");
+    }
+
+    return await this.#refreshProfile(profile.name, {
+      force: true
+    });
+  }
+
+  async markProfileFailure(profileName: string, error: string): Promise<void> {
+    const cooldownUntil = new Date(Date.now() + 60_000).toISOString();
+    await this.#updateState((state) => ({
+      ...state,
+      profiles: {
+        ...state.profiles,
+        [profileName]: {
+          ...state.profiles?.[profileName],
+          cooldownUntil,
+          lastError: error,
+          updatedAt: new Date().toISOString()
+        }
+      }
+    }));
+  }
+
+  async #selectProfile(sessionKey: string): Promise<ProfileFile | null> {
+    const profiles = await this.#listProfiles();
+    if (profiles.length === 0) {
+      return null;
+    }
+
+    const state = await this.#readState();
+    const profileByName = new Map(profiles.map((profile) => [profile.name, profile]));
+    const assignedName = state.assignments?.[sessionKey];
+    if (assignedName) {
+      const assigned = profileByName.get(assignedName);
+      if (assigned && this.#isProfileAvailable(assigned.name, state)) {
+        return assigned;
+      }
+    }
+
+    const available = profiles.filter((profile) => this.#isProfileAvailable(profile.name, state));
+    const candidates = available.length > 0 ? available : profiles;
+    const selected = candidates
+      .map((profile) => ({
+        profile,
+        score: this.#scoreProfile(profile.name, state, sessionKey)
+      }))
+      .sort((left, right) =>
+        right.score - left.score ||
+        stableHash(`${sessionKey}:${left.profile.name}`) - stableHash(`${sessionKey}:${right.profile.name}`)
+      )[0]?.profile ?? null;
+
+    if (selected) {
+      await this.#updateState((current) => ({
+        ...current,
+        assignments: {
+          ...current.assignments,
+          [sessionKey]: selected.name
+        }
+      }));
+    }
+
+    return selected;
+  }
+
+  #isProfileAvailable(profileName: string, state: AuthPoolState): boolean {
+    const cooldownUntil = state.profiles?.[profileName]?.cooldownUntil;
+    if (!cooldownUntil) {
+      return true;
+    }
+
+    return Date.parse(cooldownUntil) <= Date.now();
+  }
+
+  #scoreProfile(profileName: string, state: AuthPoolState, sessionKey: string): number {
+    const profileState = state.profiles?.[profileName];
+    const weight = profileState?.weight && profileState.weight > 0 ? profileState.weight : 1;
+    const inflight = this.#runtimeInflight.get(profileName) ?? 0;
+    const jitter = (stableHash(`${sessionKey}:${profileName}`) % 1_000) / 1_000_000;
+    return weight - inflight * 2 + jitter;
+  }
+
+  async #refreshProfile(
+    profileName: string,
+    options: {
+      readonly force: boolean;
+    }
+  ): Promise<AuthPoolTokenSet> {
+    const inflight = this.#refreshInflight.get(profileName);
+    if (inflight) {
+      return await inflight;
+    }
+
+    const promise = this.#refreshProfileImpl(profileName, options);
+    this.#refreshInflight.set(profileName, promise);
+    try {
+      return await promise;
+    } finally {
+      this.#refreshInflight.delete(profileName);
+    }
+  }
+
+  async #refreshProfileImpl(
+    profileName: string,
+    options: {
+      readonly force: boolean;
+    }
+  ): Promise<AuthPoolTokenSet> {
+    const profilePath = path.join(this.#profilesRoot, `${profileName}.json`);
+    let auth = await this.#readAuth(profilePath);
+    if (!options.force && auth.tokens?.access_token && !isAccessTokenNearExpiry(auth.tokens.access_token)) {
+      return tokensFromAuth(profileName, auth);
+    }
+
+    const refreshToken = auth.tokens?.refresh_token?.trim();
+    if (!refreshToken) {
+      throw new Error(`Auth profile ${profileName} is missing refresh_token`);
+    }
+
+    try {
+      const refreshResponse = await this.#requestTokenRefresh(refreshToken);
+      auth = {
+        ...auth,
+        tokens: {
+          ...auth.tokens,
+          ...(refreshResponse.id_token ? { id_token: refreshResponse.id_token } : {}),
+          ...(refreshResponse.access_token ? { access_token: refreshResponse.access_token } : {}),
+          ...(refreshResponse.refresh_token ? { refresh_token: refreshResponse.refresh_token } : {})
+        },
+        last_refresh: new Date().toISOString()
+      };
+      await writeAuth(profilePath, auth);
+      await this.#clearProfileFailure(profileName);
+      return tokensFromAuth(profileName, auth);
+    } catch (error) {
+      await this.markProfileFailure(profileName, error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+  }
+
+  async #requestTokenRefresh(refreshToken: string): Promise<RefreshResponsePayload> {
+    const fetchImpl = this.options.fetch ?? fetch;
+    const response = await fetchImpl(process.env[TOKEN_REFRESH_URL_OVERRIDE_ENV] ?? TOKEN_REFRESH_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        client_id: CODEX_CHATGPT_CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken
+      }),
+      signal: AbortSignal.timeout(20_000)
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`ChatGPT token refresh failed (${response.status}): ${body || response.statusText}`);
+    }
+
+    return (await response.json()) as RefreshResponsePayload;
+  }
+
+  async #clearProfileFailure(profileName: string): Promise<void> {
+    await this.#updateState((state) => ({
+      ...state,
+      profiles: {
+        ...state.profiles,
+        [profileName]: {
+          ...state.profiles?.[profileName],
+          cooldownUntil: undefined,
+          lastError: undefined,
+          updatedAt: new Date().toISOString()
+        }
+      }
+    }));
+  }
+
+  async #listProfiles(): Promise<ProfileFile[]> {
+    if (!(await fileExists(this.#profilesRoot))) {
+      return [];
+    }
+
+    const entries = await fs.readdir(this.#profilesRoot, { withFileTypes: true });
+    const profiles = entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => ({
+        name: path.basename(entry.name, ".json"),
+        path: path.join(this.#profilesRoot, entry.name)
+      }))
+      .sort((left, right) => left.name.localeCompare(right.name));
+    return profiles;
+  }
+
+  async #readAuth(authJsonPath: string): Promise<StoredAuthJson> {
+    const raw = await fs.readFile(authJsonPath, "utf8");
+    return JSON.parse(raw) as StoredAuthJson;
+  }
+
+  async #readState(): Promise<AuthPoolState> {
+    try {
+      const raw = await fs.readFile(this.#statePath, "utf8");
+      return normalizeState(JSON.parse(raw) as Partial<AuthPoolState>);
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        return {
+          version: 1,
+          assignments: {},
+          profiles: {}
+        };
+      }
+
+      throw error;
+    }
+  }
+
+  async #updateState(update: (state: AuthPoolState) => AuthPoolState): Promise<void> {
+    const run = this.#stateWriteQueue
+      .catch(() => {})
+      .then(async () => {
+        const state = await this.#readState();
+        const next = normalizeState(update(state));
+        await ensureDir(path.dirname(this.#statePath));
+        await fs.writeFile(this.#statePath, `${JSON.stringify(next, null, 2)}\n`, {
+          mode: 0o600
+        });
+      });
+    this.#stateWriteQueue = run;
+    await run;
+  }
+
+  #incrementInflight(profileName: string): void {
+    this.#runtimeInflight.set(profileName, (this.#runtimeInflight.get(profileName) ?? 0) + 1);
+  }
+
+  #decrementInflight(profileName: string): void {
+    const next = Math.max(0, (this.#runtimeInflight.get(profileName) ?? 0) - 1);
+    if (next === 0) {
+      this.#runtimeInflight.delete(profileName);
+      return;
+    }
+    this.#runtimeInflight.set(profileName, next);
+  }
+}
+
+function normalizeState(state: Partial<AuthPoolState>): AuthPoolState {
+  return {
+    version: 1,
+    assignments: state.assignments ?? {},
+    profiles: state.profiles ?? {}
+  };
+}
+
+function tokensFromAuth(profileName: string, auth: StoredAuthJson): AuthPoolTokenSet {
+  const accessToken = auth.tokens?.access_token?.trim();
+  if (!accessToken) {
+    throw new Error(`Auth profile ${profileName} is missing access_token`);
+  }
+
+  const chatgptAccountId = auth.tokens?.account_id?.trim();
+  if (!chatgptAccountId) {
+    throw new Error(`Auth profile ${profileName} is missing account_id`);
+  }
+
+  return {
+    profileName,
+    accessToken,
+    chatgptAccountId,
+    chatgptPlanType: parseChatGptPlanType(auth.tokens?.id_token) ?? parseChatGptPlanType(accessToken)
+  };
+}
+
+function isAccessTokenNearExpiry(accessToken: string): boolean {
+  const expiresAt = parseJwtExpiration(accessToken);
+  return typeof expiresAt === "number" && expiresAt <= Date.now() + REFRESH_LEEWAY_MS;
+}
+
+function parseJwtExpiration(jwt: string): number | null {
+  const payload = jwt.split(".")[1];
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      readonly exp?: unknown;
+    };
+    return typeof parsed.exp === "number" ? parsed.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseChatGptPlanType(jwt: string | undefined): string | null {
+  const payload = jwt?.split(".")[1];
+  if (!payload) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      readonly "https://api.openai.com/auth"?: {
+        readonly chatgpt_plan_type?: unknown;
+      };
+      readonly chatgpt_plan_type?: unknown;
+    };
+    const planType =
+      parsed["https://api.openai.com/auth"]?.chatgpt_plan_type ??
+      parsed.chatgpt_plan_type;
+    return typeof planType === "string" && planType.trim() ? planType.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function stableHash(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+async function writeAuth(authJsonPath: string, auth: StoredAuthJson): Promise<void> {
+  const stat = await fs.stat(authJsonPath).catch(() => null);
+  const tempPath = path.join(
+    path.dirname(authJsonPath),
+    `.${path.basename(authJsonPath)}.${process.pid}.${Date.now()}.tmp`
+  );
+  await fs.writeFile(tempPath, `${JSON.stringify(auth, null, 2)}\n`, {
+    mode: stat ? stat.mode & 0o777 : 0o600
+  });
+  await fs.rename(tempPath, authJsonPath);
+}

--- a/src/services/codex/app-server-client.ts
+++ b/src/services/codex/app-server-client.ts
@@ -63,6 +63,12 @@ export interface ChatGptAuthTokensProvider {
   readonly refresh: (context: ChatGptAuthTokensRefreshContext) => Promise<ChatGptAuthTokenSet>;
 }
 
+export interface ChatGptDeviceCodeLogin {
+  readonly loginId: string;
+  readonly verificationUrl: string;
+  readonly userCode: string;
+}
+
 interface BufferedTurnEvents {
   text: string;
   terminalState: "completed" | "aborted" | null;
@@ -263,6 +269,31 @@ export class AppServerClient extends EventEmitter {
       chatgptAccountId: tokens.chatgptAccountId,
       chatgptPlanType: tokens.chatgptPlanType
     });
+  }
+
+  async loginWithChatGptDeviceCode(): Promise<ChatGptDeviceCodeLogin> {
+    const login = await this.request("account/login/start", {
+      type: "chatgptDeviceCode"
+    }) as Record<string, unknown>;
+    const loginId = readResponseString(login, "loginId", "login_id");
+    const verificationUrl = readResponseString(login, "verificationUrl", "verification_url");
+    const userCode = readResponseString(login, "userCode", "user_code");
+    if (!loginId || !verificationUrl || !userCode) {
+      throw new Error("Codex app-server returned an invalid ChatGPT device-code login response");
+    }
+
+    return {
+      loginId,
+      verificationUrl,
+      userCode
+    };
+  }
+
+  async cancelLogin(loginId: string): Promise<string | null> {
+    const result = await this.request("account/login/cancel", {
+      loginId
+    }) as Record<string, unknown>;
+    return readResponseString(result, "status");
   }
 
   async readAccountSummary(refreshToken = false): Promise<AppServerAccountSummary> {
@@ -982,6 +1013,19 @@ function normalizeCreditsSnapshot(credits: RawCreditsSnapshot | null | undefined
     unlimited: Boolean(credits.unlimited),
     balance: credits.balance ?? null
   };
+}
+
+function readResponseString(
+  response: Record<string, unknown>,
+  ...keys: readonly string[]
+): string | null {
+  for (const key of keys) {
+    const value = response[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
 }
 
 function normalizeGeneratedImageArtifact(

--- a/src/services/codex/app-server-client.ts
+++ b/src/services/codex/app-server-client.ts
@@ -48,6 +48,21 @@ interface ActiveTurn {
   reject: (error: Error) => void;
 }
 
+export interface ChatGptAuthTokenSet {
+  readonly accessToken: string;
+  readonly chatgptAccountId: string;
+  readonly chatgptPlanType: string | null;
+}
+
+export interface ChatGptAuthTokensRefreshContext {
+  readonly reason: "unauthorized";
+  readonly previousAccountId: string | null;
+}
+
+export interface ChatGptAuthTokensProvider {
+  readonly refresh: (context: ChatGptAuthTokensRefreshContext) => Promise<ChatGptAuthTokenSet>;
+}
+
 interface BufferedTurnEvents {
   text: string;
   terminalState: "completed" | "aborted" | null;
@@ -147,6 +162,7 @@ export class AppServerClient extends EventEmitter {
       readonly openAiApiKey?: string | undefined;
       readonly personalMemoryFilePath?: string | undefined;
       readonly heartbeatIntervalMs?: number | undefined;
+      readonly chatGptAuthTokensProvider?: ChatGptAuthTokensProvider | undefined;
     }
   ) {
     super();
@@ -237,6 +253,15 @@ export class AppServerClient extends EventEmitter {
     await this.request("account/login/start", {
       type: "apiKey",
       apiKey: this.options.openAiApiKey
+    });
+  }
+
+  async loginWithChatGptAuthTokens(tokens: ChatGptAuthTokenSet): Promise<void> {
+    await this.request("account/login/start", {
+      type: "chatgptAuthTokens",
+      accessToken: tokens.accessToken,
+      chatgptAccountId: tokens.chatgptAccountId,
+      chatgptPlanType: tokens.chatgptPlanType
     });
   }
 
@@ -566,6 +591,10 @@ export class AppServerClient extends EventEmitter {
 
     if (message.id) {
       const pending = this.#pendingRequests.get(message.id);
+      if (!pending && message.method) {
+        void this.#handleServerRequest(message.id, message.method, message.params ?? {});
+        return;
+      }
       if (!pending) {
         return;
       }
@@ -589,6 +618,69 @@ export class AppServerClient extends EventEmitter {
 
     this.emit("notification", message.method, message.params);
     this.#handleTurnEvent(message.method, message.params ?? {});
+  }
+
+  async #handleServerRequest(
+    requestId: string,
+    method: string,
+    params: Record<string, any>
+  ): Promise<void> {
+    try {
+      if (method !== "account/chatgptAuthTokens/refresh") {
+        await this.#sendRpcError(requestId, `Unsupported app-server request: ${method}`);
+        return;
+      }
+
+      if (!this.options.chatGptAuthTokensProvider) {
+        await this.#sendRpcError(requestId, "ChatGPT auth token provider is not configured");
+        return;
+      }
+
+      const refreshed = await this.options.chatGptAuthTokensProvider.refresh({
+        reason: params.reason === "unauthorized" ? "unauthorized" : "unauthorized",
+        previousAccountId: typeof params.previousAccountId === "string" ? params.previousAccountId : null
+      });
+      await this.#sendRpcResult(requestId, {
+        accessToken: refreshed.accessToken,
+        chatgptAccountId: refreshed.chatgptAccountId,
+        chatgptPlanType: refreshed.chatgptPlanType
+      });
+    } catch (error) {
+      await this.#sendRpcError(requestId, error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async #sendRpcResult(requestId: string, result: JsonValue): Promise<void> {
+    await this.#sendRawRpc({
+      id: requestId,
+      result
+    });
+  }
+
+  async #sendRpcError(requestId: string, message: string): Promise<void> {
+    await this.#sendRawRpc({
+      id: requestId,
+      error: {
+        code: -32000,
+        message
+      }
+    });
+  }
+
+  async #sendRawRpc(payload: JsonValue): Promise<void> {
+    if (!this.#socket || this.#socket.readyState !== WebSocket.OPEN) {
+      throw new Error("Codex app-server websocket is not connected");
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      this.#socket?.send(JSON.stringify(payload), (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
   }
 
   #handleTurnEvent(method: string, params: Record<string, any>): void {

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -26,6 +26,7 @@ export class AppServerProcess {
   readonly #geminiHttpProxy: string | undefined;
   readonly #geminiHttpsProxy: string | undefined;
   readonly #geminiAllProxy: string | undefined;
+  readonly #bootstrapAuth: boolean;
   #child: ChildProcessByStdio<null, Readable, Readable> | undefined;
   #homePrepared = false;
 
@@ -42,6 +43,7 @@ export class AppServerProcess {
     readonly geminiHttpProxy?: string | undefined;
     readonly geminiHttpsProxy?: string | undefined;
     readonly geminiAllProxy?: string | undefined;
+    readonly bootstrapAuth?: boolean | undefined;
   }) {
     this.#brokerHttpBaseUrl = options.brokerHttpBaseUrl;
     this.#codexHome = options.codexHome;
@@ -56,6 +58,7 @@ export class AppServerProcess {
     this.#geminiHttpProxy = options.geminiHttpProxy;
     this.#geminiHttpsProxy = options.geminiHttpsProxy;
     this.#geminiAllProxy = options.geminiAllProxy;
+    this.#bootstrapAuth = options.bootstrapAuth ?? true;
   }
 
   get url(): string {
@@ -68,7 +71,9 @@ export class AppServerProcess {
     }
 
     await this.#prepareCodexHome();
-    await this.#bootstrapAuth();
+    if (this.#bootstrapAuth) {
+      await this.#bootstrapAuthFromExisting();
+    }
     await this.#disableConfiguredMcpServers();
     await this.#ensureGitCommitHook();
     const tempadLinkServiceUrl = await this.#resolveTempadLinkServiceUrl();
@@ -182,7 +187,7 @@ export class AppServerProcess {
     this.#homePrepared = true;
   }
 
-  async #bootstrapAuth(): Promise<void> {
+  async #bootstrapAuthFromExisting(): Promise<void> {
     const authTarget = path.join(this.#codexHome, "auth.json");
 
     if (await fileExists(authTarget)) {

--- a/src/services/codex/codex-broker.ts
+++ b/src/services/codex/codex-broker.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { AppServerClient } from "./app-server-client.js";
 import { AppServerProcess } from "./app-server-process.js";
 import type { SlackSessionRecord, SlackUserIdentity } from "../../types.js";
+import type { AuthPoolLease } from "../auth-pool-service.js";
+import type { AuthPoolService } from "../auth-pool-service.js";
 import type {
   AppServerAccountSummary,
   CodexInputItem,
@@ -26,9 +28,11 @@ export class CodexBroker extends EventEmitter {
   readonly #personalMemoryFilePath: string;
   readonly #reposRoot: string;
   readonly #codexGeneratedImagesRoot: string;
+  readonly #authPool?: AuthPoolService | undefined;
   #slackBotIdentity: SlackUserIdentity | null = null;
   #reconnectPromise: Promise<void> | undefined;
   #connectQueue: Promise<void> = Promise.resolve();
+  #authTurnQueue: Promise<void> = Promise.resolve();
   #stopping = false;
   readonly #ignoredDisconnectClients = new WeakSet<AppServerClient>();
 
@@ -48,6 +52,7 @@ export class CodexBroker extends EventEmitter {
     readonly geminiHttpsProxy?: string | undefined;
     readonly geminiAllProxy?: string | undefined;
     readonly openAiApiKey?: string | undefined;
+    readonly authPool?: AuthPoolService | undefined;
   }) {
     super();
     this.#serviceName = options.serviceName;
@@ -57,6 +62,7 @@ export class CodexBroker extends EventEmitter {
     this.#personalMemoryFilePath = getPersonalMemoryPath(options.codexHome);
     this.#reposRoot = options.reposRoot;
     this.#codexGeneratedImagesRoot = path.join(options.codexHome, "generated_images");
+    this.#authPool = options.authPool;
 
     if (options.codexAppServerUrl) {
       this.#client = this.#createClient(options.codexAppServerUrl);
@@ -117,6 +123,10 @@ export class CodexBroker extends EventEmitter {
   async startTurn(session: SlackSessionRecord, input: readonly CodexInputItem[]): Promise<StartedTurn> {
     if (!session.codexThreadId) {
       throw new Error(`Session ${session.key} has no Codex thread id`);
+    }
+
+    if (this.#authPool?.mode === "on") {
+      return await this.#startTurnWithAuthPool(session, input);
     }
 
     return await this.#withRecovery(() =>
@@ -181,10 +191,69 @@ export class CodexBroker extends EventEmitter {
       openAiApiKey: this.#openAiApiKey,
       personalMemoryFilePath: this.#personalMemoryFilePath,
       reposRoot: this.#reposRoot,
-      codexGeneratedImagesRoot: this.#codexGeneratedImagesRoot
+      codexGeneratedImagesRoot: this.#codexGeneratedImagesRoot,
+      chatGptAuthTokensProvider: this.#authPool
+        ? {
+            refresh: async (context) => {
+              const tokens = await this.#authPool!.refreshForPreviousAccount(context.previousAccountId);
+              return {
+                accessToken: tokens.accessToken,
+                chatgptAccountId: tokens.chatgptAccountId,
+                chatgptPlanType: tokens.chatgptPlanType
+              };
+            }
+          }
+        : undefined
     });
     client.setSlackBotIdentity(this.#slackBotIdentity);
     return client;
+  }
+
+  async #startTurnWithAuthPool(
+    session: SlackSessionRecord,
+    input: readonly CodexInputItem[]
+  ): Promise<StartedTurn> {
+    const previousTurn = this.#authTurnQueue.catch(() => {});
+    let unlock!: () => void;
+    const currentTurnGate = new Promise<void>((resolve) => {
+      unlock = resolve;
+    });
+    this.#authTurnQueue = previousTurn.then(() => currentTurnGate);
+    await previousTurn;
+
+    let lease: AuthPoolLease | null = null;
+    try {
+      lease = await this.#authPool!.leaseForSession(session.key);
+      if (lease) {
+        logger.info("Using Auth Pool profile for Codex turn", {
+          sessionKey: session.key,
+          profileName: lease.tokens.profileName
+        });
+        await this.#withRecovery(() =>
+          this.#client.loginWithChatGptAuthTokens({
+            accessToken: lease!.tokens.accessToken,
+            chatgptAccountId: lease!.tokens.chatgptAccountId,
+            chatgptPlanType: lease!.tokens.chatgptPlanType
+          })
+        );
+      }
+
+      const started = await this.#withRecovery(() =>
+        this.#client.startTurn(session.codexThreadId!, session.workspacePath, input)
+      );
+      const completion = started.completion.finally(() => {
+        lease?.release();
+        unlock();
+      });
+      return {
+        turnId: started.turnId,
+        completion
+      };
+    } catch (error) {
+      lease?.release();
+      unlock();
+      throw error;
+    }
   }
 
   #bindClient(client: AppServerClient): void {

--- a/src/worker-index.ts
+++ b/src/worker-index.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import { loadConfig } from "./config.js";
 import { createHttpHandler } from "./http/router.js";
 import { configureLogger, logger } from "./logger.js";
+import { AuthPoolService } from "./services/auth-pool-service.js";
 import { CodexBroker } from "./services/codex/codex-broker.js";
 import { IsolatedMcpService } from "./services/codex/isolated-mcp-service.js";
 import { GitHubAuthorMappingService } from "./services/github-author-mapping-service.js";
@@ -32,6 +33,9 @@ export async function startWorkerService(): Promise<{
     stateDir: config.stateDir
   });
   await githubAuthorMappings.load();
+  const authPool = new AuthPoolService({
+    config
+  });
   const codexBroker = new CodexBroker({
     serviceName: config.serviceName,
     brokerHttpBaseUrl: config.brokerHttpBaseUrl,
@@ -47,7 +51,8 @@ export async function startWorkerService(): Promise<{
     geminiHttpProxy: config.geminiHttpProxy,
     geminiHttpsProxy: config.geminiHttpsProxy,
     geminiAllProxy: config.geminiAllProxy,
-    openAiApiKey: config.codexOpenAiApiKey
+    openAiApiKey: config.codexOpenAiApiKey,
+    authPool
   });
   const bridge = new SlackCodexBridge({
     config,

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -204,6 +204,59 @@ describe("AppServerClient disconnect handling", () => {
     });
   });
 
+  it("starts and cancels ChatGPT device-code login", async () => {
+    const requests: string[] = [];
+    const server = await createServer((socket, message) => {
+      if (message.method === "initialize") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { ok: true }
+        }));
+        return;
+      }
+
+      requests.push(message.method ?? "");
+      if (message.method === "account/login/start") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: {
+            loginId: "login-1",
+            verificationUrl: "https://chatgpt.example/codex/device",
+            userCode: "CODE-1234"
+          }
+        }));
+        return;
+      }
+
+      if (message.method === "account/login/cancel") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: {
+            status: "canceled"
+          }
+        }));
+      }
+    });
+    servers.push(server);
+
+    const client = new AppServerClient({
+      url: server.url,
+      serviceName: "test",
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      reposRoot: "/tmp/repos"
+    });
+
+    await client.connect();
+
+    await expect(client.loginWithChatGptDeviceCode()).resolves.toEqual({
+      loginId: "login-1",
+      verificationUrl: "https://chatgpt.example/codex/device",
+      userCode: "CODE-1234"
+    });
+    await expect(client.cancelLogin("login-1")).resolves.toBe("canceled");
+    expect(requests).toEqual(["account/login/start", "account/login/cancel"]);
+  });
+
   it("buffers turn events that arrive before startTurn finishes registering the turn", async () => {
     const server = await createServer((socket, message) => {
       if (message.method === "initialize") {

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -144,6 +144,66 @@ describe("AppServerClient disconnect handling", () => {
     await expect(started.completion).rejects.toThrow(/closed/i);
   });
 
+  it("responds to app-server ChatGPT auth token refresh requests", async () => {
+    let resolveRefreshResponse!: (value: Record<string, unknown>) => void;
+    const refreshResponse = new Promise<Record<string, unknown>>((resolve) => {
+      resolveRefreshResponse = resolve;
+    });
+    const server = await createServer((socket, message) => {
+      if (message.method === "initialize") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { ok: true }
+        }));
+        socket.send(JSON.stringify({
+          id: "server-refresh-1",
+          method: "account/chatgptAuthTokens/refresh",
+          params: {
+            reason: "unauthorized",
+            previousAccountId: "account-1"
+          }
+        }));
+        return;
+      }
+
+      if (message.id === "server-refresh-1") {
+        resolveRefreshResponse(message as Record<string, unknown>);
+      }
+    });
+    servers.push(server);
+
+    const client = new AppServerClient({
+      url: server.url,
+      serviceName: "test",
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      reposRoot: "/tmp/repos",
+      chatGptAuthTokensProvider: {
+        refresh: async (context) => {
+          expect(context).toEqual({
+            reason: "unauthorized",
+            previousAccountId: "account-1"
+          });
+          return {
+            accessToken: "new-access",
+            chatgptAccountId: "account-1",
+            chatgptPlanType: "pro"
+          };
+        }
+      }
+    });
+
+    await client.connect();
+
+    await expect(refreshResponse).resolves.toMatchObject({
+      id: "server-refresh-1",
+      result: {
+        accessToken: "new-access",
+        chatgptAccountId: "account-1",
+        chatgptPlanType: "pro"
+      }
+    });
+  });
+
   it("buffers turn events that arrive before startTurn finishes registering the turn", async () => {
     const server = await createServer((socket, message) => {
       if (message.method === "initialize") {

--- a/test/auth-pool-service.test.ts
+++ b/test/auth-pool-service.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+import { AuthPoolService } from "../src/services/auth-pool-service.js";
+
+describe("AuthPoolService", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((directory) =>
+        fs.rm(directory, {
+          recursive: true,
+          force: true
+        })
+      )
+    );
+  });
+
+  it("leases a sticky profile for a session", async () => {
+    const { config, profilesRoot } = await createPoolFixture();
+    await writeProfile(profilesRoot, "alpha", {
+      account_id: "account-alpha",
+      access_token: jwtWithExpiration(Math.floor(Date.now() / 1000) + 3600),
+      refresh_token: "refresh-alpha"
+    });
+    await writeProfile(profilesRoot, "bravo", {
+      account_id: "account-bravo",
+      access_token: jwtWithExpiration(Math.floor(Date.now() / 1000) + 3600),
+      refresh_token: "refresh-bravo"
+    });
+    const pool = new AuthPoolService({
+      config
+    });
+
+    const first = await pool.leaseForSession("session-1");
+    const second = await pool.leaseForSession("session-1");
+    first?.release();
+    second?.release();
+
+    expect(first?.tokens.profileName).toBeTruthy();
+    expect(second?.tokens.profileName).toBe(first?.tokens.profileName);
+  });
+
+  it("refreshes a shared profile once and atomically writes rotated tokens", async () => {
+    const { config, profilesRoot } = await createPoolFixture();
+    await writeProfile(profilesRoot, "alpha", {
+      account_id: "account-alpha",
+      access_token: jwtWithExpiration(Math.floor(Date.now() / 1000) - 60),
+      refresh_token: "old-refresh"
+    });
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        id_token: jwtWithPlan("pro")
+      }), {
+        headers: {
+          "Content-Type": "application/json"
+        }
+      })
+    );
+    const pool = new AuthPoolService({
+      config,
+      fetch: fetchMock as typeof fetch
+    });
+
+    const [left, right] = await Promise.all([
+      pool.refreshForPreviousAccount("account-alpha"),
+      pool.refreshForPreviousAccount("account-alpha")
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(left.accessToken).toBe("new-access");
+    expect(right.accessToken).toBe("new-access");
+    expect(left.chatgptPlanType).toBe("pro");
+    const written = JSON.parse(await fs.readFile(path.join(profilesRoot, "alpha.json"), "utf8")) as {
+      readonly tokens: Record<string, string>;
+      readonly last_refresh?: string;
+    };
+    expect(written.tokens.refresh_token).toBe("new-refresh");
+    expect(written.last_refresh).toEqual(expect.any(String));
+  });
+
+  async function createPoolFixture() {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "auth-pool-"));
+    tempDirs.push(dataRoot);
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot,
+      AUTH_POOL_LB: "on"
+    } as NodeJS.ProcessEnv);
+    const profilesRoot = path.join(dataRoot, "auth-profiles", "docker", "profiles");
+    await fs.mkdir(profilesRoot, {
+      recursive: true
+    });
+    return {
+      config,
+      profilesRoot
+    };
+  }
+});
+
+async function writeProfile(
+  profilesRoot: string,
+  name: string,
+  tokens: {
+    readonly account_id: string;
+    readonly access_token: string;
+    readonly refresh_token: string;
+  }
+): Promise<void> {
+  await fs.writeFile(
+    path.join(profilesRoot, `${name}.json`),
+    JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens
+    }),
+    "utf8"
+  );
+}
+
+function jwtWithExpiration(exp: number): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify({ exp })).toString("base64url"),
+    "signature"
+  ].join(".");
+}
+
+function jwtWithPlan(plan: string): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify({
+      "https://api.openai.com/auth": {
+        chatgpt_plan_type: plan
+      }
+    })).toString("base64url"),
+    "signature"
+  ].join(".");
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -22,6 +22,7 @@ describe("loadConfig", () => {
     expect(config.reposRoot.endsWith(".data/repos")).toBe(true);
     expect(config.logDir.endsWith(".data/logs")).toBe(true);
     expect(config.codexHostHomePath).toBeUndefined();
+    expect(config.authPoolLbMode).toBe("off");
     expect(config.slackInitialThreadHistoryCount).toBe(8);
     expect(config.slackHistoryApiMaxLimit).toBe(50);
     expect(config.slackActiveTurnReconcileIntervalMs).toBe(15_000);
@@ -123,5 +124,22 @@ describe("loadConfig", () => {
     } as NodeJS.ProcessEnv);
 
     expect(config.brokerAdminToken).toBe("secret-admin-token");
+  });
+
+  it("parses auth pool load balancing mode", () => {
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      AUTH_POOL_LB: "on"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.authPoolLbMode).toBe("on");
+    expect(() =>
+      loadConfig({
+        SLACK_APP_TOKEN: "xapp-test",
+        SLACK_BOT_TOKEN: "xoxb-test",
+        AUTH_POOL_LB: "maybe"
+      } as NodeJS.ProcessEnv)
+    ).toThrowError("Invalid AUTH_POOL_LB value");
   });
 });


### PR DESCRIPTION
## Summary
- add `AuthPoolService` for Auth Profile selection, sticky session assignment, per-profile refresh singleflight, cooldown state, and atomic profile writes
- add app-server `chatgptAuthTokens` injection plus `account/chatgptAuthTokens/refresh` response handling so refresh stays centralized in the broker
- wire `AUTH_POOL_LB=off|shadow|on` into combined/worker runtimes; `on` leases a profile before a turn and serializes turns while using the single shared app-server auth state

## Tests
- pnpm test -- test/auth-pool-service.test.ts test/app-server-client.test.ts test/config.test.ts
- pnpm build

Note: the targeted vitest invocation ran the full suite in this repo: 33 files / 168 tests passed.