### PR TITLE
Make local file paths clickable in Slack posts

### DIFF
--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -19,6 +19,7 @@ Slack broker API usage for this session:
 - Record a silent wait state without posting to Slack with: {{post_state_wait_command}}
 - Record a silent block state without posting a second Slack message with: {{post_state_block_command}}
 - Upload a local image or file with: {{post_file_command}}
+- When the user should open a generated local artifact, prefer uploading it with `/slack/post-file` instead of only posting a filesystem path.
 - Built-in Codex image-generation outputs are saved under `{{codex_generated_images_root}}/<thread-id>/...`. When you want to share one in Slack, upload it yourself with `/slack/post-file` and an absolute `file_path`.
 - Read earlier thread context with: {{thread_history_command}}
 - Register a broker-managed background job with: {{register_job_command}}

--- a/src/services/slack/slack-mrkdwn.ts
+++ b/src/services/slack/slack-mrkdwn.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from "node:url";
+
 const mdBoldItalicRe = /\*\*\*(.+?)\*\*\*/g;
 const mdBoldRe = /\*\*(.+?)\*\*/g;
 const mdItalicRe = /\*([^*\n]+?)\*/g;
@@ -9,8 +11,11 @@ const mdOrderedListRe = /^(\s*)\d+\.\s+/gm;
 const mdTableRowRe = /^\|(.+)\|$/m;
 const mdTableSepRe = /^\|[\s:]*-{2,}[\s:]*(\|[\s:]*-{2,}[\s:]*)*\|$/m;
 const inlineCodeUrlRe = /(https?:\/\/|www\.|(?:[a-z0-9-]+\.)+[a-z]{2,}(?:[:/]|$))/i;
+const localFilePathCandidateRe = /\/(?:Users|Volumes|tmp|private\/tmp|var\/folders)\/[A-Za-z0-9._~!$&'()*+,;=:@%#/-]+/g;
+const localFilePathRe = /^\/(?:Users|Volumes|tmp|private\/tmp|var\/folders)\/.+/;
 const slackLinkLabelRe = /^<([^>|]+)\|([^>]+)>$/;
 const slackLinkBareRe = /^<([^>]+)>$/;
+const slackLinkTokenRe = /<[^>\n]+>/g;
 
 const phBIOpen = "\x00BI\x01";
 const phBIClose = "\x00BI\x02";
@@ -47,6 +52,10 @@ export function markdownToSlackFallbackText(text: string): string {
 
 function sanitizeSlackCodeSegment(text: string): string {
   if (text.startsWith("```")) {
+    const linkifiedFence = linkifyLocalFilePathCodeFence(text);
+    if (linkifiedFence) {
+      return linkifiedFence;
+    }
     return text;
   }
   if (text.length < 2 || text[0] !== "`" || text[text.length - 1] !== "`") {
@@ -54,6 +63,11 @@ function sanitizeSlackCodeSegment(text: string): string {
   }
 
   let inner = text.slice(1, -1);
+  const linkifiedPath = formatLocalFilePathLink(inner.trim());
+  if (linkifiedPath) {
+    return linkifiedPath;
+  }
+
   inner = normalizeInlineCodeSlackLink(inner);
   if (!inlineCodeUrlRe.test(inner)) {
     return text;
@@ -218,7 +232,7 @@ function convertCommonMarkdown(text: string): string {
   converted = converted.replaceAll("\n---\n", "\n———\n");
   converted = converted.replaceAll("\n***\n", "\n———\n");
   converted = converted.replaceAll("\n___\n", "\n———\n");
-  return converted;
+  return linkifyLocalFilePaths(converted);
 }
 
 function normalizeMarkdownLinkTarget(target: string): string {
@@ -227,7 +241,108 @@ function normalizeMarkdownLinkTarget(target: string): string {
   if (bareMatch) {
     return bareMatch[1]!;
   }
+  const fileUrl = localFilePathToFileUrl(trimmed);
+  if (fileUrl) {
+    return fileUrl;
+  }
   return trimmed;
+}
+
+function linkifyLocalFilePathCodeFence(text: string): string | undefined {
+  if (!text.endsWith("```")) {
+    return undefined;
+  }
+
+  let body = text.slice(3, -3).trim();
+  const firstLineBreakIndex = body.indexOf("\n");
+  if (
+    firstLineBreakIndex > 0 &&
+    /^[A-Za-z0-9_-]+$/.test(body.slice(0, firstLineBreakIndex).trim()) &&
+    isLocalFilePath(body.slice(firstLineBreakIndex + 1).trim())
+  ) {
+    body = body.slice(firstLineBreakIndex + 1).trim();
+  }
+
+  const lines = body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+
+  if (lines.length === 0 || !lines.every(isLocalFilePath)) {
+    return undefined;
+  }
+
+  return lines.map((line) => formatLocalFilePathLink(line) ?? line).join("\n");
+}
+
+function linkifyLocalFilePaths(text: string): string {
+  let result = "";
+  let index = 0;
+
+  for (const match of text.matchAll(slackLinkTokenRe)) {
+    const matchIndex = match.index ?? 0;
+    result += linkifyLocalFilePathsInPlainText(text.slice(index, matchIndex));
+    result += match[0];
+    index = matchIndex + match[0].length;
+  }
+
+  result += linkifyLocalFilePathsInPlainText(text.slice(index));
+  return result;
+}
+
+function linkifyLocalFilePathsInPlainText(text: string): string {
+  return text.replaceAll(localFilePathCandidateRe, (match, offset: number) => {
+    const previous = text.slice(Math.max(0, offset - 7), offset);
+    if (previous.includes("://")) {
+      return match;
+    }
+
+    const [filePath, suffix] = splitTrailingLocalFilePathPunctuation(match);
+    return `${formatLocalFilePathLink(filePath) ?? match}${suffix}`;
+  });
+}
+
+function formatLocalFilePathLink(filePath: string): string | undefined {
+  const fileUrl = localFilePathToFileUrl(filePath);
+  if (!fileUrl) {
+    return undefined;
+  }
+
+  return `<${fileUrl}|${escapeSlackLinkLabel(filePath)}>`;
+}
+
+function localFilePathToFileUrl(filePath: string): string | undefined {
+  const trimmed = filePath.trim();
+  if (!isLocalFilePath(trimmed)) {
+    return undefined;
+  }
+
+  return pathToFileURL(trimmed).href;
+}
+
+function isLocalFilePath(value: string): boolean {
+  return localFilePathRe.test(value.trim());
+}
+
+function splitTrailingLocalFilePathPunctuation(filePath: string): readonly [string, string] {
+  let end = filePath.length;
+  while (end > 0 && /[.,;:!?)}\]]/.test(filePath[end - 1]!)) {
+    end -= 1;
+  }
+
+  if (end === filePath.length) {
+    return [filePath, ""];
+  }
+
+  return [filePath.slice(0, end), filePath.slice(end)];
+}
+
+function escapeSlackLinkLabel(label: string): string {
+  return label
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("|", "¦");
 }
 
 function normalizeOrderedListPrefix(match: string): string {

--- a/test/slack-mrkdwn.test.ts
+++ b/test/slack-mrkdwn.test.ts
@@ -72,6 +72,30 @@ describe("markdownToMrkdwn", () => {
       name: "markdown link strips slack angle wrapped target",
       input: "[OpenAI](<https://openai.com>)",
       expected: "<https://openai.com|OpenAI>"
+    },
+    {
+      name: "local file paths become clickable file links",
+      input: "文件在你电脑桌面：/Users/enther/Desktop/proactive-agent-industry-deck.html，直接打开。",
+      expected:
+        "文件在你电脑桌面：<file:///Users/enther/Desktop/proactive-agent-industry-deck.html|/Users/enther/Desktop/proactive-agent-industry-deck.html>，直接打开。"
+    },
+    {
+      name: "markdown links can target local file paths",
+      input: "[打开 HTML](/Users/enther/Desktop/proactive agent deck.html)",
+      expected:
+        "<file:///Users/enther/Desktop/proactive%20agent%20deck.html|打开 HTML>"
+    },
+    {
+      name: "inline-code local file path becomes a clickable file link",
+      input: "文件在：`/Users/enther/Desktop/proactive-agent-industry-deck.html`",
+      expected:
+        "文件在：<file:///Users/enther/Desktop/proactive-agent-industry-deck.html|/Users/enther/Desktop/proactive-agent-industry-deck.html>"
+    },
+    {
+      name: "code-fenced local file path becomes a clickable file link",
+      input: "文件在：\n```\n/Users/enther/Desktop/proactive-agent-industry-deck.html\n```",
+      expected:
+        "文件在：\n<file:///Users/enther/Desktop/proactive-agent-industry-deck.html|/Users/enther/Desktop/proactive-agent-industry-deck.html>"
     }
   ] as const;
 


### PR DESCRIPTION
## Summary
- Convert local absolute paths in Slack markdown output into `file://` mrkdwn links
- Handle bare paths, markdown links, inline code, and path-only fenced code blocks
- Add prompt guidance to upload generated local artifacts with `/slack/post-file`

## Tests
- `pnpm exec vitest run test/slack-mrkdwn.test.ts`
- `pnpm build`
- `pnpm test`