### PR TITLE
[codex] Move broker state to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ If `BROKER_ADMIN_TOKEN` is set, `/admin/api/*` requires that token via `x-admin-
 
 The container image:
 
-- uses Node 22
+- uses Node 22.5+ for the built-in SQLite runtime state store
 - installs `git`
 - installs `gh`
 - installs `rg` via `ripgrep`
@@ -285,13 +285,13 @@ Durable broker-owned identity/config data:
 
 Disposable runtime state:
 
-- `state/`
+- `state/broker.sqlite`
 - `sessions/`
 - `jobs/`
 - `logs/`
 - `repos/`
 
-The macOS bare-run deploy path only reuses the durable broker-owned subset that defines behavior and identity. It intentionally leaves the disposable runtime state behind and starts the VM with a clean `sessions/`, `jobs/`, `logs/`, and `repos/`.
+The macOS bare-run deploy path only reuses the durable broker-owned subset that defines behavior and identity. It intentionally leaves the disposable runtime state behind and starts the VM with a clean `state/`, `sessions/`, `jobs/`, `logs/`, and `repos/`.
 
 ## Logging
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.5.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && node scripts/build/copy-static-assets.mjs",

--- a/scripts/ops/lib.mjs
+++ b/scripts/ops/lib.mjs
@@ -5,10 +5,12 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 export const repoRoot = path.resolve(scriptDir, "..", "..");
+const STATE_DATABASE_FILENAME = "broker.sqlite";
 
 function formatCommand(command, args) {
   return [command, ...args].join(" ");
@@ -75,36 +77,28 @@ export function getPublishedPort(inspect, containerPort = "3000/tcp") {
 }
 
 export async function readSessionStatsFromHost(dataRootSource) {
-  const sessionsDir = path.join(dataRootSource, "state", "sessions");
-  try {
-    const entries = await fsp.readdir(sessionsDir);
-    let activeCount = 0;
-    let sessionCount = 0;
-    for (const entry of entries) {
-      if (!entry.endsWith(".json")) {
-        continue;
-      }
-
-      sessionCount += 1;
-      const record = JSON.parse(await fsp.readFile(path.join(sessionsDir, entry), "utf8"));
-      if (record.activeTurnId) {
-        activeCount += 1;
-      }
-    }
-
+  const dbPath = path.join(dataRootSource, "state", STATE_DATABASE_FILENAME);
+  if (!fs.existsSync(dbPath)) {
     return {
-      activeCount,
-      sessionCount
+      activeCount: 0,
+      sessionCount: 0
     };
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-      return {
-        activeCount: 0,
-        sessionCount: 0
-      };
-    }
+  }
 
-    throw error;
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    const row = db.prepare(`
+      SELECT
+        COUNT(*) AS sessionCount,
+        SUM(CASE WHEN active_turn_id IS NOT NULL THEN 1 ELSE 0 END) AS activeCount
+      FROM sessions
+    `).get();
+    return {
+      activeCount: Number(row?.activeCount ?? 0),
+      sessionCount: Number(row?.sessionCount ?? 0)
+    };
+  } finally {
+    db.close();
   }
 }
 
@@ -258,9 +252,7 @@ export async function checkContainer(containerName, options = {}) {
         "  '/app/.data/codex-home/AGENT.md',",
         "  '/app/.data/codex-home/config.toml',",
         "  '/app/.data/runtime-home/.codex/AGENT.md',",
-        "  '/app/.data/state/sessions',",
-        "  '/app/.data/state/inbound-messages',",
-        "  '/app/.data/state/background-jobs',",
+        "  '/app/.data/state/broker.sqlite',",
         "  '/app/.data/repos',",
         "  '/app/.data/sessions'",
         "];",
@@ -316,47 +308,25 @@ export async function writeRolloutMetadata(directory, payload) {
   await fsp.writeFile(path.join(directory, "metadata.json"), `${JSON.stringify(payload, null, 2)}\n`);
 }
 
-async function readJsonIfExists(filePath) {
-  try {
-    return JSON.parse(await fsp.readFile(filePath, "utf8"));
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-      return undefined;
-    }
-
-    throw error;
+function readDetailedStateFromSqlite(dataRootSource) {
+  const dbPath = path.join(dataRootSource, "state", STATE_DATABASE_FILENAME);
+  if (!fs.existsSync(dbPath)) {
+    return {
+      sessions: [],
+      inboundMessages: [],
+      backgroundJobs: []
+    };
   }
-}
 
-async function readJsonRecordsFromDirectory(directory) {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
   try {
-    const entries = await fsp.readdir(directory);
-    const records = [];
-    for (const entry of entries.sort()) {
-      if (!entry.endsWith(".json")) {
-        continue;
-      }
-
-      const payload = await readJsonIfExists(path.join(directory, entry));
-      if (payload === undefined) {
-        continue;
-      }
-
-      if (Array.isArray(payload)) {
-        records.push(...payload);
-        continue;
-      }
-
-      records.push(payload);
-    }
-
-    return records;
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-      return [];
-    }
-
-    throw error;
+    return {
+      sessions: db.prepare("SELECT * FROM sessions ORDER BY created_at ASC").all().map(sessionFromRow),
+      inboundMessages: db.prepare("SELECT * FROM inbound_messages ORDER BY CAST(message_ts AS REAL), message_ts").all().map(inboundMessageFromRow),
+      backgroundJobs: db.prepare("SELECT * FROM background_jobs ORDER BY created_at ASC").all().map(backgroundJobFromRow)
+    };
+  } finally {
+    db.close();
   }
 }
 
@@ -430,12 +400,12 @@ async function readRecentBrokerLogRecords(logsRoot, limit) {
 export async function readDetailedStateFromHost(dataRootSource, options = {}) {
   const openInboundLimit = options.openInboundLimit ?? 20;
   const logLineLimit = options.logLineLimit ?? 40;
-  const stateRoot = path.join(dataRootSource, "state");
   const logsRoot = path.join(dataRootSource, "logs");
-
-  const sessions = await readJsonRecordsFromDirectory(path.join(stateRoot, "sessions"));
-  const inboundMessages = await readJsonRecordsFromDirectory(path.join(stateRoot, "inbound-messages"));
-  const backgroundJobs = await readJsonRecordsFromDirectory(path.join(stateRoot, "background-jobs"));
+  const {
+    sessions,
+    inboundMessages,
+    backgroundJobs
+  } = readDetailedStateFromSqlite(dataRootSource);
 
   const activeSessions = sessions
     .filter((session) => session?.activeTurnId)
@@ -458,4 +428,92 @@ export async function readDetailedStateFromHost(dataRootSource, options = {}) {
     ),
     recentBrokerLogs: brokerLogs
   };
+}
+
+function sessionFromRow(row) {
+  return {
+    key: row.key,
+    channelId: row.channel_id,
+    rootThreadTs: row.root_thread_ts,
+    workspacePath: row.workspace_path,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    codexThreadId: row.codex_thread_id ?? undefined,
+    activeTurnId: row.active_turn_id ?? undefined,
+    activeTurnStartedAt: row.active_turn_started_at ?? undefined,
+    lastObservedMessageTs: row.last_observed_message_ts ?? undefined,
+    lastDeliveredMessageTs: row.last_delivered_message_ts ?? undefined,
+    lastSlackReplyAt: row.last_slack_reply_at ?? undefined,
+    lastProgressReminderAt: row.last_progress_reminder_at ?? undefined,
+    lastTurnSignalTurnId: row.last_turn_signal_turn_id ?? undefined,
+    lastTurnSignalKind: row.last_turn_signal_kind ?? undefined,
+    lastTurnSignalReason: row.last_turn_signal_reason ?? undefined,
+    lastTurnSignalAt: row.last_turn_signal_at ?? undefined,
+    coAuthorCandidateUserIds: readJson(row.co_author_candidate_user_ids, undefined),
+    coAuthorCandidateRevision: row.co_author_candidate_revision ?? undefined,
+    coAuthorConfirmedUserIds: readJson(row.co_author_confirmed_user_ids, undefined),
+    coAuthorConfirmedRevision: row.co_author_confirmed_revision ?? undefined,
+    coAuthorIgnoreMissingRevision: row.co_author_ignore_missing_revision ?? undefined,
+    coAuthorPromptRevision: row.co_author_prompt_revision ?? undefined,
+    coAuthorPromptedAt: row.co_author_prompted_at ?? undefined
+  };
+}
+
+function inboundMessageFromRow(row) {
+  return {
+    key: row.key,
+    sessionKey: row.session_key,
+    channelId: row.channel_id,
+    channelType: row.channel_type ?? undefined,
+    rootThreadTs: row.root_thread_ts,
+    messageTs: row.message_ts,
+    source: row.source,
+    userId: row.user_id,
+    text: row.text,
+    senderKind: row.sender_kind ?? undefined,
+    botId: row.bot_id ?? undefined,
+    appId: row.app_id ?? undefined,
+    senderUsername: row.sender_username ?? undefined,
+    mentionedUserIds: readJson(row.mentioned_user_ids, []),
+    contextText: row.context_text ?? undefined,
+    images: readJson(row.images, []),
+    slackMessage: readJson(row.slack_message, undefined),
+    backgroundJob: readJson(row.background_job, undefined),
+    unexpectedTurnStop: readJson(row.unexpected_turn_stop, undefined),
+    status: row.status,
+    batchId: row.batch_id ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function backgroundJobFromRow(row) {
+  return {
+    id: row.id,
+    token: row.token,
+    sessionKey: row.session_key,
+    channelId: row.channel_id,
+    rootThreadTs: row.root_thread_ts,
+    kind: row.kind,
+    shell: row.shell,
+    cwd: row.cwd,
+    scriptPath: row.script_path,
+    restartOnBoot: row.restart_on_boot !== 0,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    startedAt: row.started_at ?? undefined,
+    heartbeatAt: row.heartbeat_at ?? undefined,
+    completedAt: row.completed_at ?? undefined,
+    cancelledAt: row.cancelled_at ?? undefined,
+    exitCode: row.exit_code ?? undefined,
+    error: row.error ?? undefined,
+    lastEventAt: row.last_event_at ?? undefined,
+    lastEventKind: row.last_event_kind ?? undefined,
+    lastEventSummary: row.last_event_summary ?? undefined
+  };
+}
+
+function readJson(value, fallback) {
+  return typeof value === "string" ? JSON.parse(value) : fallback;
 }

--- a/scripts/ops/macos-bootstrap.mjs
+++ b/scripts/ops/macos-bootstrap.mjs
@@ -355,9 +355,7 @@ async function buildPortableGhConfigHome(sourceGhConfigHome, targetRuntimeHome) 
 }
 
 async function initializeRuntimeData(dataRoot) {
-  await ensureDir(path.join(dataRoot, "state", "sessions"));
-  await ensureDir(path.join(dataRoot, "state", "inbound-messages"));
-  await ensureDir(path.join(dataRoot, "state", "background-jobs"));
+  await ensureDir(path.join(dataRoot, "state"));
   await ensureDir(path.join(dataRoot, "jobs"));
   await ensureDir(path.join(dataRoot, "sessions"));
   await ensureDir(path.join(dataRoot, "logs", "raw"));
@@ -366,7 +364,6 @@ async function initializeRuntimeData(dataRoot) {
   await ensureDir(path.join(dataRoot, "repos"));
   await ensureDir(path.join(dataRoot, "runtime-home"));
   await ensureDir(path.join(dataRoot, "auth-profiles", "docker", "profiles"));
-  await fs.writeFile(path.join(dataRoot, "state", "processed-event-ids.json"), "[]\n", "utf8");
 }
 
 function renderEnvFile(env) {

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -448,19 +448,21 @@ export class SlackConversationService {
       return session;
     }
 
+    const latestSession = this.#findSessionByKey(session.key);
+
     if (dispatchMessages.length > 0 && dispatchMessages.every((message) => isUnexpectedTurnStopMessage(message))) {
-      return session;
+      return latestSession;
     }
 
-    const signalKind = session.lastTurnSignalTurnId === turnId ? session.lastTurnSignalKind : undefined;
+    const signalKind = latestSession.lastTurnSignalTurnId === turnId ? latestSession.lastTurnSignalKind : undefined;
     if (isStopExplainingTurnSignalKind(signalKind)) {
-      if (signalKind !== "wait" || this.#hasRunningBackgroundJob(session)) {
-        return session;
+      if (signalKind !== "wait" || this.#hasRunningBackgroundJob(latestSession)) {
+        return latestSession;
       }
     }
 
-    if (this.#hasPendingUnexpectedStopNudge(session, turnId)) {
-      return session;
+    if (this.#hasPendingUnexpectedStopNudge(latestSession, turnId)) {
+      return latestSession;
     }
 
     const reason = signalKind === "wait"
@@ -468,12 +470,12 @@ export class SlackConversationService {
       : "The previous run ended without an explicit final, block, or wait state. Either continue the work, send a final Slack update, declare a block that clearly names the human/external blocker, or declare a wait state backed by a running broker-managed async job.";
 
     await this.acceptUnexpectedTurnStop({
-      session,
+      session: latestSession,
       previousTurnId: turnId,
       reason
     });
 
-    return this.#findSessionByKey(session.key);
+    return this.#findSessionByKey(latestSession.key);
   }
 
   #hasRunningBackgroundJob(session: SlackSessionRecord): boolean {
@@ -760,11 +762,6 @@ export class SlackConversationService {
 
     if (turnId) {
       latestSession = await this.#inboundStore.markTurnBatchDone(latestSession, turnId);
-    }
-
-    if (session.activeTurnId) {
-      latestSession = await this.#sessions.setActiveTurnId(session.channelId, session.rootThreadTs, undefined);
-      this.#resetRuntimeProcessing(session.key);
     }
 
     this.#clearAssistantStatus(session.channelId, session.rootThreadTs);

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 
 import type {
@@ -9,90 +8,67 @@ import type {
   PersistedInboundSource,
   SlackSessionRecord
 } from "../types.js";
-import { ensureDir, fileExists } from "../utils/fs.js";
+import { ensureDir } from "../utils/fs.js";
+
+export const STATE_DATABASE_FILENAME = "broker.sqlite";
+
+type SqlValue = string | number | bigint | null;
+type SqlRow = Record<string, unknown>;
 
 export class StateStore {
   readonly #stateDir: string;
   readonly #sessionsRoot: string;
-  readonly #processedEventsFilePath: string;
-  readonly #sessionsDirPath: string;
-  readonly #inboundDirPath: string;
-  readonly #jobsDirPath: string;
-
-  #sessions = new Map<string, SlackSessionRecord>();
-  #processedEventIds: string[] = [];
-  #processedEventIdSet = new Set<string>();
-  #inboundMessagesBySession = new Map<string, Map<string, PersistedInboundMessage>>();
-  #backgroundJobs = new Map<string, PersistedBackgroundJob>();
-  #writeChains = new Map<string, Promise<void>>();
+  #database: DatabaseSync | undefined;
 
   constructor(stateDir: string, sessionsRoot: string) {
     this.#stateDir = stateDir;
     this.#sessionsRoot = sessionsRoot;
-    this.#processedEventsFilePath = path.join(stateDir, "processed-event-ids.json");
-    this.#sessionsDirPath = path.join(stateDir, "sessions");
-    this.#inboundDirPath = path.join(stateDir, "inbound-messages");
-    this.#jobsDirPath = path.join(stateDir, "background-jobs");
   }
 
   async load(): Promise<void> {
     await ensureDir(this.#stateDir);
-    await ensureDir(this.#sessionsDirPath);
-    await ensureDir(this.#inboundDirPath);
-    await ensureDir(this.#jobsDirPath);
+    this.#openDatabase();
+    this.#migrate();
+  }
 
-    this.#resetInMemoryState();
-
-    await this.#loadSplitState();
+  close(): void {
+    this.#database?.close();
+    this.#database = undefined;
   }
 
   listSessions(): SlackSessionRecord[] {
-    return [...this.#sessions.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+    return this.#databaseRequired()
+      .prepare("SELECT * FROM sessions ORDER BY created_at ASC")
+      .all()
+      .map((row) => this.#rowToSession(row as SqlRow));
   }
 
   getSession(key: string): SlackSessionRecord | undefined {
-    return this.#sessions.get(key);
+    const row = this.#databaseRequired()
+      .prepare("SELECT * FROM sessions WHERE key = ?")
+      .get(key) as SqlRow | undefined;
+    return row ? this.#rowToSession(row) : undefined;
   }
 
   async upsertSession(record: SlackSessionRecord): Promise<void> {
     const normalized = this.#normalizeSession(record);
-    this.#sessions.set(normalized.key, normalized);
-    await this.#writeJsonAtomic(
-      path.join(this.#sessionsDirPath, `${encodeKey(normalized.key)}.json`),
-      normalized
-    );
+    this.#transaction(() => {
+      this.#upsertSession(normalized);
+    });
   }
 
   async deleteSession(key: string): Promise<boolean> {
-    const filePath = path.join(this.#sessionsDirPath, `${encodeKey(key)}.json`);
-    let deleted = false;
-
-    await this.#runSerialized(filePath, async () => {
-      if (!this.#sessions.has(key)) {
-        return;
+    return this.#transaction(() => {
+      const existing = this.#databaseRequired()
+        .prepare("SELECT key FROM sessions WHERE key = ?")
+        .get(key);
+      if (!existing) {
+        return false;
       }
 
-      const jobIds = [...this.#backgroundJobs.values()]
-        .filter((job) => job.sessionKey === key)
-        .map((job) => job.id);
-
-      this.#sessions.delete(key);
-      this.#inboundMessagesBySession.delete(key);
-      for (const jobId of jobIds) {
-        this.#backgroundJobs.delete(jobId);
-      }
-
-      await Promise.all([
-        fs.rm(filePath, { force: true }),
-        fs.rm(path.join(this.#inboundDirPath, `${encodeKey(key)}.json`), { force: true }),
-        ...jobIds.map((jobId) =>
-          fs.rm(path.join(this.#jobsDirPath, `${encodeKey(jobId)}.json`), { force: true })
-        )
-      ]);
-      deleted = true;
+      this.#databaseRequired().prepare("DELETE FROM sessions WHERE key = ?").run(key);
+      return true;
     });
-
-    return deleted;
   }
 
   async patchSession(
@@ -101,17 +77,14 @@ export class StateStore {
       | Partial<SlackSessionRecord>
       | ((current: SlackSessionRecord) => Partial<SlackSessionRecord>)
   ): Promise<SlackSessionRecord> {
-    const filePath = path.join(this.#sessionsDirPath, `${encodeKey(key)}.json`);
-    let updated!: SlackSessionRecord;
-
-    await this.#runSerialized(filePath, async () => {
-      const current = this.#sessions.get(key);
+    return this.#transaction(() => {
+      const current = this.getSession(key);
       if (!current) {
         throw new Error(`Unknown session: ${key}`);
       }
 
       const resolvedPatch = typeof patch === "function" ? patch(current) : patch;
-      updated = this.#normalizeSession({
+      const updated = this.#normalizeSession({
         ...current,
         ...resolvedPatch,
         key: current.key,
@@ -121,25 +94,29 @@ export class StateStore {
         createdAt: current.createdAt
       });
 
-      this.#sessions.set(key, updated);
-      await this.#writeJsonAtomicUnlocked(filePath, updated);
+      this.#upsertSession(updated);
+      return updated;
     });
-
-    return updated;
   }
 
   hasProcessedEvent(eventId: string): boolean {
-    return this.#processedEventIdSet.has(eventId);
+    return Boolean(this.#databaseRequired()
+      .prepare("SELECT 1 FROM processed_events WHERE event_id = ?")
+      .get(eventId));
   }
 
   async markProcessedEvent(eventId: string): Promise<void> {
-    if (this.hasProcessedEvent(eventId)) {
-      return;
-    }
-
-    this.#processedEventIds = [...this.#processedEventIds, eventId].slice(-2_000);
-    this.#processedEventIdSet = new Set(this.#processedEventIds);
-    await this.#writeJsonAtomic(this.#processedEventsFilePath, this.#processedEventIds);
+    this.#transaction(() => {
+      this.#databaseRequired()
+        .prepare("INSERT OR IGNORE INTO processed_events (event_id) VALUES (?)")
+        .run(eventId);
+      this.#databaseRequired().exec(`
+        DELETE FROM processed_events
+        WHERE sequence NOT IN (
+          SELECT sequence FROM processed_events ORDER BY sequence DESC LIMIT 2000
+        )
+      `);
+    });
   }
 
   listInboundMessages(options?: {
@@ -148,40 +125,46 @@ export class StateStore {
     readonly batchId?: string | undefined;
     readonly source?: PersistedInboundSource | readonly PersistedInboundSource[] | undefined;
   }): PersistedInboundMessage[] {
-    const statuses = Array.isArray(options?.status)
-      ? options.status
-      : options?.status
-        ? [options.status]
-        : undefined;
-    const sources = Array.isArray(options?.source)
-      ? options.source
-      : options?.source
-        ? [options.source]
-        : undefined;
-    const sessionKeys = options?.sessionKey ? [options.sessionKey] : [...this.#inboundMessagesBySession.keys()];
+    const where: string[] = [];
+    const params: SqlValue[] = [];
+    const statuses = arrayOption(options?.status);
+    const sources = arrayOption(options?.source);
 
-    return sessionKeys
-      .flatMap((sessionKey) => [...(this.#inboundMessagesBySession.get(sessionKey)?.values() ?? [])])
-      .filter((message) => {
-        if (statuses && !statuses.includes(message.status)) {
-          return false;
-        }
+    if (options?.sessionKey) {
+      where.push("session_key = ?");
+      params.push(options.sessionKey);
+    }
+    if (statuses) {
+      where.push(`status IN (${placeholders(statuses.length)})`);
+      params.push(...statuses);
+    }
+    if (options?.batchId) {
+      where.push("batch_id = ?");
+      params.push(options.batchId);
+    }
+    if (sources) {
+      where.push(`source IN (${placeholders(sources.length)})`);
+      params.push(...sources);
+    }
 
-        if (options?.batchId && message.batchId !== options.batchId) {
-          return false;
-        }
+    const sql = [
+      "SELECT * FROM inbound_messages",
+      where.length > 0 ? `WHERE ${where.join(" AND ")}` : "",
+      "ORDER BY CAST(message_ts AS REAL) ASC, message_ts ASC"
+    ].filter(Boolean).join(" ");
 
-        if (sources && !sources.includes(message.source)) {
-          return false;
-        }
-
-        return true;
-      })
+    return this.#databaseRequired()
+      .prepare(sql)
+      .all(...params)
+      .map((row) => this.#rowToInboundMessage(row as SqlRow))
       .sort(compareInboundMessages);
   }
 
   getInboundMessage(sessionKey: string, messageTs: string): PersistedInboundMessage | undefined {
-    return this.#inboundMessagesBySession.get(sessionKey)?.get(messageTs);
+    const row = this.#databaseRequired()
+      .prepare("SELECT * FROM inbound_messages WHERE session_key = ? AND message_ts = ?")
+      .get(sessionKey, messageTs) as SqlRow | undefined;
+    return row ? this.#rowToInboundMessage(row) : undefined;
   }
 
   getLatestInboundMessageTs(sessionKey: string, options?: {
@@ -194,9 +177,13 @@ export class StateStore {
   }
 
   async upsertInboundMessage(record: PersistedInboundMessage): Promise<void> {
-    const messages = this.#getOrCreateInboundSession(record.sessionKey);
-    messages.set(record.messageTs, record);
-    await this.#writeInboundSession(record.sessionKey);
+    const normalized = this.#normalizeInboundMessage(record);
+    if (!normalized) {
+      throw new Error(`Invalid inbound message: ${record.key}`);
+    }
+    this.#transaction(() => {
+      this.#upsertInboundMessage(normalized);
+    });
   }
 
   async updateInboundMessage(
@@ -207,21 +194,21 @@ export class StateStore {
       readonly batchId?: string | undefined;
     }
   ): Promise<PersistedInboundMessage | undefined> {
-    const messages = this.#inboundMessagesBySession.get(sessionKey);
-    const existing = messages?.get(messageTs);
-    if (!existing) {
-      return undefined;
-    }
+    return this.#transaction(() => {
+      const existing = this.getInboundMessage(sessionKey, messageTs);
+      if (!existing) {
+        return undefined;
+      }
 
-    const updated: PersistedInboundMessage = {
-      ...existing,
-      status: patch.status ?? existing.status,
-      batchId: patch.batchId,
-      updatedAt: new Date().toISOString()
-    };
-    messages!.set(messageTs, updated);
-    await this.#writeInboundSession(sessionKey);
-    return updated;
+      const updated: PersistedInboundMessage = {
+        ...existing,
+        status: patch.status ?? existing.status,
+        batchId: patch.batchId,
+        updatedAt: new Date().toISOString()
+      };
+      this.#upsertInboundMessage(updated);
+      return updated;
+    });
   }
 
   async updateInboundMessagesForBatch(
@@ -232,35 +219,27 @@ export class StateStore {
       readonly batchId?: string | undefined;
     }
   ): Promise<PersistedInboundMessage[]> {
-    const messages = this.#inboundMessagesBySession.get(sessionKey);
-    if (!messages) {
-      return [];
-    }
+    return this.#transaction(() => {
+      const updatedAt = new Date().toISOString();
+      const updated: PersistedInboundMessage[] = [];
 
-    const updatedAt = new Date().toISOString();
-    const updated: PersistedInboundMessage[] = [];
-
-    for (const messageTs of messageTsList) {
-      const existing = messages.get(messageTs);
-      if (!existing) {
-        continue;
+      for (const messageTs of messageTsList) {
+        const existing = this.getInboundMessage(sessionKey, messageTs);
+        if (!existing) {
+          continue;
+        }
+        const nextMessage: PersistedInboundMessage = {
+          ...existing,
+          status: patch.status ?? existing.status,
+          batchId: patch.batchId,
+          updatedAt
+        };
+        this.#upsertInboundMessage(nextMessage);
+        updated.push(nextMessage);
       }
 
-      const nextMessage: PersistedInboundMessage = {
-        ...existing,
-        status: patch.status ?? existing.status,
-        batchId: patch.batchId,
-        updatedAt
-      };
-      messages.set(messageTs, nextMessage);
-      updated.push(nextMessage);
-    }
-
-    if (updated.length > 0) {
-      await this.#writeInboundSession(sessionKey);
-    }
-
-    return updated;
+      return updated;
+    });
   }
 
   async resetInflightMessages(sessionKey: string, batchId?: string | undefined): Promise<PersistedInboundMessage[]> {
@@ -284,143 +263,423 @@ export class StateStore {
     readonly sessionKey?: string | undefined;
     readonly id?: string | undefined;
   }): PersistedBackgroundJob[] {
-    return [...this.#backgroundJobs.values()]
-      .filter((job) => {
-        if (options?.sessionKey && job.sessionKey !== options.sessionKey) {
-          return false;
-        }
+    const where: string[] = [];
+    const params: SqlValue[] = [];
+    if (options?.sessionKey) {
+      where.push("session_key = ?");
+      params.push(options.sessionKey);
+    }
+    if (options?.id) {
+      where.push("id = ?");
+      params.push(options.id);
+    }
 
-        if (options?.id && job.id !== options.id) {
-          return false;
-        }
+    const sql = [
+      "SELECT * FROM background_jobs",
+      where.length > 0 ? `WHERE ${where.join(" AND ")}` : "",
+      "ORDER BY created_at ASC"
+    ].filter(Boolean).join(" ");
 
-        return true;
-      })
-      .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+    return this.#databaseRequired()
+      .prepare(sql)
+      .all(...params)
+      .map((row) => this.#rowToBackgroundJob(row as SqlRow));
   }
 
   getBackgroundJob(id: string): PersistedBackgroundJob | undefined {
-    return this.#backgroundJobs.get(id);
+    const row = this.#databaseRequired()
+      .prepare("SELECT * FROM background_jobs WHERE id = ?")
+      .get(id) as SqlRow | undefined;
+    return row ? this.#rowToBackgroundJob(row) : undefined;
   }
 
   async upsertBackgroundJob(record: PersistedBackgroundJob): Promise<void> {
-    this.#backgroundJobs.set(record.id, record);
-    await this.#writeJsonAtomic(
-      path.join(this.#jobsDirPath, `${encodeKey(record.id)}.json`),
-      record
-    );
-  }
-
-  async #loadSplitState(): Promise<void> {
-    this.#processedEventIds = await this.#readJsonFile(this.#processedEventsFilePath, []);
-    this.#processedEventIdSet = new Set(this.#processedEventIds);
-
-    for (const session of await this.#readEntityDirectory(this.#sessionsDirPath)) {
-      const normalized = this.#normalizeSession(session as Partial<SlackSessionRecord>);
-      this.#sessions.set(normalized.key, normalized);
+    const normalized = this.#normalizeBackgroundJob(record);
+    if (!normalized) {
+      throw new Error(`Invalid background job: ${record.id}`);
     }
-
-    for (const raw of await this.#readEntityDirectory(this.#inboundDirPath)) {
-      const normalizedMessages = (Array.isArray(raw) ? raw : [])
-        .map((message) => this.#normalizeInboundMessage(message as Partial<PersistedInboundMessage>))
-        .filter((message): message is PersistedInboundMessage => message !== null);
-      if (normalizedMessages.length === 0) {
-        continue;
-      }
-
-      const sessionKey = normalizedMessages[0]!.sessionKey;
-      this.#inboundMessagesBySession.set(
-        sessionKey,
-        new Map(normalizedMessages.map((message) => [message.messageTs, message]))
-      );
-    }
-
-    for (const job of await this.#readEntityDirectory(this.#jobsDirPath)) {
-      const normalized = this.#normalizeBackgroundJob(job as Partial<PersistedBackgroundJob>);
-      if (normalized) {
-        this.#backgroundJobs.set(normalized.id, normalized);
-      }
-    }
-  }
-
-  async #writeInboundSession(sessionKey: string): Promise<void> {
-    const messages = [...(this.#inboundMessagesBySession.get(sessionKey)?.values() ?? [])]
-      .sort(compareInboundMessages);
-    await this.#writeJsonAtomic(
-      path.join(this.#inboundDirPath, `${encodeKey(sessionKey)}.json`),
-      messages
-    );
-  }
-
-  async #writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
-    await this.#runSerialized(filePath, async () => {
-      await this.#writeJsonAtomicUnlocked(filePath, value);
+    this.#transaction(() => {
+      this.#upsertBackgroundJob(normalized);
     });
   }
 
-  async #writeJsonAtomicUnlocked(filePath: string, value: unknown): Promise<void> {
-    await ensureDir(path.dirname(filePath));
-    const tempFilePath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
-    await fs.writeFile(tempFilePath, JSON.stringify(value, null, 2));
-    await fs.rename(tempFilePath, filePath);
-  }
-
-  async #runSerialized<T>(key: string, action: () => Promise<T>): Promise<T> {
-    const previous = this.#writeChains.get(key) ?? Promise.resolve();
-    let result!: T;
-    const next = previous
-      .catch(() => {})
-      .then(async () => {
-        result = await action();
-      });
-
-    this.#writeChains.set(key, next);
-    try {
-      await next;
-    } finally {
-      if (this.#writeChains.get(key) === next) {
-        this.#writeChains.delete(key);
-      }
+  #openDatabase(): void {
+    if (this.#database) {
+      return;
     }
-
-    return result;
+    this.#database = new DatabaseSync(path.join(this.#stateDir, STATE_DATABASE_FILENAME));
+    this.#database.exec(`
+      PRAGMA foreign_keys = ON;
+      PRAGMA journal_mode = WAL;
+      PRAGMA synchronous = NORMAL;
+    `);
   }
 
-  async #readJsonFile<T>(filePath: string, fallback: T): Promise<T> {
-    if (!(await fileExists(filePath))) {
-      return fallback;
-    }
+  #migrate(): void {
+    this.#transaction(() => {
+      this.#databaseRequired().exec(`
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL
+        );
 
-    return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+        CREATE TABLE IF NOT EXISTS sessions (
+          key TEXT PRIMARY KEY,
+          channel_id TEXT NOT NULL,
+          root_thread_ts TEXT NOT NULL,
+          workspace_path TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          codex_thread_id TEXT,
+          active_turn_id TEXT,
+          active_turn_started_at TEXT,
+          last_observed_message_ts TEXT,
+          last_delivered_message_ts TEXT,
+          last_slack_reply_at TEXT,
+          last_progress_reminder_at TEXT,
+          last_turn_signal_turn_id TEXT,
+          last_turn_signal_kind TEXT,
+          last_turn_signal_reason TEXT,
+          last_turn_signal_at TEXT,
+          co_author_candidate_user_ids TEXT,
+          co_author_candidate_revision INTEGER,
+          co_author_confirmed_user_ids TEXT,
+          co_author_confirmed_revision INTEGER,
+          co_author_ignore_missing_revision INTEGER,
+          co_author_prompt_revision INTEGER,
+          co_author_prompted_at TEXT,
+          UNIQUE(channel_id, root_thread_ts)
+        );
+
+        CREATE TABLE IF NOT EXISTS inbound_messages (
+          key TEXT NOT NULL UNIQUE,
+          session_key TEXT NOT NULL REFERENCES sessions(key) ON DELETE CASCADE,
+          channel_id TEXT NOT NULL,
+          channel_type TEXT,
+          root_thread_ts TEXT NOT NULL,
+          message_ts TEXT NOT NULL,
+          source TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          text TEXT NOT NULL,
+          sender_kind TEXT,
+          bot_id TEXT,
+          app_id TEXT,
+          sender_username TEXT,
+          mentioned_user_ids TEXT,
+          context_text TEXT,
+          images TEXT,
+          slack_message TEXT,
+          background_job TEXT,
+          unexpected_turn_stop TEXT,
+          status TEXT NOT NULL,
+          batch_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY(session_key, message_ts)
+        );
+
+        CREATE TABLE IF NOT EXISTS background_jobs (
+          id TEXT PRIMARY KEY,
+          token TEXT NOT NULL,
+          session_key TEXT NOT NULL REFERENCES sessions(key) ON DELETE CASCADE,
+          channel_id TEXT NOT NULL,
+          root_thread_ts TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          shell TEXT NOT NULL,
+          cwd TEXT NOT NULL,
+          script_path TEXT NOT NULL,
+          restart_on_boot INTEGER NOT NULL,
+          status TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          started_at TEXT,
+          heartbeat_at TEXT,
+          completed_at TEXT,
+          cancelled_at TEXT,
+          exit_code INTEGER,
+          error TEXT,
+          last_event_at TEXT,
+          last_event_kind TEXT,
+          last_event_summary TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS processed_events (
+          sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+          event_id TEXT NOT NULL UNIQUE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_sessions_activity ON sessions(updated_at);
+        CREATE INDEX IF NOT EXISTS idx_inbound_session_status ON inbound_messages(session_key, status, batch_id);
+        CREATE INDEX IF NOT EXISTS idx_inbound_source ON inbound_messages(session_key, source, message_ts);
+        CREATE INDEX IF NOT EXISTS idx_jobs_session_status ON background_jobs(session_key, status);
+      `);
+      this.#databaseRequired()
+        .prepare("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (?, ?)")
+        .run(1, new Date().toISOString());
+    });
   }
 
-  async #readEntityDirectory(directoryPath: string): Promise<unknown[]> {
-    const entries = await fs.readdir(directoryPath, { withFileTypes: true });
-    const files = entries
-      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
-      .sort((left, right) => left.name.localeCompare(right.name));
-
-    return await Promise.all(
-      files.map(async (entry) => JSON.parse(await fs.readFile(path.join(directoryPath, entry.name), "utf8")))
+  #upsertSession(record: SlackSessionRecord): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO sessions (
+        key, channel_id, root_thread_ts, workspace_path, created_at, updated_at,
+        codex_thread_id, active_turn_id, active_turn_started_at,
+        last_observed_message_ts, last_delivered_message_ts, last_slack_reply_at,
+        last_progress_reminder_at, last_turn_signal_turn_id, last_turn_signal_kind,
+        last_turn_signal_reason, last_turn_signal_at,
+        co_author_candidate_user_ids, co_author_candidate_revision,
+        co_author_confirmed_user_ids, co_author_confirmed_revision,
+        co_author_ignore_missing_revision, co_author_prompt_revision, co_author_prompted_at
+      ) VALUES (${placeholders(24)})
+      ON CONFLICT(key) DO UPDATE SET
+        channel_id = excluded.channel_id,
+        root_thread_ts = excluded.root_thread_ts,
+        workspace_path = excluded.workspace_path,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        codex_thread_id = excluded.codex_thread_id,
+        active_turn_id = excluded.active_turn_id,
+        active_turn_started_at = excluded.active_turn_started_at,
+        last_observed_message_ts = excluded.last_observed_message_ts,
+        last_delivered_message_ts = excluded.last_delivered_message_ts,
+        last_slack_reply_at = excluded.last_slack_reply_at,
+        last_progress_reminder_at = excluded.last_progress_reminder_at,
+        last_turn_signal_turn_id = excluded.last_turn_signal_turn_id,
+        last_turn_signal_kind = excluded.last_turn_signal_kind,
+        last_turn_signal_reason = excluded.last_turn_signal_reason,
+        last_turn_signal_at = excluded.last_turn_signal_at,
+        co_author_candidate_user_ids = excluded.co_author_candidate_user_ids,
+        co_author_candidate_revision = excluded.co_author_candidate_revision,
+        co_author_confirmed_user_ids = excluded.co_author_confirmed_user_ids,
+        co_author_confirmed_revision = excluded.co_author_confirmed_revision,
+        co_author_ignore_missing_revision = excluded.co_author_ignore_missing_revision,
+        co_author_prompt_revision = excluded.co_author_prompt_revision,
+        co_author_prompted_at = excluded.co_author_prompted_at
+    `).run(
+      record.key,
+      record.channelId,
+      record.rootThreadTs,
+      record.workspacePath,
+      record.createdAt,
+      record.updatedAt,
+      record.codexThreadId ?? null,
+      record.activeTurnId ?? null,
+      record.activeTurnStartedAt ?? null,
+      record.lastObservedMessageTs ?? null,
+      record.lastDeliveredMessageTs ?? null,
+      record.lastSlackReplyAt ?? null,
+      record.lastProgressReminderAt ?? null,
+      record.lastTurnSignalTurnId ?? null,
+      record.lastTurnSignalKind ?? null,
+      record.lastTurnSignalReason ?? null,
+      record.lastTurnSignalAt ?? null,
+      jsonOrNull(record.coAuthorCandidateUserIds),
+      record.coAuthorCandidateRevision ?? null,
+      jsonOrNull(record.coAuthorConfirmedUserIds),
+      record.coAuthorConfirmedRevision ?? null,
+      record.coAuthorIgnoreMissingRevision ?? null,
+      record.coAuthorPromptRevision ?? null,
+      record.coAuthorPromptedAt ?? null
     );
   }
 
-  #getOrCreateInboundSession(sessionKey: string): Map<string, PersistedInboundMessage> {
-    let messages = this.#inboundMessagesBySession.get(sessionKey);
-    if (!messages) {
-      messages = new Map();
-      this.#inboundMessagesBySession.set(sessionKey, messages);
-    }
-
-    return messages;
+  #upsertInboundMessage(record: PersistedInboundMessage): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO inbound_messages (
+        key, session_key, channel_id, channel_type, root_thread_ts, message_ts,
+        source, user_id, text, sender_kind, bot_id, app_id, sender_username,
+        mentioned_user_ids, context_text, images, slack_message, background_job,
+        unexpected_turn_stop, status, batch_id, created_at, updated_at
+      ) VALUES (${placeholders(23)})
+      ON CONFLICT(session_key, message_ts) DO UPDATE SET
+        key = excluded.key,
+        session_key = excluded.session_key,
+        channel_id = excluded.channel_id,
+        channel_type = excluded.channel_type,
+        root_thread_ts = excluded.root_thread_ts,
+        message_ts = excluded.message_ts,
+        source = excluded.source,
+        user_id = excluded.user_id,
+        text = excluded.text,
+        sender_kind = excluded.sender_kind,
+        bot_id = excluded.bot_id,
+        app_id = excluded.app_id,
+        sender_username = excluded.sender_username,
+        mentioned_user_ids = excluded.mentioned_user_ids,
+        context_text = excluded.context_text,
+        images = excluded.images,
+        slack_message = excluded.slack_message,
+        background_job = excluded.background_job,
+        unexpected_turn_stop = excluded.unexpected_turn_stop,
+        status = excluded.status,
+        batch_id = excluded.batch_id,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `).run(
+      record.key,
+      record.sessionKey,
+      record.channelId,
+      record.channelType ?? null,
+      record.rootThreadTs,
+      record.messageTs,
+      record.source,
+      record.userId,
+      record.text,
+      record.senderKind ?? null,
+      record.botId ?? null,
+      record.appId ?? null,
+      record.senderUsername ?? null,
+      jsonOrNull(record.mentionedUserIds ?? []),
+      record.contextText ?? null,
+      jsonOrNull(record.images ?? []),
+      jsonOrNull(record.slackMessage),
+      jsonOrNull(record.backgroundJob),
+      jsonOrNull(record.unexpectedTurnStop),
+      record.status,
+      record.batchId ?? null,
+      record.createdAt,
+      record.updatedAt
+    );
   }
 
-  #resetInMemoryState(): void {
-    this.#sessions = new Map();
-    this.#processedEventIds = [];
-    this.#processedEventIdSet = new Set();
-    this.#inboundMessagesBySession = new Map();
-    this.#backgroundJobs = new Map();
+  #upsertBackgroundJob(record: PersistedBackgroundJob): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO background_jobs (
+        id, token, session_key, channel_id, root_thread_ts, kind, shell, cwd,
+        script_path, restart_on_boot, status, created_at, updated_at, started_at,
+        heartbeat_at, completed_at, cancelled_at, exit_code, error,
+        last_event_at, last_event_kind, last_event_summary
+      ) VALUES (${placeholders(22)})
+      ON CONFLICT(id) DO UPDATE SET
+        token = excluded.token,
+        session_key = excluded.session_key,
+        channel_id = excluded.channel_id,
+        root_thread_ts = excluded.root_thread_ts,
+        kind = excluded.kind,
+        shell = excluded.shell,
+        cwd = excluded.cwd,
+        script_path = excluded.script_path,
+        restart_on_boot = excluded.restart_on_boot,
+        status = excluded.status,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        started_at = excluded.started_at,
+        heartbeat_at = excluded.heartbeat_at,
+        completed_at = excluded.completed_at,
+        cancelled_at = excluded.cancelled_at,
+        exit_code = excluded.exit_code,
+        error = excluded.error,
+        last_event_at = excluded.last_event_at,
+        last_event_kind = excluded.last_event_kind,
+        last_event_summary = excluded.last_event_summary
+    `).run(
+      record.id,
+      record.token,
+      record.sessionKey,
+      record.channelId,
+      record.rootThreadTs,
+      record.kind,
+      record.shell,
+      record.cwd,
+      record.scriptPath,
+      record.restartOnBoot ? 1 : 0,
+      record.status,
+      record.createdAt,
+      record.updatedAt,
+      record.startedAt ?? null,
+      record.heartbeatAt ?? null,
+      record.completedAt ?? null,
+      record.cancelledAt ?? null,
+      record.exitCode ?? null,
+      record.error ?? null,
+      record.lastEventAt ?? null,
+      record.lastEventKind ?? null,
+      record.lastEventSummary ?? null
+    );
+  }
+
+  #rowToSession(row: SqlRow): SlackSessionRecord {
+    return this.#normalizeSession({
+      key: stringColumn(row, "key"),
+      channelId: stringColumn(row, "channel_id"),
+      rootThreadTs: stringColumn(row, "root_thread_ts"),
+      workspacePath: stringColumn(row, "workspace_path"),
+      createdAt: stringColumn(row, "created_at"),
+      updatedAt: stringColumn(row, "updated_at"),
+      codexThreadId: optionalStringColumn(row, "codex_thread_id"),
+      activeTurnId: optionalStringColumn(row, "active_turn_id"),
+      activeTurnStartedAt: optionalStringColumn(row, "active_turn_started_at"),
+      lastObservedMessageTs: optionalStringColumn(row, "last_observed_message_ts"),
+      lastDeliveredMessageTs: optionalStringColumn(row, "last_delivered_message_ts"),
+      lastSlackReplyAt: optionalStringColumn(row, "last_slack_reply_at"),
+      lastProgressReminderAt: optionalStringColumn(row, "last_progress_reminder_at"),
+      lastTurnSignalTurnId: optionalStringColumn(row, "last_turn_signal_turn_id"),
+      lastTurnSignalKind: optionalStringColumn(row, "last_turn_signal_kind") as SlackSessionRecord["lastTurnSignalKind"],
+      lastTurnSignalReason: optionalStringColumn(row, "last_turn_signal_reason"),
+      lastTurnSignalAt: optionalStringColumn(row, "last_turn_signal_at"),
+      coAuthorCandidateUserIds: readJsonColumn(row, "co_author_candidate_user_ids", undefined),
+      coAuthorCandidateRevision: optionalNumberColumn(row, "co_author_candidate_revision"),
+      coAuthorConfirmedUserIds: readJsonColumn(row, "co_author_confirmed_user_ids", undefined),
+      coAuthorConfirmedRevision: optionalNumberColumn(row, "co_author_confirmed_revision"),
+      coAuthorIgnoreMissingRevision: optionalNumberColumn(row, "co_author_ignore_missing_revision"),
+      coAuthorPromptRevision: optionalNumberColumn(row, "co_author_prompt_revision"),
+      coAuthorPromptedAt: optionalStringColumn(row, "co_author_prompted_at")
+    });
+  }
+
+  #rowToInboundMessage(row: SqlRow): PersistedInboundMessage {
+    return this.#normalizeInboundMessage({
+      key: stringColumn(row, "key"),
+      sessionKey: stringColumn(row, "session_key"),
+      channelId: stringColumn(row, "channel_id"),
+      channelType: optionalStringColumn(row, "channel_type"),
+      rootThreadTs: stringColumn(row, "root_thread_ts"),
+      messageTs: stringColumn(row, "message_ts"),
+      source: stringColumn(row, "source") as PersistedInboundSource,
+      userId: stringColumn(row, "user_id"),
+      text: stringColumn(row, "text"),
+      senderKind: optionalStringColumn(row, "sender_kind") as PersistedInboundMessage["senderKind"],
+      botId: optionalStringColumn(row, "bot_id"),
+      appId: optionalStringColumn(row, "app_id"),
+      senderUsername: optionalStringColumn(row, "sender_username"),
+      mentionedUserIds: readJsonColumn(row, "mentioned_user_ids", []),
+      contextText: optionalStringColumn(row, "context_text"),
+      images: readJsonColumn(row, "images", []),
+      slackMessage: readJsonColumn(row, "slack_message", undefined),
+      backgroundJob: readJsonColumn(row, "background_job", undefined),
+      unexpectedTurnStop: readJsonColumn(row, "unexpected_turn_stop", undefined),
+      status: stringColumn(row, "status") as PersistedInboundMessageStatus,
+      batchId: optionalStringColumn(row, "batch_id"),
+      createdAt: stringColumn(row, "created_at"),
+      updatedAt: stringColumn(row, "updated_at")
+    })!;
+  }
+
+  #rowToBackgroundJob(row: SqlRow): PersistedBackgroundJob {
+    return this.#normalizeBackgroundJob({
+      id: stringColumn(row, "id"),
+      token: stringColumn(row, "token"),
+      sessionKey: stringColumn(row, "session_key"),
+      channelId: stringColumn(row, "channel_id"),
+      rootThreadTs: stringColumn(row, "root_thread_ts"),
+      kind: stringColumn(row, "kind"),
+      shell: stringColumn(row, "shell"),
+      cwd: stringColumn(row, "cwd"),
+      scriptPath: stringColumn(row, "script_path"),
+      restartOnBoot: booleanColumn(row, "restart_on_boot", true),
+      status: stringColumn(row, "status") as PersistedBackgroundJob["status"],
+      createdAt: stringColumn(row, "created_at"),
+      updatedAt: stringColumn(row, "updated_at"),
+      startedAt: optionalStringColumn(row, "started_at"),
+      heartbeatAt: optionalStringColumn(row, "heartbeat_at"),
+      completedAt: optionalStringColumn(row, "completed_at"),
+      cancelledAt: optionalStringColumn(row, "cancelled_at"),
+      exitCode: optionalNumberColumn(row, "exit_code"),
+      error: optionalStringColumn(row, "error"),
+      lastEventAt: optionalStringColumn(row, "last_event_at"),
+      lastEventKind: optionalStringColumn(row, "last_event_kind"),
+      lastEventSummary: optionalStringColumn(row, "last_event_summary")
+    })!;
   }
 
   #normalizeSession(session: Partial<SlackSessionRecord>): SlackSessionRecord {
@@ -534,6 +793,80 @@ export class StateStore {
       lastEventSummary: raw.lastEventSummary
     };
   }
+
+  #databaseRequired(): DatabaseSync {
+    if (!this.#database) {
+      throw new Error("StateStore has not been loaded");
+    }
+    return this.#database;
+  }
+
+  #transaction<T>(operation: () => T): T {
+    const db = this.#databaseRequired();
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const result = operation();
+      db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+}
+
+function placeholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function arrayOption<T>(value: T | readonly T[] | undefined): readonly T[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value as readonly T[] : [value as T];
+}
+
+function jsonOrNull(value: unknown): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+function readJsonColumn<T>(row: SqlRow, column: string, fallback: T): T {
+  const value = row[column];
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  return JSON.parse(value) as T;
+}
+
+function stringColumn(row: SqlRow, column: string): string {
+  return String(row[column]);
+}
+
+function optionalStringColumn(row: SqlRow, column: string): string | undefined {
+  const value = row[column];
+  return value === null || value === undefined ? undefined : String(value);
+}
+
+function optionalNumberColumn(row: SqlRow, column: string): number | undefined {
+  const value = row[column];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  return undefined;
+}
+
+function booleanColumn(row: SqlRow, column: string, fallback: boolean): boolean {
+  const value = row[column];
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+  if (typeof value === "bigint") {
+    return value !== 0n;
+  }
+  return fallback;
 }
 
 function compareInboundMessages(left: PersistedInboundMessage, right: PersistedInboundMessage): number {
@@ -542,10 +875,6 @@ function compareInboundMessages(left: PersistedInboundMessage, right: PersistedI
 
 function normalizeSessionDirectoryName(channelId: string, rootThreadTs: string): string {
   return `${channelId}-${rootThreadTs}`.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-}
-
-function encodeKey(value: string): string {
-  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 function normalizeStringArray(value: unknown): readonly string[] | undefined {

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -1625,25 +1625,27 @@ async function waitForSessionActive(
 }
 
 async function readSessionRecord(tempRoot: string, sessionKey: string): Promise<SlackSessionRecord> {
-  const sessionFile = path.join(
-    tempRoot,
-    "state",
-    "sessions",
-    `${Buffer.from(sessionKey, "utf8").toString("base64url")}.json`
-  );
-  const raw = await fs.readFile(sessionFile, "utf8");
-  return JSON.parse(raw) as SlackSessionRecord;
+  const store = new StateStore(path.join(tempRoot, "state"), path.join(tempRoot, "sessions"));
+  await store.load();
+  try {
+    const session = store.getSession(sessionKey);
+    if (!session) {
+      throw new Error(`Unknown session: ${sessionKey}`);
+    }
+    return session;
+  } finally {
+    store.close();
+  }
 }
 
 async function readInboundMessages(tempRoot: string, sessionKey: string): Promise<PersistedInboundMessage[]> {
-  const inboundFile = path.join(
-    tempRoot,
-    "state",
-    "inbound-messages",
-    `${Buffer.from(sessionKey, "utf8").toString("base64url")}.json`
-  );
-  const raw = await fs.readFile(inboundFile, "utf8");
-  return JSON.parse(raw) as PersistedInboundMessage[];
+  const store = new StateStore(path.join(tempRoot, "state"), path.join(tempRoot, "sessions"));
+  await store.load();
+  try {
+    return store.listInboundMessages({ sessionKey });
+  } finally {
+    store.close();
+  }
 }
 
 async function delay(timeoutMs: number): Promise<void> {

--- a/test/slack-conversation-service.test.ts
+++ b/test/slack-conversation-service.test.ts
@@ -146,7 +146,7 @@ describe("SlackConversationService", () => {
     await service.stop();
   });
 
-  it("clears the active turn when a silent stop state is recorded", async () => {
+  it("records a silent stop state without owning active turn completion", async () => {
     const codex = new EventEmitter();
     const recordTurnSignal = vi.fn(async () => TEST_SESSION);
     const setActiveTurnId = vi.fn(async () => ({
@@ -186,7 +186,7 @@ describe("SlackConversationService", () => {
       kind: "wait",
       reason: "waiting on async job"
     }));
-    expect(setActiveTurnId).toHaveBeenCalledWith("C123", "111.222", undefined);
+    expect(setActiveTurnId).not.toHaveBeenCalled();
     expect(listInboundMessages).toHaveBeenCalledWith(expect.objectContaining({
       channelId: "C123",
       rootThreadTs: "111.222",
@@ -197,7 +197,7 @@ describe("SlackConversationService", () => {
     await service.stop();
   });
 
-  it("clears the active turn when posting a visible final Slack message", async () => {
+  it("records a visible final Slack message without owning active turn completion", async () => {
     const codex = new EventEmitter();
     const recordTurnSignal = vi.fn(async () => TEST_SESSION);
     const setActiveTurnId = vi.fn(async () => ({
@@ -241,7 +241,7 @@ describe("SlackConversationService", () => {
       turnId: "turn-1",
       kind: "final"
     }));
-    expect(setActiveTurnId).toHaveBeenCalledWith("C123", "111.222", undefined);
+    expect(setActiveTurnId).not.toHaveBeenCalled();
 
     await service.stop();
   });

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { StateStore } from "../src/store/state-store.js";
+import { STATE_DATABASE_FILENAME, StateStore } from "../src/store/state-store.js";
 
 describe("StateStore", () => {
-  it("serializes concurrent saves without losing the final state", async () => {
+  it("persists sessions and processed events in the SQLite database", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
     const sessionsRoot = path.join(stateDir, "sessions");
     const store = new StateStore(stateDir, sessionsRoot);
@@ -25,18 +25,67 @@ describe("StateStore", () => {
         updatedAt: "2026-03-15T00:00:00.000Z"
       })
     ]);
+    store.close();
 
-    const processedEventIds = JSON.parse(
-      await fs.readFile(path.join(stateDir, "processed-event-ids.json"), "utf8")
-    ) as string[];
-    const persistedSession = JSON.parse(
-      await fs.readFile(
-        path.join(stateDir, "sessions", Buffer.from("C123:111.222", "utf8").toString("base64url") + ".json"),
-        "utf8"
-      )
-    ) as { readonly key: string };
+    await expect(fs.access(path.join(stateDir, STATE_DATABASE_FILENAME))).resolves.toBeUndefined();
 
-    expect(processedEventIds).toEqual(expect.arrayContaining(["EvA", "EvB"]));
-    expect(persistedSession).toEqual(expect.objectContaining({ key: "C123:111.222" }));
+    const reloaded = new StateStore(stateDir, sessionsRoot);
+    await reloaded.load();
+    expect(reloaded.hasProcessedEvent("EvA")).toBe(true);
+    expect(reloaded.hasProcessedEvent("EvB")).toBe(true);
+    expect(reloaded.getSession("C123:111.222")).toEqual(expect.objectContaining({
+      key: "C123:111.222"
+    }));
+    reloaded.close();
+  });
+
+  it("deletes session state transactionally with inbound messages and background jobs", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const store = new StateStore(stateDir, sessionsRoot);
+    await store.load();
+    await store.upsertSession({
+      key: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      workspacePath: "/tmp/sessions/C123-111.222/workspace",
+      createdAt: "2026-03-15T00:00:00.000Z",
+      updatedAt: "2026-03-15T00:00:00.000Z"
+    });
+    await store.upsertInboundMessage({
+      key: "inbound-1",
+      sessionKey: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      messageTs: "111.223",
+      source: "thread_reply",
+      userId: "U123",
+      text: "follow up",
+      status: "pending",
+      createdAt: "2026-03-15T00:00:01.000Z",
+      updatedAt: "2026-03-15T00:00:01.000Z"
+    });
+    await store.upsertBackgroundJob({
+      id: "job-1",
+      token: "token-1",
+      sessionKey: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      kind: "watch_ci",
+      shell: "sh",
+      cwd: "/tmp/sessions/C123-111.222/workspace",
+      scriptPath: "/tmp/jobs/job-1/run.sh",
+      restartOnBoot: true,
+      status: "running",
+      createdAt: "2026-03-15T00:00:02.000Z",
+      updatedAt: "2026-03-15T00:00:02.000Z"
+    });
+
+    await expect(store.deleteSession("C123:111.222")).resolves.toBe(true);
+
+    expect(store.getSession("C123:111.222")).toBeUndefined();
+    expect(store.listInboundMessages({ sessionKey: "C123:111.222" })).toHaveLength(0);
+    expect(store.listBackgroundJobs({ sessionKey: "C123:111.222" })).toHaveLength(0);
+    store.close();
   });
 });


### PR DESCRIPTION
## What changed

- Replaced the broker split JSON state files with a single SQLite database at `state/broker.sqlite`.
- Updated session, inbound message, processed event, and background job state reads/writes to use transactional SQLite tables with cascading session deletes.
- Updated ops/bootstrap/status tooling and README runtime layout for the SQLite state file.
- Tightened active turn lifecycle semantics so `/slack/post-state` records final/block/wait state without claiming turn completion; actual turn completion still owns clearing `activeTurnId`.

## Why

The broker state is cross-cutting runtime coordination data. Keeping it in scattered JSON files made concurrent reads/writes and cleanup semantics fragile. SQLite gives one transactional state surface and makes cleanup/session inspection less error-prone.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test`
- `node --check scripts/ops/lib.mjs && node --check scripts/ops/macos-bootstrap.mjs`