### PR TITLE
[codex] Run macOS services from current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Before running it, make sure the Slack app credentials are available through one
 
 What it prepares:
 
-- `releases/<sha>` worktrees for worker releases
+- `releases/<sha>` worktrees for admin and worker releases
 - `current`, `previous`, and `failed` release links
 - shared runtime state under `.data/`
 - support homes under `runtime-support/`
@@ -196,15 +196,15 @@ What it does not do:
 
 ### Runtime layout on the VM
 
-The fixed clone is both the admin code root and the Git source of truth for worker releases.
+The fixed clone is the Git source of truth for release worktrees. Runtime services execute code through the `current` release link, not directly from the fixed clone.
 
 - `<service-root>/`:
   - long-lived git clone
-  - admin launchd working directory
+  - release manager and shared runtime root
 - `<service-root>/releases/<sha>/`:
-  - worker build for a specific commit
+  - admin and worker build for a specific commit
 - `<service-root>/current`:
-  - symlink to the active worker release
+  - symlink to the active admin/worker release
 - `<service-root>/previous`:
   - symlink to the last good worker release
 - `<service-root>/failed`:
@@ -214,7 +214,7 @@ The fixed clone is both the admin code root and the Git source of truth for work
 
 ### Deploy and rollback
 
-The admin service fetches from the VM's local Git clone and deploys a selected ref into a new worker release directory.
+The admin service fetches from the VM's local Git clone and deploys a selected ref into a new release directory. Both launchd agents are written to execute through `current`; the deploy operation switches `current` before restarting the worker.
 
 - deploy:
   - `git fetch origin`

--- a/scripts/ops/macos-bootstrap.mjs
+++ b/scripts/ops/macos-bootstrap.mjs
@@ -152,9 +152,9 @@ function printHelp() {
       "",
       "What it does:",
       "  - expects to run inside the VM's long-lived git clone",
-      "  - uses that clone as the stable admin/control repo",
+      "  - uses that clone as the stable Git source for release worktrees",
       "  - prepares shared runtime directories under the service root",
-      "  - creates a worker release from the current commit under releases/<sha>",
+      "  - creates an admin/worker release from the current commit under releases/<sha>",
       "  - writes admin/worker launchd plists and env files",
       "  - starts admin immediately; worker is optional",
       "",
@@ -580,12 +580,12 @@ async function ensureInitialWorkerRelease(paths, options) {
 }
 
 async function writeLaunchdFiles(paths, options, seedBrokerEnv) {
-  const launcherPath = path.join(paths.repoRoot, "scripts", "ops", "macos-launchd-launcher.mjs");
+  const launcherPath = path.join(paths.currentReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
   const adminPlist = renderPlist({
     label: options.adminLabel,
     nodePath: options.nodePath,
     launcherPath,
-    repoRootPath: paths.repoRoot,
+    repoRootPath: paths.currentReleasePath,
     envFilePath: paths.adminEnvFile,
     entryPoint: "dist/src/admin-index.js",
     stdoutPath: paths.adminStdoutPath,

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -1021,15 +1021,17 @@ describe.sequential("slack-codex-broker e2e", () => {
     });
     let turnCount = 0;
     const mockCodex = new MockCodexAppServer({
-      onTurnStart: async () => {
+      onTurnStart: async (context) => {
         turnCount += 1;
         if (turnCount === 1) {
+          await waitForSessionActive(tempRoot, "C123:777.220");
           await postJson(`${brokerBaseUrl}/slack/post-state`, {
             channel_id: "C123",
             thread_ts: "777.220",
             kind: "wait",
             reason: "waiting for async job"
           });
+          context.complete("");
         }
       }
     });
@@ -1078,30 +1080,39 @@ describe.sequential("slack-codex-broker e2e", () => {
       appId: "AAPP"
     });
     let turnCount = 0;
+    const firstTurnCompleted = createDeferred<void>();
     const mockCodex = new MockCodexAppServer({
-      onTurnStart: async () => {
+      onTurnStart: async (context) => {
         turnCount += 1;
         if (turnCount === 1) {
-          const registerResponse = await fetch(`${brokerBaseUrl}/jobs/register`, {
-            method: "POST",
-            headers: {
-              "content-type": "application/json"
-            },
-            body: JSON.stringify({
+          try {
+            await waitForSessionActive(tempRoot, "C123:778.220");
+            const registerResponse = await fetch(`${brokerBaseUrl}/jobs/register`, {
+              method: "POST",
+              headers: {
+                "content-type": "application/json"
+              },
+              body: JSON.stringify({
+                channel_id: "C123",
+                thread_ts: "778.220",
+                kind: "watch_ci",
+                script: "#!/bin/sh\nsleep 30"
+              })
+            });
+            expect(registerResponse.ok).toBe(true);
+
+            await postJson(`${brokerBaseUrl}/slack/post-state`, {
               channel_id: "C123",
               thread_ts: "778.220",
-              kind: "watch_ci",
-              script: "#!/bin/sh\nsleep 30"
-            })
-          });
-          expect(registerResponse.ok).toBe(true);
-
-          await postJson(`${brokerBaseUrl}/slack/post-state`, {
-            channel_id: "C123",
-            thread_ts: "778.220",
-            kind: "wait",
-            reason: "waiting for async job"
-          });
+              kind: "wait",
+              reason: "waiting for async job"
+            });
+            context.complete("");
+            firstTurnCompleted.resolve();
+          } catch (error) {
+            firstTurnCompleted.reject(error);
+            throw error;
+          }
         }
       }
     });
@@ -1129,12 +1140,13 @@ describe.sequential("slack-codex-broker e2e", () => {
       text: "<@UBOT> 盯一下这个"
     });
 
-    await waitForSessionIdle(tempRoot, "C123:778.220");
+    await firstTurnCompleted.promise;
+    await waitForSessionIdle(tempRoot, "C123:778.220", 60_000);
     const postedMessageCountAfterIdle = mockSlack.postedMessages.length;
     await delay(1_000);
     expect(turnCount).toBe(1);
     expect(mockSlack.postedMessages).toHaveLength(postedMessageCountAfterIdle);
-  }, 60_000);
+  }, 90_000);
 
   it("does not wake a silent block turn that already recorded its blocker", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
@@ -1149,16 +1161,25 @@ describe.sequential("slack-codex-broker e2e", () => {
       appId: "AAPP"
     });
     let turnCount = 0;
+    const firstTurnCompleted = createDeferred<void>();
     const mockCodex = new MockCodexAppServer({
-      onTurnStart: async () => {
+      onTurnStart: async (context) => {
         turnCount += 1;
         if (turnCount === 1) {
-          await postJson(`${brokerBaseUrl}/slack/post-state`, {
-            channel_id: "C123",
-            thread_ts: "779.220",
-            kind: "block",
-            reason: "waiting for user approval"
-          });
+          try {
+            await waitForSessionActive(tempRoot, "C123:779.220");
+            await postJson(`${brokerBaseUrl}/slack/post-state`, {
+              channel_id: "C123",
+              thread_ts: "779.220",
+              kind: "block",
+              reason: "waiting for user approval"
+            });
+            context.complete("");
+            firstTurnCompleted.resolve();
+          } catch (error) {
+            firstTurnCompleted.reject(error);
+            throw error;
+          }
         }
       }
     });
@@ -1186,12 +1207,13 @@ describe.sequential("slack-codex-broker e2e", () => {
       text: "<@UBOT> 这步先停住"
     });
 
-    await waitForSessionIdle(tempRoot, "C123:779.220");
+    await firstTurnCompleted.promise;
+    await waitForSessionIdle(tempRoot, "C123:779.220", 60_000);
     const postedMessageCountAfterIdle = mockSlack.postedMessages.length;
     await delay(1_000);
     expect(turnCount).toBe(1);
     expect(mockSlack.postedMessages).toHaveLength(postedMessageCountAfterIdle);
-  }, 60_000);
+  }, 90_000);
 
   it("does not wake a silent final turn or replay stale watcher events after completion", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
@@ -1208,34 +1230,43 @@ describe.sequential("slack-codex-broker e2e", () => {
     let turnCount = 0;
     let registeredJobId = "";
     let registeredJobToken = "";
+    const firstTurnCompleted = createDeferred<void>();
     const mockCodex = new MockCodexAppServer({
-      onTurnStart: async () => {
+      onTurnStart: async (context) => {
         turnCount += 1;
         if (turnCount === 1) {
-          const registerResponse = await fetch(`${brokerBaseUrl}/jobs/register`, {
-            method: "POST",
-            headers: {
-              "content-type": "application/json"
-            },
-            body: JSON.stringify({
+          try {
+            await waitForSessionActive(tempRoot, "C123:780.220");
+            const registerResponse = await fetch(`${brokerBaseUrl}/jobs/register`, {
+              method: "POST",
+              headers: {
+                "content-type": "application/json"
+              },
+              body: JSON.stringify({
+                channel_id: "C123",
+                thread_ts: "780.220",
+                kind: "watch_ci",
+                script: "#!/bin/sh\nsleep 30"
+              })
+            });
+            expect(registerResponse.ok).toBe(true);
+            const registerJson = await registerResponse.json() as {
+              job: { id: string; token: string };
+            };
+            registeredJobId = registerJson.job.id;
+            registeredJobToken = registerJson.job.token;
+
+            await postJson(`${brokerBaseUrl}/slack/post-state`, {
               channel_id: "C123",
               thread_ts: "780.220",
-              kind: "watch_ci",
-              script: "#!/bin/sh\nsleep 30"
-            })
-          });
-          expect(registerResponse.ok).toBe(true);
-          const registerJson = await registerResponse.json() as {
-            job: { id: string; token: string };
-          };
-          registeredJobId = registerJson.job.id;
-          registeredJobToken = registerJson.job.token;
-
-          await postJson(`${brokerBaseUrl}/slack/post-state`, {
-            channel_id: "C123",
-            thread_ts: "780.220",
-            kind: "final"
-          });
+              kind: "final"
+            });
+            context.complete("");
+            firstTurnCompleted.resolve();
+          } catch (error) {
+            firstTurnCompleted.reject(error);
+            throw error;
+          }
         }
       }
     });
@@ -1263,7 +1294,8 @@ describe.sequential("slack-codex-broker e2e", () => {
       text: "<@UBOT> 合并之后继续盯一下"
     });
 
-    await waitForSessionIdle(tempRoot, "C123:780.220");
+    await firstTurnCompleted.promise;
+    await waitForSessionIdle(tempRoot, "C123:780.220", 60_000);
     expect(turnCount).toBe(1);
     expect(registeredJobId).not.toBe("");
     expect(registeredJobToken).not.toBe("");
@@ -1285,7 +1317,7 @@ describe.sequential("slack-codex-broker e2e", () => {
     await delay(1_000);
     expect(turnCount).toBe(1);
     expect(mockSlack.postedMessages).toHaveLength(postedMessageCountAfterIdle);
-  }, 60_000);
+  }, 90_000);
 
   it("does not recover the broker's own Slack messages as inbound work", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
@@ -1584,10 +1616,12 @@ async function waitForSessionIdle(
   timeoutMs = DEFAULT_E2E_TIMEOUT_MS
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
+  let lastSession: SlackSessionRecord | undefined;
 
   while (Date.now() < deadline) {
     try {
       const session = await readSessionRecord(tempRoot, sessionKey);
+      lastSession = session;
       if (!session.activeTurnId) {
         return;
       }
@@ -1598,7 +1632,11 @@ async function waitForSessionIdle(
     await delay(100);
   }
 
-  throw new Error(`Timed out waiting for session idle: ${sessionKey}`);
+  throw new Error(`Timed out waiting for session idle: ${sessionKey}; lastSession=${JSON.stringify({
+    activeTurnId: lastSession?.activeTurnId ?? null,
+    lastTurnSignalKind: lastSession?.lastTurnSignalKind ?? null,
+    lastTurnSignalTurnId: lastSession?.lastTurnSignalTurnId ?? null
+  })}`);
 }
 
 async function waitForSessionActive(
@@ -1713,4 +1751,23 @@ async function postJson(url: string, payload: Record<string, unknown>): Promise<
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for ${url}: ${await response.text()}`);
   }
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject
+  };
 }

--- a/test/macos-bootstrap.test.ts
+++ b/test/macos-bootstrap.test.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("macOS bootstrap", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((directory) =>
+        fs.rm(directory, {
+          force: true,
+          recursive: true
+        })
+      )
+    );
+  });
+
+  it("writes admin and worker launchd agents that both run from the current release", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-bootstrap-"));
+    tempDirs.push(tempRoot);
+
+    const home = path.join(tempRoot, "home");
+    const fakeBin = path.join(tempRoot, "bin");
+    const serviceRoot = path.join(tempRoot, "service");
+    const commandLog = path.join(tempRoot, "commands.log");
+    const revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    await fs.mkdir(path.join(home, ".codex"), { recursive: true });
+    await fs.mkdir(fakeBin, { recursive: true });
+    await fs.mkdir(serviceRoot, { recursive: true });
+    await writeExecutable(path.join(fakeBin, "git"), [
+      "#!/bin/sh",
+      "set -eu",
+      "echo \"git $*\" >> \"$FAKE_COMMAND_LOG\"",
+      "if [ \"${1:-}\" = \"rev-parse\" ] && [ \"${2:-}\" = \"HEAD\" ]; then",
+      "  echo \"$TEST_REVISION\"",
+      "  exit 0",
+      "fi",
+      "if [ \"${1:-}\" = \"branch\" ] && [ \"${2:-}\" = \"--show-current\" ]; then",
+      "  echo main",
+      "  exit 0",
+      "fi",
+      "if [ \"${1:-}\" = \"-C\" ] && [ \"${3:-}\" = \"worktree\" ] && [ \"${4:-}\" = \"add\" ]; then",
+      "  mkdir -p \"$6/.git\"",
+      "  echo \"$7\" > \"$6/.revision\"",
+      "  exit 0",
+      "fi",
+      "echo \"unexpected git command: $*\" >&2",
+      "exit 1"
+    ].join("\n"));
+    await writeExecutable(path.join(fakeBin, "corepack"), fakeCommandScript("corepack"));
+    await writeExecutable(path.join(fakeBin, "npm"), fakeCommandScript("npm"));
+    await writeExecutable(path.join(fakeBin, "launchctl"), fakeCommandScript("launchctl"));
+    await writeExecutable(path.join(fakeBin, "node"), fakeCommandScript("node"));
+
+    const result = await runNodeScript(
+      [
+        "scripts/ops/macos-bootstrap.mjs",
+        "--service-root",
+        serviceRoot,
+        "--label",
+        "test.admin",
+        "--worker-label",
+        "test.worker",
+        "--node-path",
+        path.join(fakeBin, "node"),
+        "--corepack-path",
+        path.join(fakeBin, "corepack")
+      ],
+      {
+        ...process.env,
+        PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        HOME: home,
+        SLACK_APP_TOKEN: "xapp-test",
+        SLACK_BOT_TOKEN: "xoxb-test",
+        TEST_REVISION: revision,
+        FAKE_COMMAND_LOG: commandLog
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      ok: true,
+      serviceRoot,
+      currentReleasePath: path.join(serviceRoot, "current"),
+      workerStarted: false
+    });
+
+    const currentReleasePath = path.join(serviceRoot, "current");
+    const releaseRoot = path.join(serviceRoot, "releases", revision);
+    await expect(fs.readlink(currentReleasePath)).resolves.toBe(path.relative(serviceRoot, releaseRoot));
+
+    const adminPlist = await fs.readFile(path.join(home, "Library", "LaunchAgents", "test.admin.plist"), "utf8");
+    const workerPlist = await fs.readFile(path.join(home, "Library", "LaunchAgents", "test.worker.plist"), "utf8");
+    const launcherPath = path.join(currentReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
+
+    expectLaunchdRuntime(adminPlist, {
+      launcherPath,
+      repoRootPath: currentReleasePath,
+      entryPoint: "dist/src/admin-index.js"
+    });
+    expectLaunchdRuntime(workerPlist, {
+      launcherPath,
+      repoRootPath: currentReleasePath,
+      entryPoint: "dist/src/worker-index.js"
+    });
+  });
+});
+
+async function writeExecutable(filePath: string, content: string): Promise<void> {
+  await fs.writeFile(filePath, `${content}\n`, "utf8");
+  await fs.chmod(filePath, 0o755);
+}
+
+function fakeCommandScript(command: string): string {
+  return [
+    "#!/bin/sh",
+    "set -eu",
+    `echo "${command} $*" >> "$FAKE_COMMAND_LOG"`
+  ].join("\n");
+}
+
+function runNodeScript(args: readonly string[], env: NodeJS.ProcessEnv): Promise<{
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (status) => {
+      resolve({
+        status,
+        stdout,
+        stderr
+      });
+    });
+  });
+}
+
+function expectLaunchdRuntime(
+  plist: string,
+  expected: {
+    readonly launcherPath: string;
+    readonly repoRootPath: string;
+    readonly entryPoint: string;
+  }
+): void {
+  expect(plist).toContain(`<string>${expected.launcherPath}</string>`);
+  expect(plist).toContain([
+    "    <string>--repo-root</string>",
+    `    <string>${expected.repoRootPath}</string>`
+  ].join("\n"));
+  expect(plist).toContain([
+    "    <string>--entry-point</string>",
+    `    <string>${expected.entryPoint}</string>`
+  ].join("\n"));
+  expect(plist).toContain([
+    "  <key>WorkingDirectory</key>",
+    `  <string>${expected.repoRootPath}</string>`
+  ].join("\n"));
+}


### PR DESCRIPTION
## Summary

- Add an end-to-end macOS bootstrap test that runs the real bootstrap CLI with fake system commands and verifies both launchd agents execute through `current`.
- Change bootstrap-generated admin launchd configuration to use the release-managed launcher and `current` as its repo root/working directory, matching the worker.
- Stabilize post-state e2e cases by waiting until the broker has persisted the active turn before the mock Codex runtime posts `wait`, `block`, or `final` state.
- Update runtime layout docs so the fixed clone is described as the release manager/source repo, not the admin runtime root.

## Root Cause

The live handoff says admin and worker should both run from `/Users/admin/services/slack-codex-broker/current`, but `macos-bootstrap.mjs` still generated the admin plist from the service-root clone. Re-running bootstrap could therefore regress the VM back to the stale root clone for admin/control.

CI also exposed an existing e2e race: the mock Codex server could post `/slack/post-state` immediately after `turn/start`, before the broker had written `activeTurnId` to SQLite. That made the wait/block/final state tests timing-sensitive under load.

## Validation

- `pnpm vitest run test/macos-bootstrap.test.ts`
- `pnpm vitest run test/e2e-broker.test.ts`
- `pnpm build`
- `pnpm test` (35 files, 176 tests)
