### PR TITLE
[codex] redesign admin control plane resources

### DIFF
--- a/src/http/admin-page.ts
+++ b/src/http/admin-page.ts
@@ -6,21 +6,23 @@ export function renderAdminPage(options: {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>${escapeHtml(options.serviceName)} 控制台</title>
+  <title>${escapeHtml(options.serviceName)} 管理台</title>
   <style>
     :root {
       color-scheme: dark;
-      --accent: #ff962d;
-      --accent-soft: rgba(255, 150, 45, 0.1);
-      --bg: #050505;
-      --panel: #0a0a0a;
-      --border: rgba(255, 150, 45, 0.2);
-      --border-strong: rgba(255, 150, 45, 0.4);
-      --text: #eee;
-      --muted: #888;
-      --good: #34dd93;
-      --warn: #ffcb63;
-      --danger: #ff7458;
+      --bg: #07090c;
+      --panel: #10141a;
+      --panel-soft: #151b23;
+      --panel-strong: #1d2630;
+      --line: #27313c;
+      --line-strong: #405161;
+      --text: #eef3f6;
+      --muted: #8b9aa7;
+      --amber: #f6a23a;
+      --cyan: #52c7d8;
+      --green: #4bd28f;
+      --red: #ff7468;
+      --purple: #b792ff;
       --mono: "IBM Plex Mono", "SF Mono", "JetBrains Mono", ui-monospace, monospace;
     }
     * { box-sizing: border-box; }
@@ -30,334 +32,621 @@ export function renderAdminPage(options: {
       color: var(--text);
       font-family: var(--mono);
       font-size: 13px;
-      line-height: 1.4;
+      line-height: 1.45;
     }
-    .wrap {
-      max-width: 1600px;
+    .shell {
+      max-width: 1640px;
+      min-width: 980px;
       margin: 0 auto;
-      padding: 16px;
+      padding: 18px;
     }
-    header {
-      display: flex;
-      justify-content: space-between;
-      align-items: baseline;
-      border-bottom: 2px solid var(--accent);
-      padding-bottom: 8px;
-      margin-bottom: 16px;
+    .topbar {
+      display: grid;
+      grid-template-columns: minmax(260px, 1fr) auto;
+      gap: 16px;
+      align-items: end;
+      padding-bottom: 14px;
+      border-bottom: 1px solid var(--line-strong);
     }
-    h1 { margin: 0; font-size: 18px; text-transform: uppercase; color: var(--accent); }
-    .header-meta { display: flex; gap: 12px; }
-    .header-tools {
+    h1 {
+      margin: 0;
+      color: var(--text);
+      font-size: 20px;
+      letter-spacing: 0;
+      text-transform: uppercase;
+    }
+    .subtitle {
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: 11px;
+    }
+    .top-actions {
       display: flex;
-      gap: 8px;
       align-items: center;
+      justify-content: flex-end;
+      gap: 10px;
       flex-wrap: wrap;
     }
-    
-    .grid-summary {
-      display: grid;
-      grid-template-columns: repeat(4, 1fr);
-      gap: 1px;
-      background: var(--border);
-      border: 1px solid var(--border);
-      margin-bottom: 16px;
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 28px;
+      padding: 5px 8px;
+      border: 1px solid var(--line);
+      color: var(--muted);
+      background: #090c10;
+      font-size: 10px;
+      text-transform: uppercase;
+      white-space: nowrap;
     }
-    .summary-item {
-      background: var(--panel);
-      padding: 12px;
+    button {
+      min-height: 30px;
+      border: 1px solid var(--line-strong);
+      background: var(--panel-strong);
+      color: var(--text);
+      padding: 6px 11px;
+      font-family: inherit;
+      font-size: 11px;
+      font-weight: 700;
+      cursor: pointer;
+      text-transform: uppercase;
     }
-    .summary-label { font-size: 10px; color: var(--muted); text-transform: uppercase; margin-bottom: 4px; }
-    .summary-value { font-size: 20px; font-weight: bold; color: var(--accent); }
-    .summary-detail { font-size: 11px; color: var(--muted); margin-top: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    button:hover { border-color: var(--cyan); color: var(--cyan); }
+    button.primary { border-color: var(--amber); background: var(--amber); color: #111; }
+    button.secondary { background: transparent; color: var(--cyan); border-color: var(--cyan); }
+    button.danger { background: transparent; color: var(--red); border-color: var(--red); }
+    button:disabled { opacity: 0.5; cursor: default; }
 
-    .main-layout {
+    .command-grid {
       display: grid;
-      grid-template-columns: 1fr 400px;
+      grid-template-columns: minmax(360px, 1fr) minmax(360px, 1.1fr) minmax(320px, 0.9fr);
+      gap: 12px;
+      margin: 16px 0;
+    }
+    .panel {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      min-width: 0;
+    }
+    .panel-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      min-height: 38px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel-soft);
+    }
+    .panel-title {
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+    .panel-body { padding: 12px; }
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1px;
+      border: 1px solid var(--line);
+      background: var(--line);
+    }
+    .metric {
+      min-height: 76px;
+      padding: 10px 12px;
+      background: #0b0f14;
+    }
+    .metric-label {
+      color: var(--muted);
+      font-size: 10px;
+      text-transform: uppercase;
+      margin-bottom: 5px;
+    }
+    .metric-value {
+      color: var(--text);
+      font-size: 24px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .metric-value.good { color: var(--green); }
+    .metric-value.warn { color: var(--amber); }
+    .metric-value.danger { color: var(--red); }
+    .metric-detail {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 11px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .risk-strip {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .risk-cell {
+      border: 1px solid var(--line);
+      background: #0b0f14;
+      padding: 9px;
+    }
+    .risk-number {
+      font-size: 20px;
+      font-weight: 800;
+      color: var(--amber);
+    }
+    .risk-label {
+      margin-top: 3px;
+      color: var(--muted);
+      font-size: 10px;
+      text-transform: uppercase;
+    }
+    .risk-copy {
+      min-height: 48px;
+      padding: 10px;
+      border: 1px solid var(--line);
+      color: var(--muted);
+      background: #0b0f14;
+      font-size: 12px;
+    }
+    .operation-list {
+      display: grid;
+      gap: 8px;
+    }
+    .operation-row {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 10px;
+      align-items: center;
+      padding: 10px;
+      border: 1px solid var(--line);
+      background: #0b0f14;
+    }
+    .operation-main { min-width: 0; }
+    .operation-title {
+      color: var(--text);
+      font-weight: 800;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .operation-detail {
+      margin-top: 3px;
+      color: var(--muted);
+      font-size: 11px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .audit-list {
+      display: grid;
+      gap: 5px;
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 11px;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 22px;
+      padding: 2px 7px;
+      border: 1px solid currentColor;
+      font-size: 10px;
+      font-weight: 800;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .badge.good { color: var(--green); }
+    .badge.warn { color: var(--amber); }
+    .badge.danger { color: var(--red); }
+    .badge.info { color: var(--cyan); }
+    .badge.purple { color: var(--purple); }
+
+    .workspace {
+      display: grid;
+      grid-template-columns: minmax(620px, 1fr) 420px;
       gap: 16px;
       align-items: start;
     }
-    section {
-      border: 1px solid var(--border);
-      background: var(--panel);
-      margin-bottom: 16px;
-    }
-    .section-head {
-      background: var(--accent-soft);
-      padding: 6px 12px;
-      border-bottom: 1px solid var(--border);
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-    .section-title { font-size: 12px; font-weight: bold; text-transform: uppercase; color: var(--accent); }
-    
-    .toolbar { display: flex; gap: 8px; padding: 12px; border-bottom: 1px solid var(--border); background: rgba(255,255,255,0.02); }
-    .toolbar input, .toolbar select { 
-      background: #000; border: 1px solid var(--border); color: var(--text); 
-      padding: 6px 10px; font-family: inherit; font-size: 12px; 
-    }
-    .toolbar input[type="search"] { flex: 1; }
-
-    .session-table-header {
+    .stack { display: grid; gap: 16px; }
+    .toolbar {
       display: grid;
-      grid-template-columns: 1.5fr 1fr 1.2fr 1fr 80px;
-      gap: 8px;
-      padding: 8px 12px;
-      border-bottom: 1px solid var(--border);
-      color: var(--muted);
-      font-size: 11px;
-      text-transform: uppercase;
+      grid-template-columns: minmax(240px, 1fr) 120px;
+      gap: 10px;
+      padding: 12px;
+      border-bottom: 1px solid var(--line);
+      background: #0b0f14;
+    }
+    input, textarea, select {
+      width: 100%;
+      min-height: 32px;
+      border: 1px solid var(--line);
+      background: #07090c;
+      color: var(--text);
+      padding: 7px 9px;
+      font-family: inherit;
+      font-size: 12px;
+    }
+    textarea { min-height: 140px; resize: vertical; }
+    input:focus, textarea:focus, select:focus {
+      outline: 1px solid var(--cyan);
+      border-color: var(--cyan);
     }
     .session-list { display: grid; }
-    .session-row { border-bottom: 1px solid var(--border); }
+    .session-table-header,
     .session-summary {
       display: grid;
-      grid-template-columns: 1.5fr 1fr 1.2fr 1fr 80px;
-      gap: 8px;
-      padding: 10px 12px;
-      cursor: pointer;
+      grid-template-columns: minmax(180px, 1.2fr) 120px minmax(150px, 0.8fr) minmax(220px, 1fr) 76px;
+      gap: 12px;
       align-items: center;
     }
-    .session-summary:hover { background: rgba(255,150,45,0.05); }
-    .session-key { color: var(--accent); font-weight: bold; overflow: hidden; text-overflow: ellipsis; }
-    .session-body { padding: 12px; background: #000; border-top: 1px solid var(--border); }
-
-    .tui-table { width: 100%; border-collapse: collapse; font-size: 12px; }
-    .tui-table th { text-align: left; color: var(--muted); padding: 4px 8px; border-bottom: 1px solid var(--border); font-size: 10px; text-transform: uppercase; }
-    .tui-table td { padding: 6px 8px; border-bottom: 1px solid rgba(255,255,255,0.05); }
-
+    .session-table-header {
+      padding: 9px 12px;
+      color: var(--muted);
+      font-size: 10px;
+      text-transform: uppercase;
+      border-bottom: 1px solid var(--line);
+      background: #0b0f14;
+    }
+    .session-row {
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+    }
+    .session-summary {
+      padding: 12px;
+      cursor: pointer;
+    }
+    .session-summary:hover { background: #131a22; }
+    .session-key {
+      color: var(--cyan);
+      font-weight: 800;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .session-channel {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 11px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .session-body {
+      padding: 14px 12px 16px;
+      border-top: 1px solid var(--line);
+      background: #090c10;
+    }
+    .session-inspector {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .mini-panel {
+      border: 1px solid var(--line);
+      background: #0b0f14;
+      min-width: 0;
+    }
+    .mini-title {
+      padding: 7px 9px;
+      border-bottom: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 10px;
+      text-transform: uppercase;
+    }
+    .mini-body { padding: 9px; }
+    .timeline {
+      display: grid;
+      gap: 7px;
+    }
+    .timeline-event {
+      display: grid;
+      grid-template-columns: 86px auto 1fr;
+      gap: 8px;
+      align-items: baseline;
+      min-height: 26px;
+      color: var(--muted);
+      font-size: 11px;
+    }
+    .timeline-event strong {
+      color: var(--text);
+      font-size: 12px;
+    }
+    .table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    .table th {
+      text-align: left;
+      color: var(--muted);
+      font-size: 10px;
+      text-transform: uppercase;
+      padding: 4px 6px;
+      border-bottom: 1px solid var(--line);
+    }
+    .table td {
+      padding: 6px;
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      vertical-align: top;
+    }
+    .maintenance-grid {
+      display: grid;
+      gap: 10px;
+    }
     .profile-row {
       display: grid;
       gap: 8px;
-      width: 100%;
-      padding: 12px;
-      border: 1px solid var(--border);
-      background: rgba(255, 255, 255, 0.01);
+      padding: 11px;
+      border: 1px solid var(--line);
+      background: #0b0f14;
     }
     .profile-row.is-active {
-      border-color: var(--border-strong);
-      background: rgba(255, 150, 45, 0.05);
+      border-color: var(--cyan);
+      background: rgba(82, 199, 216, 0.06);
     }
     .profile-line {
       display: flex;
       gap: 8px;
       align-items: baseline;
       flex-wrap: wrap;
+      min-width: 0;
     }
     .profile-account {
-      font-weight: bold;
-      color: var(--accent);
+      color: var(--text);
+      font-weight: 800;
+      overflow-wrap: anywhere;
     }
     .profile-plan,
-    .profile-quota {
+    .summary-detail {
       color: var(--muted);
       font-size: 11px;
-    }
-    .profile-quota {
-      display: grid;
-      gap: 2px;
-    }
-    .profile-quota-line {
-      display: grid;
-      grid-template-columns: 56px 88px 1fr;
-      gap: 8px;
-      align-items: baseline;
-    }
-    .profile-quota-label {
-      color: var(--muted);
-    }
-    .profile-quota-value {
-      color: var(--text);
-      font-weight: bold;
-    }
-    .profile-quota-reset {
-      color: var(--muted);
-      text-align: right;
     }
     .profile-actions {
       display: flex;
       gap: 8px;
       flex-wrap: wrap;
-      align-items: center;
     }
-    
-    .badge {
-      display: inline-block; padding: 2px 6px; font-size: 10px; font-weight: bold;
-      text-transform: uppercase; border: 1px solid currentColor;
+    .quota-grid {
+      display: grid;
+      gap: 5px;
     }
-    .badge.good { color: var(--good); }
-    .badge.warn { color: var(--warn); }
-    .badge.danger { color: var(--danger); }
-
-    button {
-      background: var(--accent); color: #000; border: none; padding: 6px 12px;
-      font-family: inherit; font-size: 11px; font-weight: bold; cursor: pointer;
-      text-transform: uppercase;
+    .quota-line {
+      display: grid;
+      grid-template-columns: 60px 88px 1fr;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 11px;
     }
-    button.secondary { background: transparent; color: var(--accent); border: 1px solid var(--accent); }
-    button.danger { background: transparent; color: var(--danger); border: 1px solid var(--danger); }
-    button:disabled { opacity: 0.5; cursor: default; }
-    
-    textarea, input[type="password"], input[type="file"], input[type="text"] {
-      width: 100%; background: #000; border: 1px solid var(--border); color: var(--text);
-      padding: 8px; font-family: inherit; font-size: 12px;
+    .quota-line strong { color: var(--text); }
+    .deploy-actions {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 8px;
+      margin-bottom: 8px;
     }
-    textarea { min-height: 120px; }
-    
+    .release-stack {
+      display: grid;
+      gap: 8px;
+      margin-top: 10px;
+    }
+    .release-row {
+      border: 1px solid var(--line);
+      background: #0b0f14;
+      padding: 10px;
+    }
+    .log-list {
+      max-height: 260px;
+      overflow: auto;
+      font-size: 11px;
+    }
+    .log-entry {
+      display: grid;
+      grid-template-columns: 76px 1fr;
+      gap: 8px;
+      padding: 6px 12px;
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+    }
+    .log-entry.warn { color: var(--amber); }
+    .log-entry.error { color: var(--red); }
     dialog {
-      background: var(--panel); border: 2px solid var(--accent); color: var(--text);
-      padding: 0; width: 600px; max-width: 90vw;
+      width: 620px;
+      max-width: 92vw;
+      padding: 0;
+      border: 1px solid var(--cyan);
+      background: var(--panel);
+      color: var(--text);
     }
-    dialog::backdrop { background: rgba(0,0,0,0.8); backdrop-filter: blur(2px); }
-    .modal-content { padding: 20px; display: grid; gap: 16px; }
-    
-    .log-list { max-height: 400px; overflow-y: auto; font-size: 11px; }
-    .log-entry { padding: 4px 12px; border-bottom: 1px solid rgba(255,255,255,0.05); }
-    .log-entry.warn { color: var(--warn); background: rgba(255, 203, 99, 0.05); }
-    .log-entry.error { color: var(--danger); background: rgba(255, 116, 88, 0.05); }
-    @media (max-width: 1000px) {
-      .main-layout { grid-template-columns: 1fr; }
-      .grid-summary { grid-template-columns: 1fr 1fr; }
+    dialog::backdrop { background: rgba(0,0,0,0.72); }
+    .modal-content {
+      display: grid;
+      gap: 14px;
+      padding: 18px;
+    }
+    @media (max-width: 1120px) {
+      .shell { min-width: 0; }
+      .command-grid, .workspace { grid-template-columns: 1fr; }
+      .session-table-header { display: none; }
+      .session-summary { grid-template-columns: 1fr; }
+      .session-inspector { grid-template-columns: 1fr; }
+      .toolbar { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <header>
-      <h1>${escapeHtml(options.serviceName)} ADMIN</h1>
-      <div class="header-meta">
-        <span class="badge">REFRESH: 10S</span>
-        <div class="header-tools">
-          <button id="refresh-button" class="secondary">REFRESH</button>
-        </div>
+  <div class="shell">
+    <header class="topbar">
+      <div>
+        <h1>${escapeHtml(options.serviceName)} 管理台</h1>
+        <div class="subtitle">会话、发布风险、账号状态和管理操作的资源控制台。</div>
+      </div>
+      <div class="top-actions">
+        <span class="pill">刷新：10 秒</span>
+        <span class="pill" id="last-refresh">就绪</span>
+        <button id="refresh-button" class="secondary">刷新</button>
       </div>
     </header>
 
-    <div class="grid-summary">
-      <div class="summary-item">
-        <div class="summary-label">SERVICE</div>
-        <div class="summary-value" id="summary-service">--</div>
-        <div class="summary-detail" id="summary-service-detail">...</div>
-      </div>
-      <div class="summary-item">
-        <div class="summary-label">ACCOUNT</div>
-        <div class="summary-value" id="summary-account">--</div>
-        <div class="summary-detail" id="summary-account-detail">...</div>
-      </div>
-      <div class="summary-item">
-        <div class="summary-label">SESSIONS</div>
-        <div class="summary-value" id="summary-sessions">--</div>
-        <div class="summary-detail" id="summary-sessions-detail">...</div>
-      </div>
-      <div class="summary-item">
-        <div class="summary-label">JOBS</div>
-        <div class="summary-value" id="summary-jobs">--</div>
-        <div class="summary-detail" id="summary-jobs-detail">...</div>
-      </div>
+    <div class="command-grid">
+      <section class="panel">
+        <div class="panel-head">
+          <div class="panel-title">运行状态</div>
+          <span id="summary-service-badge" class="badge info">同步中</span>
+        </div>
+        <div class="panel-body">
+          <div class="metric-grid">
+            <div class="metric">
+              <div class="metric-label">服务</div>
+              <div class="metric-value good" id="summary-service">--</div>
+              <div class="metric-detail" id="summary-service-detail">...</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">账号</div>
+              <div class="metric-value" id="summary-account">--</div>
+              <div class="metric-detail" id="summary-account-detail">...</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">会话</div>
+              <div class="metric-value warn" id="summary-sessions">--</div>
+              <div class="metric-detail" id="summary-sessions-detail">...</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">任务</div>
+              <div class="metric-value" id="summary-jobs">--</div>
+              <div class="metric-detail" id="summary-jobs-detail">...</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <div class="panel-title">发布风险门禁</div>
+          <span id="risk-badge" class="badge info">检查中</span>
+        </div>
+        <div class="panel-body">
+          <div id="risk-panel"></div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <div class="panel-title">操作记录</div>
+          <span class="badge purple">审计</span>
+        </div>
+        <div class="panel-body">
+          <div id="operations-panel" class="operation-list"></div>
+          <div id="audit-panel" class="audit-list"></div>
+        </div>
+      </section>
     </div>
 
-    <div class="main-layout">
-      <div class="stack-main">
-        <section>
-          <div class="section-head">
-            <div class="section-title">Sessions</div>
-            <div id="last-refresh" style="font-size:10px; color:var(--muted)">READY</div>
+    <div class="workspace">
+      <main class="stack">
+        <section class="panel">
+          <div class="panel-head">
+            <div class="panel-title">会话工作队列</div>
+            <span class="summary-detail">待处理：<span id="session-open-count">0</span>（人：<span id="session-human-count">0</span> 系统：<span id="session-system-count">0</span>）</span>
           </div>
           <div class="toolbar">
-            <input id="session-search" type="search" placeholder="FILTER SESSIONS..." />
+            <input id="session-search" type="search" placeholder="筛选会话..." />
             <select id="session-filter">
-              <option value="all">ALL</option>
-              <option value="active">ACTIVE</option>
-              <option value="inbound">INBOUND</option>
-              <option value="jobs">JOBS</option>
-              <option value="issues">ISSUES</option>
+              <option value="all">全部</option>
+              <option value="active">活跃</option>
+              <option value="inbound">有待处理消息</option>
+              <option value="jobs">有运行任务</option>
+              <option value="issues">有问题</option>
             </select>
           </div>
           <div class="session-table-header">
-            <div>Session Key / Channel</div>
-            <div>Status / Slack</div>
-            <div>Inbound / Jobs</div>
-            <div>Current Lead</div>
-            <div>Action</div>
+            <div>会话 / 频道</div>
+            <div>状态 / Slack</div>
+            <div>消息 / 任务</div>
+            <div>当前线索</div>
+            <div>操作</div>
           </div>
           <div id="sessions-panel" class="session-list"></div>
         </section>
 
-        <section>
-          <div class="section-head">
-            <div class="section-title">System Logs</div>
+        <section class="panel">
+          <div class="panel-head">
+            <div class="panel-title">系统日志</div>
           </div>
           <div id="logs-panel" class="log-list"></div>
         </section>
-      </div>
+      </main>
 
-      <div class="stack-side">
-        <section>
-          <div class="section-head">
-            <div class="section-title">Auth Profiles</div>
-            <button id="open-add-profile-dialog">ADD</button>
+      <aside class="stack">
+        <section class="panel">
+          <div class="panel-head">
+            <div class="panel-title">发布</div>
+            <button id="deploy-release-button" class="primary">发布</button>
           </div>
-          <div id="auth-profiles-panel" style="padding:12px; display:grid; gap:8px;"></div>
-          <div id="replace-status" style="padding:8px; font-size:10px;"></div>
-        </section>
-
-        <section>
-          <div class="section-head">
-            <div class="section-title">GitHub Authors</div>
-            <button id="open-github-author-dialog">ADD</button>
-          </div>
-          <div class="toolbar" style="border-bottom:none;">
-            <input id="github-author-search" type="search" placeholder="FILTER AUTHORS..." />
-          </div>
-          <div id="github-authors-panel" style="padding:12px; display:grid; gap:8px;"></div>
-          <div id="github-authors-status" style="padding:8px; font-size:10px;"></div>
-        </section>
-
-        <section>
-          <div class="section-head">
-            <div class="section-title">Deploy</div>
-            <button id="deploy-release-button">DEPLOY</button>
-          </div>
-          <div style="padding:12px; display:grid; gap:8px;">
-            <input id="deploy-ref-input" type="text" placeholder="COMMIT / BRANCH / TAG" />
-            <div style="display:flex; gap:8px;">
-              <button id="rollback-release-button" class="secondary" style="flex:1">ROLLBACK</button>
+          <div class="panel-body">
+            <div class="deploy-actions">
+              <input id="deploy-ref-input" type="text" placeholder="提交 / 分支 / 标签" />
+              <button id="rollback-release-button" class="secondary">回滚</button>
             </div>
-            <div id="deploy-panel" style="display:grid; gap:8px;"></div>
-            <div id="deploy-status" style="font-size:10px;"></div>
+            <div id="deploy-panel"></div>
+            <div id="deploy-status" class="summary-detail" style="margin-top:8px;"></div>
           </div>
         </section>
 
-        <section>
-          <div class="section-head">
-            <div class="section-title">Runtime Info</div>
+        <section class="panel">
+          <div class="panel-head">
+            <div class="panel-title">认证档案</div>
+            <button id="open-add-profile-dialog">新增</button>
           </div>
-          <div id="service-card" style="padding:12px; font-size:11px;"></div>
+          <div id="auth-profiles-panel" class="panel-body maintenance-grid"></div>
+          <div id="replace-status" class="summary-detail" style="padding:0 12px 12px;"></div>
         </section>
-      </div>
+
+        <section class="panel">
+          <div class="panel-head">
+            <div class="panel-title">GitHub 作者映射</div>
+            <button id="open-github-author-dialog">新增</button>
+          </div>
+          <div class="toolbar" style="grid-template-columns:1fr; border-top:0;">
+            <input id="github-author-search" type="search" placeholder="筛选作者..." />
+          </div>
+          <div id="github-authors-panel" class="panel-body maintenance-grid"></div>
+          <div id="github-authors-status" class="summary-detail" style="padding:0 12px 12px;"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <div class="panel-title">运行信息</div>
+          </div>
+          <div id="service-card" class="panel-body summary-detail"></div>
+        </section>
+      </aside>
     </div>
   </div>
 
   <dialog id="add-profile-dialog"><div class="modal-content">
-    <div class="section-title">Add auth profile</div>
+    <div class="panel-title">新增认证档案</div>
     <input id="profile-auth-file" type="file" accept="application/json,.json" />
-    <textarea id="profile-auth-text" placeholder="PASTE AUTH.JSON HERE..."></textarea>
+    <textarea id="profile-auth-text" placeholder="在这里粘贴 auth.json..."></textarea>
     <div style="display:flex; gap:8px; justify-content:flex-end;">
-      <button id="close-add-profile-dialog" class="secondary">CANCEL</button>
-      <button id="submit-add-profile-dialog">SAVE</button>
+      <button id="close-add-profile-dialog" class="secondary">取消</button>
+      <button id="submit-add-profile-dialog" class="primary">保存</button>
     </div>
-    <div id="add-profile-status" style="font-size:10px;"></div>
+    <div id="add-profile-status" class="summary-detail"></div>
   </div></dialog>
 
   <dialog id="github-author-dialog"><div class="modal-content">
-    <div class="section-title">GitHub author mapping</div>
-    <input id="github-author-slack-user-id" type="text" placeholder="SLACK USER ID (U123...)" />
-    <input id="github-author-value" type="text" placeholder="Name <email@example.com>" />
+    <div class="panel-title">GitHub 作者映射</div>
+    <input id="github-author-slack-user-id" type="text" placeholder="Slack 用户 ID（U123...）" />
+    <input id="github-author-value" type="text" placeholder="姓名 <email@example.com>" />
     <div style="display:flex; gap:8px; justify-content:flex-end;">
-      <button id="close-github-author-dialog" class="secondary">CANCEL</button>
-      <button id="submit-github-author-dialog">SAVE</button>
+      <button id="close-github-author-dialog" class="secondary">取消</button>
+      <button id="submit-github-author-dialog" class="primary">保存</button>
     </div>
-    <div id="github-author-dialog-status" style="font-size:10px;"></div>
+    <div id="github-author-dialog-status" class="summary-detail"></div>
   </div></dialog>
 
   <script>
@@ -374,65 +663,41 @@ export function renderAdminPage(options: {
     const deployRefInput = document.getElementById("deploy-ref-input");
     const uiStateStorageKey = "admin-ui-state:" + window.location.pathname;
     const deferredUiStatePersistMs = 150;
+    const sessionDetailCache = new Map();
     let latestStatus = null;
     let uiState = loadUiState();
     let uiStatePersistTimer = null;
 
     function esc(value) {
-      return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+      return String(value ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
     }
-
     function defaultUiState() {
-      return {
-        sessionSearch: "",
-        sessionFilter: "all",
-        expandedSessionKeys: []
-      };
+      return { sessionSearch: "", sessionFilter: "all", expandedSessionKeys: [] };
     }
-
     function normalizeUiState(value) {
       const next = value && typeof value === "object" ? value : {};
-      const sessionFilterValue = ["all", "active", "inbound", "jobs", "issues"].includes(String(next.sessionFilter || ""))
-        ? String(next.sessionFilter)
-        : "all";
+      const sessionFilterValue = ["all", "active", "inbound", "jobs", "issues"].includes(String(next.sessionFilter || "")) ? String(next.sessionFilter) : "all";
       const sessionSearchValue = typeof next.sessionSearch === "string" ? next.sessionSearch : "";
-      const expandedSessionKeys = Array.isArray(next.expandedSessionKeys)
-        ? [...new Set(next.expandedSessionKeys.map((item) => String(item)).filter(Boolean))]
-        : [];
-      return {
-        sessionSearch: sessionSearchValue,
-        sessionFilter: sessionFilterValue,
-        expandedSessionKeys
-      };
+      const expandedSessionKeys = Array.isArray(next.expandedSessionKeys) ? [...new Set(next.expandedSessionKeys.map((item) => String(item)).filter(Boolean))] : [];
+      return { sessionSearch: sessionSearchValue, sessionFilter: sessionFilterValue, expandedSessionKeys };
     }
-
     function loadUiState() {
       try {
         const raw = window.localStorage.getItem(uiStateStorageKey);
-        if (!raw) {
-          return defaultUiState();
-        }
-        return normalizeUiState(JSON.parse(raw));
+        return raw ? normalizeUiState(JSON.parse(raw)) : defaultUiState();
       } catch {
         return defaultUiState();
       }
     }
-
     function cancelScheduledUiStatePersistence() {
-      if (uiStatePersistTimer == null) {
-        return;
-      }
+      if (uiStatePersistTimer == null) return;
       window.clearTimeout(uiStatePersistTimer);
       uiStatePersistTimer = null;
     }
-
     function persistUiState() {
       cancelScheduledUiStatePersistence();
-      try {
-        window.localStorage.setItem(uiStateStorageKey, JSON.stringify(uiState));
-      } catch {}
+      try { window.localStorage.setItem(uiStateStorageKey, JSON.stringify(uiState)); } catch {}
     }
-
     function scheduleUiStatePersistence() {
       cancelScheduledUiStatePersistence();
       uiStatePersistTimer = window.setTimeout(() => {
@@ -440,7 +705,6 @@ export function renderAdminPage(options: {
         persistUiState();
       }, deferredUiStatePersistMs);
     }
-
     function updateUiState(patch, options) {
       uiState = normalizeUiState(Object.assign({}, uiState, patch || {}));
       if (options?.deferPersist) {
@@ -449,251 +713,278 @@ export function renderAdminPage(options: {
       }
       persistUiState();
     }
-
     function isSessionExpanded(sessionKey) {
       return uiState.expandedSessionKeys.includes(String(sessionKey));
     }
-
     function updateSessionExpansion(sessionKey, expanded) {
       const next = new Set(uiState.expandedSessionKeys);
-      if (expanded) {
-        next.add(String(sessionKey));
-      } else {
-        next.delete(String(sessionKey));
-      }
-      updateUiState({
-        expandedSessionKeys: [...next]
-      });
+      if (expanded) next.add(String(sessionKey)); else next.delete(String(sessionKey));
+      updateUiState({ expandedSessionKeys: [...next] });
     }
-
     function pruneExpandedSessionKeys(sessionKeys) {
       const allowedKeys = new Set((sessionKeys || []).map((sessionKey) => String(sessionKey)));
       const expandedSessionKeys = uiState.expandedSessionKeys.filter((sessionKey) => allowedKeys.has(sessionKey));
-      if (expandedSessionKeys.length === uiState.expandedSessionKeys.length) {
-        return;
-      }
-      updateUiState({
-        expandedSessionKeys
-      });
+      if (expandedSessionKeys.length === uiState.expandedSessionKeys.length) return;
+      updateUiState({ expandedSessionKeys });
     }
-
+    function authHeaders(extra) {
+      return Object.assign({}, extra || {});
+    }
     function fmtTime(value) {
-      if (!value) return "—";
+      if (!value) return "--";
       try { return new Date(value).toLocaleTimeString(); } catch { return String(value); }
     }
-
-    function clampPercent(value) {
-      const number = Number(value);
-      return Math.max(0, Math.min(100, Math.round(number || 0)));
+    function fmtDateTime(value) {
+      if (!value) return "--";
+      try { return new Date(value).toLocaleString(); } catch { return String(value); }
     }
-
-    function formatWindowLabel(mins) {
-      const m = Number(mins);
-      if (m === 300) return "5h";
-      if (m === 10080) return "weekly";
-      if (m % 1440 === 0) return (m/1440) + "d";
-      if (m % 60 === 0) return (m/60) + "h";
-      return m + "m";
+    function fmtDuration(sec) {
+      const s = Number(sec || 0);
+      if (s <= 0) return "刚启动";
+      const h = Math.floor(s / 3600);
+      const m = Math.floor((s % 3600) / 60);
+      return (h > 0 ? h + " 小时 " : "") + m + " 分钟";
     }
-
     function formatRelativeDuration(ms) {
       const absMs = Math.abs(ms);
       const m = Math.round(absMs / 60000);
-      if (m < 60) return m + "m";
+      if (m < 60) return m + " 分钟";
       const h = Math.round(absMs / 3600000);
-      if (h < 48) return h + "h";
-      return Math.round(absMs / 86400000) + "d";
+      if (h < 48) return h + " 小时";
+      return Math.round(absMs / 86400000) + " 天";
     }
-
     function formatResetTime(sec) {
-      if (sec == null) return "unknown reset";
+      if (sec == null) return "未知";
       const delta = (Number(sec) * 1000) - Date.now();
       const rel = formatRelativeDuration(delta);
-      return delta > 0 ? "in " + rel : rel + " ago";
+      return delta > 0 ? rel + "后" : rel + "前";
     }
-
-    function fmtDuration(sec) {
-      const s = Number(sec || 0);
-      if (s <= 0) return "JUST STARTED";
-      const h = Math.floor(s / 3600);
-      const m = Math.floor((s % 3600) / 60);
-      return (h > 0 ? h + "h " : "") + m + "m";
+    function clampPercent(value) {
+      return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
     }
-
     function statusTone(status) {
       const v = String(status || "").toLowerCase();
-      if (["running", "active", "ok", "completed"].includes(v)) return "good";
-      if (["pending", "inflight", "starting"].includes(v)) return "warn";
-      if (["failed", "error", "stopped"].includes(v)) return "danger";
+      if (["succeeded", "running", "active", "ok", "completed", "done"].includes(v)) return "good";
+      if (["pending", "inflight", "registered", "starting", "idle", "started", "wait"].includes(v)) return "warn";
+      if (["failed", "error", "stopped", "cancelled"].includes(v)) return "danger";
+      if (["deploy", "rollback"].includes(v)) return "info";
       return "";
     }
-
-    function renderBadge(label, tone) {
-      return '<span class="badge ' + (tone || "") + '">' + esc(label) + "</span>";
+    function statusLabel(value) {
+      const labels = {
+        active: "活跃",
+        idle: "空闲",
+        ok: "正常",
+        running: "运行中",
+        registered: "已注册",
+        pending: "待处理",
+        inflight: "处理中",
+        done: "已完成",
+        completed: "已完成",
+        succeeded: "成功",
+        failed: "失败",
+        error: "错误",
+        stopped: "已停止",
+        cancelled: "已取消",
+        started: "已开始",
+        starting: "启动中",
+        wait: "等待",
+        final: "结束",
+        block: "阻塞",
+        progress: "进展",
+        inspect: "查看",
+        session: "会话",
+        admin: "管理",
+        audit: "审计",
+        unknown: "未知",
+        combined: "合并模式"
+      };
+      const key = String(value || "").toLowerCase();
+      return labels[key] || String(value || "");
     }
-
-    function authHeaders(extra) {
-      return Object.assign({}, extra || {});
+    function operationLabel(value) {
+      const labels = {
+        deploy: "发布",
+        rollback: "回滚",
+        auth_profile_add: "新增认证档案",
+        auth_profile_delete: "删除认证档案",
+        auth_profile_activate: "切换认证档案",
+        github_author_upsert: "保存 GitHub 作者",
+        github_author_delete: "删除 GitHub 作者"
+      };
+      return labels[String(value || "")] || String(value || "");
+    }
+    function sourceLabel(value) {
+      const labels = {
+        app_mention: "提及",
+        direct_message: "私信",
+        thread_reply: "线程回复",
+        background_job_event: "后台任务事件",
+        unexpected_turn_stop: "异常停止"
+      };
+      return labels[String(value || "")] || String(value || "");
+    }
+    function renderBadge(label, tone) {
+      return '<span class="badge ' + esc(tone || statusTone(label)) + '">' + esc(statusLabel(label)) + "</span>";
+    }
+    function pickOperationLabel(operation) {
+      return operation?.request?.ref || operation?.request?.name || operation?.request?.slackUserId || operation?.id || "-";
     }
 
     function renderSummary(data) {
       const s = data.service || {};
       const st = data.state || {};
       const a = data.account || {};
-      const rl = data.rateLimits || {};
-      
-      document.getElementById("summary-service").textContent = "ONLINE";
-      document.getElementById("summary-service-detail").textContent = "PID " + (s.pid || "-") + " · UP " + fmtDuration(s.uptimeSeconds);
-      
-      document.getElementById("summary-account").textContent = a.ok ? (a.account?.planType || "LOGGED") : "ERROR";
-      document.getElementById("summary-account-detail").textContent = a.ok ? (a.account?.email || "NO EMAIL") : (a.error || "ERR");
-      
+      document.getElementById("summary-service").textContent = "在线";
+      document.getElementById("summary-service-detail").textContent = "PID " + (s.pid || "-") + " · 运行 " + fmtDuration(s.uptimeSeconds);
+      document.getElementById("summary-service-badge").textContent = statusLabel(s.mode || "admin");
+      document.getElementById("summary-account").textContent = a.ok ? (a.account?.planType || "已登录") : "异常";
+      document.getElementById("summary-account-detail").textContent = a.ok ? (a.account?.email || "无邮箱") : (a.error || "账号不可用");
       document.getElementById("summary-sessions").textContent = (st.activeCount || 0) + "/" + (st.sessionCount || 0);
-      document.getElementById("summary-sessions-detail").textContent =
-        "OPEN: " + (st.openInboundCount || 0) +
-        " (H:" + (st.openHumanInboundCount || 0) +
-        " S:" + (st.openSystemInboundCount || 0) + ")";
-      
+      document.getElementById("summary-sessions-detail").textContent = "待处理：" + (st.openInboundCount || 0) + "（人：" + (st.openHumanInboundCount || 0) + " 系统：" + (st.openSystemInboundCount || 0) + "）";
       document.getElementById("summary-jobs").textContent = st.runningBackgroundJobCount || 0;
-      document.getElementById("summary-jobs-detail").textContent = "FAILED: " + (st.failedBackgroundJobCount || 0);
+      document.getElementById("summary-jobs-detail").textContent = "失败：" + (st.failedBackgroundJobCount || 0);
+      document.getElementById("session-open-count").textContent = st.openInboundCount || 0;
+      document.getElementById("session-human-count").textContent = st.openHumanInboundCount || 0;
+      document.getElementById("session-system-count").textContent = st.openSystemInboundCount || 0;
+    }
+
+    function renderRiskPanel(data) {
+      const st = data.state || {};
+      const active = Number(st.activeCount || 0);
+      const open = Number(st.openInboundCount || 0);
+      const running = Number(st.runningBackgroundJobCount || 0);
+      const safe = active + open + running === 0;
+      const badge = document.getElementById("risk-badge");
+      badge.textContent = safe ? "安全" : "需要确认";
+      badge.className = "badge " + (safe ? "good" : "warn");
+      document.getElementById("risk-panel").innerHTML =
+        '<div class="risk-strip">' +
+          '<div class="risk-cell"><div class="risk-number">' + active + '</div><div class="risk-label">活跃回合</div></div>' +
+          '<div class="risk-cell"><div class="risk-number">' + open + '</div><div class="risk-label">待处理消息</div></div>' +
+          '<div class="risk-cell"><div class="risk-number">' + running + '</div><div class="risk-label">运行任务</div></div>' +
+        '</div>' +
+        '<div class="risk-copy">' + (safe
+          ? '当前没有活跃工作，发布和回滚不需要额外确认。'
+          : '发布和回滚会中断正在进行的管理工作，执行前必须显式确认。') + '</div>';
+    }
+
+    function renderOperations(data) {
+      const operationsPanel = document.getElementById("operations-panel");
+      const auditPanel = document.getElementById("audit-panel");
+      const operations = data.operations || [];
+      const events = data.auditEvents || [];
+      if (!operations.length) {
+        operationsPanel.innerHTML = '<div class="summary-detail">暂无管理操作</div>';
+      } else {
+        operationsPanel.innerHTML = operations.slice(0, 5).map((operation) =>
+          '<div class="operation-row">' +
+            renderBadge(operation.status || "unknown", statusTone(operation.status)) +
+            '<div class="operation-main">' +
+              '<div class="operation-title">' + esc(operationLabel(operation.kind)) + '</div>' +
+              '<div class="operation-detail">' + esc(pickOperationLabel(operation)) + '</div>' +
+            '</div>' +
+            '<div class="summary-detail">' + esc(fmtTime(operation.updatedAt)) + '</div>' +
+          '</div>'
+        ).join("");
+      }
+      auditPanel.innerHTML = events.length
+        ? events.slice(0, 6).map((event) => '<div>' + esc(fmtTime(event.createdAt) + " · " + operationLabel(event.action) + " · " + statusLabel(event.status)) + '</div>').join("")
+        : "";
     }
 
     function renderService(data) {
       const s = data.service || {};
-      document.getElementById("service-card").innerHTML = 
-        '<div style="display:grid; gap:4px;">' +
-        '<div>NAME: ' + esc(s.name) + '</div>' +
-        '<div>PORT: ' + esc(s.port) + '</div>' +
-        '<div>START: ' + esc(new Date(s.startedAt).toLocaleString()) + '</div>' +
-        '<div style="margin-top:8px; color:var(--muted); font-size:10px;">ROOTS:</div>' +
-        '<div style="word-break:break-all;">' + esc(s.sessionsRoot) + '</div>' +
+      document.getElementById("service-card").innerHTML =
+        '<div style="display:grid; gap:6px;">' +
+          '<div>名称：' + esc(s.name) + '</div>' +
+          '<div>模式：' + esc(statusLabel(s.mode)) + '</div>' +
+          '<div>端口：' + esc(s.port) + '</div>' +
+          '<div>启动：' + esc(fmtDateTime(s.startedAt)) + '</div>' +
+          '<div style="word-break:break-all;">会话目录：' + esc(s.sessionsRoot) + '</div>' +
+          '<div style="word-break:break-all;">CODEX_HOME: ' + esc(s.codexHome) + '</div>' +
         '</div>';
     }
 
     function renderReleaseCard(label, release) {
-      if (!release?.targetPath) {
-        return '<div class="summary-detail">' + esc(label + ": none") + "</div>";
-      }
+      if (!release?.targetPath) return '<div class="summary-detail">' + esc(label + "：无") + "</div>";
       const metadata = release.metadata || {};
       const heading = metadata.shortRevision || metadata.revision || release.targetPath.split("/").pop() || "release";
-      const detail = metadata.builtAt ? new Date(metadata.builtAt).toLocaleString() : release.targetPath;
-      return '<div class="profile-row">' +
-               '<div class="profile-line">' +
-                 '<span class="profile-account">' + esc(label + ": " + heading) + "</span>" +
-                 '<span class="profile-plan">' + esc(metadata.branch || "detached") + "</span>" +
-               "</div>" +
-               '<div class="summary-detail">' + esc(detail) + "</div>" +
-             "</div>";
+      return '<div class="release-row">' +
+        '<div class="profile-line"><span class="profile-account">' + esc(label + "：" + heading) + '</span><span class="profile-plan">' + esc(metadata.branch || "detached") + '</span></div>' +
+        '<div class="summary-detail">' + esc(metadata.builtAt ? fmtDateTime(metadata.builtAt) : release.targetPath) + '</div>' +
+      '</div>';
     }
-
     function renderDeployment(data) {
       const deployment = data.deployment;
       const panel = document.getElementById("deploy-panel");
       if (!deployment) {
-        panel.innerHTML = '<div class="summary-detail">WORKER DEPLOYMENT UNAVAILABLE</div>';
+        panel.innerHTML = '<div class="summary-detail">Worker 发布状态不可用</div>';
         return;
       }
-
       const admin = deployment.admin || {};
       const worker = deployment.worker || {};
       panel.innerHTML =
-        '<div style="display:flex; gap:8px; flex-wrap:wrap;">' +
-          renderBadge(admin.launchdLoaded ? "ADMIN LOADED" : "ADMIN DOWN", admin.launchdLoaded ? "good" : "danger") +
-          renderBadge(admin.healthOk ? "ADMIN HTTP OK" : "ADMIN HTTP FAIL", admin.healthOk ? "good" : "danger") +
-          renderBadge(worker.launchdLoaded ? "WORKER LOADED" : "WORKER DOWN", worker.launchdLoaded ? "good" : "danger") +
-          renderBadge(worker.healthOk ? "HTTP OK" : "HTTP FAIL", worker.healthOk ? "good" : "danger") +
-          renderBadge(worker.readyOk ? "CODEX READY" : "CODEX FAIL", worker.readyOk ? "good" : "danger") +
-        "</div>" +
-        renderReleaseCard("CURRENT", deployment.currentRelease) +
-        renderReleaseCard("PREVIOUS", deployment.previousRelease);
+        '<div style="display:flex; gap:6px; flex-wrap:wrap;">' +
+          renderBadge(admin.launchdLoaded ? "管理进程已加载" : "管理进程未运行", admin.launchdLoaded ? "good" : "danger") +
+          renderBadge(admin.healthOk ? "管理 HTTP 正常" : "管理 HTTP 异常", admin.healthOk ? "good" : "danger") +
+          renderBadge(worker.launchdLoaded ? "工作进程已加载" : "工作进程未运行", worker.launchdLoaded ? "good" : "danger") +
+          renderBadge(worker.healthOk ? "HTTP 正常" : "HTTP 异常", worker.healthOk ? "good" : "danger") +
+          renderBadge(worker.readyOk ? "Codex 就绪" : "Codex 异常", worker.readyOk ? "good" : "danger") +
+        '</div>' +
+        '<div class="release-stack">' +
+          renderReleaseCard("当前版本", deployment.currentRelease) +
+          renderReleaseCard("上一版本", deployment.previousRelease) +
+        '</div>';
     }
 
     function renderProfileQuota(rateLimits) {
-      if (!rateLimits || !rateLimits.ok) {
-        return '<div class="profile-quota">' + esc(rateLimits?.error || "quota unavailable") + "</div>";
-      }
+      if (!rateLimits || !rateLimits.ok) return '<div class="summary-detail">' + esc(rateLimits?.error || "额度不可用") + '</div>';
       const snapshot = rateLimits.rateLimits || {};
       const primary = snapshot.primary;
       const secondary = snapshot.secondary;
-      const primaryValue = primary ? String(100 - clampPercent(primary.usedPercent)) + "% LEFT" : "—";
-      const primaryReset = primary ? formatResetTime(primary.resetsAt) : "unavailable";
-      const secondaryValue = secondary ? String(100 - clampPercent(secondary.usedPercent)) + "% LEFT" : "—";
-      const secondaryReset = secondary ? formatResetTime(secondary.resetsAt) : "unavailable";
-      return '<div class="profile-quota">' +
-               '<div class="profile-quota-line">' +
-                 '<span class="profile-quota-label">5H</span>' +
-                 '<span class="profile-quota-value">' + esc(primaryValue) + '</span>' +
-                 '<span class="profile-quota-reset">' + esc(primaryReset) + '</span>' +
-               '</div>' +
-               '<div class="profile-quota-line">' +
-                 '<span class="profile-quota-label">WEEKLY</span>' +
-                 '<span class="profile-quota-value">' + esc(secondaryValue) + '</span>' +
-                 '<span class="profile-quota-reset">' + esc(secondaryReset) + '</span>' +
-               '</div>' +
-             "</div>";
+      return '<div class="quota-grid">' +
+        '<div class="quota-line"><span>5 小时</span><strong>' + esc(primary ? "剩余 " + String(100 - clampPercent(primary.usedPercent)) + "%" : "--") + '</strong><span>' + esc(primary ? formatResetTime(primary.resetsAt) : "不可用") + '</span></div>' +
+        '<div class="quota-line"><span>每周</span><strong>' + esc(secondary ? "剩余 " + String(100 - clampPercent(secondary.usedPercent)) + "%" : "--") + '</strong><span>' + esc(secondary ? formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
+      '</div>';
     }
-
     function renderAuthProfiles(data) {
       const authProfiles = data.authProfiles || {};
       const profiles = [...(authProfiles.profiles || [])].sort((left, right) => {
-        if (left.active !== right.active) {
-          return left.active ? -1 : 1;
-        }
+        if (left.active !== right.active) return left.active ? -1 : 1;
         return String(right.mtime || "").localeCompare(String(left.mtime || ""));
       });
       const panel = document.getElementById("auth-profiles-panel");
       if (!profiles.length) {
-        panel.innerHTML = '<div class="summary-detail" style="padding-top:12px;">NO AUTH PROFILES</div>';
+        panel.innerHTML = '<div class="summary-detail">暂无认证档案</div>';
         return;
       }
-
       panel.innerHTML = profiles.map((profile) => {
         const account = profile.account || {};
-        const email = account.ok ? (account.account?.email || "UNKNOWN ACCOUNT") : "ACCOUNT ERROR";
-        const plan = account.ok ? (account.account?.planType || account.account?.type || "CHATGPT") : (account.error || "account unavailable");
+        const email = account.ok ? (account.account?.email || "未知账号") : "账号异常";
+        const plan = account.ok ? (account.account?.planType || account.account?.type || "ChatGPT") : (account.error || "账号不可用");
         return '<div class="profile-row' + (profile.active ? " is-active" : "") + '">' +
-                 '<div class="profile-line">' +
-                   '<span class="profile-account">' + esc(email) + "</span>" +
-                   '<span class="profile-plan">' + esc(plan) + "</span>" +
-                 "</div>" +
-                 renderProfileQuota(profile.rateLimits) +
-                 '<div class="profile-actions">' +
-                   '<button class="secondary" data-activate-profile="' + esc(profile.name) + '"' +
-                     ' data-profile-email="' + esc(email) + '"' +
-                     (profile.active ? " disabled" : "") + ">USE</button>" +
-                   '<button class="danger" data-delete-profile="' + esc(profile.name) + '"' +
-                     ' data-profile-email="' + esc(email) + '"' +
-                     (profile.active ? " disabled" : "") + '>DELETE</button>' +
-                 "</div>" +
-               "</div>";
+          '<div class="profile-line"><span class="profile-account">' + esc(email) + '</span><span class="profile-plan">' + esc(plan) + '</span>' + (profile.active ? renderBadge("active", "info") : "") + '</div>' +
+          renderProfileQuota(profile.rateLimits) +
+          '<div class="profile-actions">' +
+            '<button class="secondary" data-activate-profile="' + esc(profile.name) + '"' + (profile.active ? " disabled" : "") + '>使用</button>' +
+            '<button class="danger" data-delete-profile="' + esc(profile.name) + '"' + (profile.active ? " disabled" : "") + '>删除</button>' +
+          '</div>' +
+        '</div>';
       }).join("");
-
       document.querySelectorAll("[data-activate-profile]").forEach((button) => {
         button.addEventListener("click", async () => {
           const name = button.getAttribute("data-activate-profile");
-          if (!name) {
-            return;
-          }
-          const activeCount = Number(latestStatus?.state?.activeCount || 0);
-          const allowActive =
-            activeCount > 0 ? window.confirm("ACTIVE SESSIONS EXIST. SWITCHING WILL INTERRUPT THEM. CONTINUE?") : false;
-          if (activeCount > 0 && !allowActive) {
-            return;
-          }
+          if (!name) return;
+          const allowActive = await confirmInterruptRisk("auth_profile_activate", "切换认证档案");
+          if (allowActive == null) return;
           await activateProfile(name, allowActive);
         });
       });
-
       document.querySelectorAll("[data-delete-profile]").forEach((button) => {
         button.addEventListener("click", async () => {
           const name = button.getAttribute("data-delete-profile");
-          const email = button.getAttribute("data-profile-email") || "this auth profile";
-          if (!name) {
-            return;
-          }
-          if (!window.confirm("DELETE " + email + "?")) {
-            return;
-          }
+          if (!name || !window.confirm("删除认证档案 " + name + "？")) return;
           await deleteProfile(name);
         });
       });
@@ -704,45 +995,27 @@ export function renderAdminPage(options: {
       const panel = document.getElementById("github-authors-panel");
       const query = String(githubAuthorSearch.value || "").toLowerCase();
       const filtered = mappings.filter((mapping) => {
-        if (!query) {
-          return true;
-        }
-
-        return [
-          mapping.slackUserId,
-          mapping.githubAuthor,
-          mapping.slackIdentity?.displayName,
-          mapping.slackIdentity?.realName,
-          mapping.slackIdentity?.username,
-          mapping.slackIdentity?.email
-        ].some((value) => String(value || "").toLowerCase().includes(query));
+        if (!query) return true;
+        return [mapping.slackUserId, mapping.githubAuthor, mapping.slackIdentity?.displayName, mapping.slackIdentity?.realName, mapping.slackIdentity?.username, mapping.slackIdentity?.email].some((value) => String(value || "").toLowerCase().includes(query));
       });
-
       if (!filtered.length) {
-        panel.innerHTML = '<div class="summary-detail" style="padding-top:12px;">NO GITHUB AUTHOR MAPPINGS</div>';
+        panel.innerHTML = '<div class="summary-detail">暂无 GitHub 作者映射</div>';
         return;
       }
-
       panel.innerHTML = filtered.map((mapping) => {
         const identity = mapping.slackIdentity || {};
         const label = identity.realName || identity.displayName || identity.username || mapping.slackUserId;
         const detail = [mapping.slackUserId, identity.email].filter(Boolean).join(" · ");
         return '<div class="profile-row">' +
-                 '<div class="profile-line">' +
-                   '<span class="profile-account">' + esc(label) + "</span>" +
-                   '<span class="profile-plan">' + esc(detail || mapping.slackUserId) + "</span>" +
-                   renderBadge(mapping.source === "manual" ? "manual" : "auto", mapping.source === "manual" ? "good" : "warn") +
-                 "</div>" +
-                 '<div class="summary-detail">' + esc(mapping.githubAuthor) + "</div>" +
-                 '<div class="summary-detail">UPDATED: ' + esc(new Date(mapping.updatedAt).toLocaleString()) + "</div>" +
-                 '<div class="profile-actions">' +
-                   '<button class="secondary" data-edit-github-author="' + esc(mapping.slackUserId) + '"' +
-                     ' data-edit-github-author-value="' + esc(mapping.githubAuthor) + '">EDIT</button>' +
-                   '<button class="danger" data-delete-github-author="' + esc(mapping.slackUserId) + '">DELETE</button>' +
-                 "</div>" +
-               "</div>";
+          '<div class="profile-line"><span class="profile-account">' + esc(label) + '</span><span class="profile-plan">' + esc(detail || mapping.slackUserId) + '</span>' + renderBadge(mapping.source === "manual" ? "手动" : "自动", mapping.source === "manual" ? "good" : "warn") + '</div>' +
+          '<div class="summary-detail">' + esc(mapping.githubAuthor) + '</div>' +
+          '<div class="summary-detail">更新：' + esc(fmtDateTime(mapping.updatedAt)) + '</div>' +
+          '<div class="profile-actions">' +
+            '<button class="secondary" data-edit-github-author="' + esc(mapping.slackUserId) + '" data-edit-github-author-value="' + esc(mapping.githubAuthor) + '">编辑</button>' +
+            '<button class="danger" data-delete-github-author="' + esc(mapping.slackUserId) + '">删除</button>' +
+          '</div>' +
+        '</div>';
       }).join("");
-
       document.querySelectorAll("[data-edit-github-author]").forEach((button) => {
         button.addEventListener("click", () => {
           document.getElementById("github-author-dialog-status").textContent = "";
@@ -751,137 +1024,172 @@ export function renderAdminPage(options: {
           githubAuthorDialog.showModal();
         });
       });
-
       document.querySelectorAll("[data-delete-github-author]").forEach((button) => {
         button.addEventListener("click", async () => {
           const slackUserId = button.getAttribute("data-delete-github-author");
-          if (!slackUserId) {
-            return;
-          }
-
-          if (!window.confirm("DELETE GITHUB AUTHOR MAPPING FOR " + slackUserId + "?")) {
-            return;
-          }
-
+          if (!slackUserId || !window.confirm("删除 " + slackUserId + " 的 GitHub 作者映射？")) return;
           await deleteGitHubAuthorMapping(slackUserId);
         });
       });
     }
 
     function summarizeSessionLead(s) {
-      if (s.openInbound?.length) return s.openInbound[0].textPreview || "NEW MSG";
+      if (s.lastTurnSignalKind) return statusLabel(s.lastTurnSignalKind) + "：" + (s.lastTurnSignalReason || "");
+      if (s.openInbound?.length) return s.openInbound[0].textPreview || "新消息";
       if (s.backgroundJobs?.length) {
-        const r = s.backgroundJobs.find(j => j.status === "running") || s.backgroundJobs[0];
-        return (r.kind || "JOB") + " (" + (r.status || "?") + ")";
+        const r = s.backgroundJobs.find((j) => j.status === "running") || s.backgroundJobs[0];
+        return (r.kind || "任务") + "（" + statusLabel(r.status || "?") + "）";
       }
-      return "IDLE";
+      return "空闲";
     }
-
     function renderSessions(data) {
       const panel = document.getElementById("sessions-panel");
       const list = data.state?.sessions || [];
       pruneExpandedSessionKeys(list.map((session) => session.key));
       const query = (sessionSearch.value || "").toLowerCase();
       const mode = sessionFilter.value;
-      
-      const filtered = list.filter(s => {
+      const filtered = list.filter((s) => {
         if (mode === "active" && !s.activeTurnId) return false;
         if (mode === "inbound" && !s.openInboundCount) return false;
         if (mode === "jobs" && !s.runningBackgroundJobCount) return false;
         if (mode === "issues" && !s.failedBackgroundJobCount) return false;
         if (!query) return true;
-        return [s.key, s.channelId, s.workspacePath].some(v => String(v).toLowerCase().includes(query));
+        return [s.key, s.channelId, s.workspacePath].some((v) => String(v || "").toLowerCase().includes(query));
       });
-
       if (!filtered.length) {
-        panel.innerHTML = '<div style="padding:20px; text-align:center; color:var(--muted)">NO SESSIONS FOUND</div>';
+        panel.innerHTML = '<div style="padding:18px; color:var(--muted); text-align:center;">没有匹配的会话</div>';
         return;
       }
-
-      panel.innerHTML = filtered.map(s => {
-        const lead = summarizeSessionLead(s);
+      panel.innerHTML = filtered.map((s) => {
         const isActive = !!s.activeTurnId;
+        const lead = summarizeSessionLead(s);
         const expanded = isSessionExpanded(s.key);
-        return '<details class="session-row" data-session-key="' + esc(s.key) + '"' + (expanded ? " open" : "") + ">" +
+        return '<details class="session-row" data-session-key="' + esc(s.key) + '"' + (expanded ? " open" : "") + '>' +
           '<summary class="session-summary">' +
-            '<div class="session-key">' + esc(s.key) + '<div style="font-size:10px; font-weight:normal; color:var(--muted)">' + esc(s.channelId) + '</div></div>' +
-            '<div>' + renderBadge(isActive ? "ACTIVE" : "IDLE", isActive ? "good" : "warn") + '<div style="font-size:10px; color:var(--muted)">UP: ' + fmtTime(s.updatedAt) + '</div></div>' +
-            '<div>OPEN: ' + (s.openInboundCount || 0) +
-              ' (H:' + (s.openHumanInboundCount || 0) +
-              ' S:' + (s.openSystemInboundCount || 0) +
-              ') / JOB: ' + (s.runningBackgroundJobCount || 0) + '</div>' +
-            '<div style="font-size:11px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;" title="' + esc(lead) + '">' + esc(lead) + '</div>' +
-            '<div><span style="color:var(--accent); font-size:10px;">EXPAND</span></div>' +
+            '<div><div class="session-key">' + esc(s.key) + '</div><div class="session-channel">' + esc(s.channelId) + ' · ' + esc(s.workspacePath || "") + '</div></div>' +
+            '<div>' + renderBadge(isActive ? "active" : "idle", isActive ? "good" : "warn") + '<div class="summary-detail">更新：' + esc(fmtTime(s.updatedAt)) + '</div></div>' +
+            '<div><strong>待处理：' + (s.openInboundCount || 0) + '（人：' + (s.openHumanInboundCount || 0) + ' 系统：' + (s.openSystemInboundCount || 0) + '）</strong><div class="summary-detail">任务：' + (s.runningBackgroundJobCount || 0) + '</div></div>' +
+            '<div class="summary-detail" title="' + esc(lead) + '">' + esc(lead) + '</div>' +
+            '<div>' + renderBadge("inspect", "info") + '</div>' +
           '</summary>' +
           '<div class="session-body">' +
-            '<div style="margin-bottom:12px; font-size:11px; color:var(--muted)">CWD: ' + esc(s.workspacePath) + '</div>' +
-            '<div style="display:grid; grid-template-columns: 1fr 1fr; gap:12px;">' +
-              '<div><div class="summary-label">INBOUND</div>' + renderInboundTable(s.openInbound) + '</div>' +
-              '<div><div class="summary-label">JOBS</div>' + renderJobsTable(s.backgroundJobs) + '</div>' +
+            '<div class="summary-detail">工作目录：' + esc(s.workspacePath) + '</div>' +
+            '<div class="session-inspector">' +
+              '<div class="mini-panel"><div class="mini-title">时间线</div><div class="mini-body"><div class="timeline" data-session-timeline="' + esc(s.key) + '">' + renderTimelinePlaceholder(s) + '</div></div></div>' +
+              '<div class="mini-panel"><div class="mini-title">消息 / 任务</div><div class="mini-body">' + renderInboundTable(s.openInbound) + renderJobsTable(s.backgroundJobs) + '</div></div>' +
             '</div>' +
           '</div>' +
         '</details>';
       }).join("");
-
       panel.querySelectorAll(".session-row").forEach((row) => {
         row.addEventListener("toggle", () => {
           const sessionKey = row.getAttribute("data-session-key");
-          if (!sessionKey) {
-            return;
-          }
+          if (!sessionKey) return;
           updateSessionExpansion(sessionKey, row.open);
+          if (row.open) loadSessionTimeline(sessionKey, row);
         });
+        if (row.open) loadSessionTimeline(row.getAttribute("data-session-key"), row);
       });
     }
-
+    function renderTimelinePlaceholder(session) {
+      return '<div class="timeline-event"><span>' + esc(fmtTime(session.createdAt)) + '</span>' + renderBadge("session", "info") + '<strong>已创建</strong></div>';
+    }
+    function renderTimelineEvents(events) {
+      if (!events?.length) return '<div class="summary-detail">暂无时间线事件</div>';
+      return events.slice(0, 12).map((event) =>
+        '<div class="timeline-event">' +
+          '<span>' + esc(fmtTime(event.at)) + '</span>' +
+          renderBadge(event.status || event.type, statusTone(event.status || event.type)) +
+          '<strong>' + esc(event.summary || event.type) + '</strong>' +
+        '</div>'
+      ).join("");
+    }
+    async function loadSessionTimeline(sessionKey, row) {
+      if (!sessionKey) return;
+      const target = row.querySelector('[data-session-timeline="' + window.CSS.escape(sessionKey) + '"]');
+      if (!target) return;
+      if (sessionDetailCache.has(sessionKey)) {
+        target.innerHTML = renderTimelineEvents(sessionDetailCache.get(sessionKey));
+        return;
+      }
+      target.innerHTML = '<div class="summary-detail">正在加载时间线...</div>';
+      try {
+        const response = await fetch("/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/timeline", { headers: authHeaders() });
+        const payload = await parseResponse(response);
+        const events = payload.events || [];
+        sessionDetailCache.set(sessionKey, events);
+        target.innerHTML = renderTimelineEvents(events);
+      } catch (error) {
+        target.innerHTML = '<div class="summary-detail">' + esc(error instanceof Error ? error.message : String(error)) + '</div>';
+      }
+    }
     function renderInboundTable(items) {
-      if (!items?.length) return '<div style="color:var(--muted); font-size:11px;">EMPTY</div>';
-      return '<table class="tui-table"><thead><tr><th>SRC</th><th>MSG</th></tr></thead><tbody>' +
-        items.map(i => '<tr><td>' + esc(i.source) + '</td><td>' + esc(i.textPreview) + '</td></tr>').join("") +
+      if (!items?.length) return '<div class="summary-detail" style="margin-bottom:8px;">没有待处理消息</div>';
+      return '<table class="table"><thead><tr><th>来源</th><th>消息</th></tr></thead><tbody>' +
+        items.map((i) => '<tr><td>' + esc(sourceLabel(i.source)) + '</td><td>' + esc(i.textPreview) + '</td></tr>').join("") +
         '</tbody></table>';
     }
-
     function renderJobsTable(jobs) {
-      if (!jobs?.length) return '<div style="color:var(--muted); font-size:11px;">EMPTY</div>';
-      return '<table class="tui-table"><thead><tr><th>STATUS</th><th>KIND</th></tr></thead><tbody>' +
-        jobs.slice(0, 5).map(j => '<tr><td>' + renderBadge(j.status, statusTone(j.status)) + '</td><td>' + esc(j.kind) + '</td></tr>').join("") +
+      if (!jobs?.length) return '<div class="summary-detail">没有任务</div>';
+      return '<table class="table" style="margin-top:10px;"><thead><tr><th>状态</th><th>类型</th></tr></thead><tbody>' +
+        jobs.slice(0, 5).map((j) => '<tr><td>' + renderBadge(j.status, statusTone(j.status)) + '</td><td>' + esc(j.kind) + '</td></tr>').join("") +
         '</tbody></table>';
     }
-
     function renderLogs(data) {
       const logs = data.state?.recentBrokerLogs || [];
       const panel = document.getElementById("logs-panel");
       if (!logs.length) {
-        panel.innerHTML = '<div style="padding:12px; color:var(--muted)">NO LOGS</div>';
+        panel.innerHTML = '<div style="padding:12px; color:var(--muted)">暂无日志</div>';
         return;
       }
-      panel.innerHTML = logs.map(e => {
-        const tone = statusTone(e.level);
-        return '<div class="log-entry ' + tone + '">[' + fmtTime(e.ts) + '] ' + esc(e.message || e.raw) + '</div>';
+      panel.innerHTML = logs.map((entry) => {
+        const tone = statusTone(entry.level);
+        return '<div class="log-entry ' + tone + '"><span>' + esc(fmtTime(entry.ts)) + '</span><span>' + esc(entry.message || entry.raw || "") + '</span></div>';
       }).join("");
     }
 
     function render(data) {
       latestStatus = data;
       renderSummary(data);
+      renderRiskPanel(data);
+      renderOperations(data);
       renderService(data);
+      renderDeployment(data);
       renderAuthProfiles(data);
       renderGitHubAuthors(data);
-      renderDeployment(data);
       renderSessions(data);
       renderLogs(data);
     }
-
     async function parseResponse(response) {
       const payload = await response.json().catch(() => ({}));
-      if (!response.ok) {
-        throw new Error(payload.error || response.statusText || "REQUEST FAILED");
-      }
+      if (!response.ok || payload.ok === false) throw new Error(payload.error || response.statusText || "请求失败");
       return payload;
     }
+    async function loadPreflight(operation) {
+      const response = await fetch("/admin/api/preflight?operation=" + encodeURIComponent(operation), { headers: authHeaders() });
+      return await parseResponse(response);
+    }
+    async function confirmInterruptRisk(operation, verb) {
+      const preflight = await loadPreflight(operation);
+      if (preflight.safe) return false;
+      const detail = "活跃：" + (preflight.activeCount || 0) + " · 待处理：" + (preflight.openInboundCount || 0) + " · 运行任务：" + (preflight.runningBackgroundJobCount || 0);
+      return window.confirm(verb + " 会中断正在进行的管理工作。" + detail + "。继续？") ? true : null;
+    }
 
+    async function refresh() {
+      refreshButton.disabled = true;
+      try {
+        const response = await fetch("/admin/api/status", { headers: authHeaders() });
+        render(await parseResponse(response));
+        lastRefresh.textContent = "已同步：" + new Date().toLocaleTimeString();
+      } catch (error) {
+        lastRefresh.textContent = "错误：" + (error instanceof Error ? error.message : String(error));
+      } finally {
+        refreshButton.disabled = false;
+      }
+    }
     async function activateProfile(name, allowActive) {
-      replaceStatus.textContent = "SWITCHING PROFILE...";
+      replaceStatus.textContent = "正在切换认证档案...";
       try {
         const response = await fetch("/admin/api/auth-profiles/" + encodeURIComponent(name) + "/activate", {
           method: "POST",
@@ -890,185 +1198,134 @@ export function renderAdminPage(options: {
         });
         const payload = await parseResponse(response);
         render(payload.status);
-        replaceStatus.innerHTML = '<span style="color:var(--good)">ACTIVE PROFILE SWITCHED</span>';
+        replaceStatus.innerHTML = '<span style="color:var(--green)">认证档案已切换</span>';
       } catch (error) {
-        replaceStatus.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        replaceStatus.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       }
     }
-
     async function deleteProfile(name) {
-      replaceStatus.textContent = "DELETING PROFILE...";
+      replaceStatus.textContent = "正在删除认证档案...";
       try {
-        const response = await fetch("/admin/api/auth-profiles/" + encodeURIComponent(name), {
-          method: "DELETE",
-          headers: authHeaders()
-        });
+        const response = await fetch("/admin/api/auth-profiles/" + encodeURIComponent(name), { method: "DELETE", headers: authHeaders() });
         const payload = await parseResponse(response);
         render(payload.status);
-        replaceStatus.innerHTML = '<span style="color:var(--good)">PROFILE DELETED</span>';
+        replaceStatus.innerHTML = '<span style="color:var(--green)">认证档案已删除</span>';
       } catch (error) {
-        replaceStatus.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        replaceStatus.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       }
     }
-
     async function submitAddProfile() {
       const status = document.getElementById("add-profile-status");
       const fileInput = document.getElementById("profile-auth-file");
       const textArea = document.getElementById("profile-auth-text");
       const submitButton = document.getElementById("submit-add-profile-dialog");
-      status.textContent = "SAVING...";
+      status.textContent = "正在保存...";
       submitButton.disabled = true;
       try {
         const content = textArea.value.trim() || (fileInput.files[0] ? await fileInput.files[0].text() : "");
-        if (!content) {
-          throw new Error("AUTH.JSON IS REQUIRED");
-        }
+        if (!content) throw new Error("必须提供 auth.json");
         const response = await fetch("/admin/api/auth-profiles", {
           method: "POST",
           headers: authHeaders({ "content-type": "application/json" }),
-          body: JSON.stringify({
-            auth_json_content: content
-          })
+          body: JSON.stringify({ auth_json_content: content })
         });
         const payload = await parseResponse(response);
         render(payload.status);
-        replaceStatus.innerHTML = '<span style="color:var(--good)">PROFILE SAVED</span>';
-        status.innerHTML = '<span style="color:var(--good)">PROFILE SAVED</span>';
+        status.innerHTML = '<span style="color:var(--green)">认证档案已保存</span>';
+        replaceStatus.innerHTML = '<span style="color:var(--green)">认证档案已保存</span>';
         addProfileDialog.close();
         fileInput.value = "";
         textArea.value = "";
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        status.innerHTML = '<span style="color:var(--danger)">' + esc(message) + "</span>";
+        status.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       } finally {
         submitButton.disabled = false;
       }
     }
-
     async function deployRelease() {
       const ref = deployRefInput.value.trim();
       if (!ref) {
-        deployStatus.innerHTML = '<span style="color:var(--danger)">REF IS REQUIRED</span>';
+        deployStatus.innerHTML = '<span style="color:var(--red)">必须填写发布目标</span>';
         return;
       }
-      const activeCount = Number(latestStatus?.state?.activeCount || 0);
-      const allowActive =
-        activeCount > 0 ? window.confirm("ACTIVE SESSIONS EXIST. DEPLOYING WILL INTERRUPT THEM. CONTINUE?") : false;
-      if (activeCount > 0 && !allowActive) {
-        return;
-      }
-      deployStatus.textContent = "DEPLOYING...";
       try {
+        const allowActive = await confirmInterruptRisk("deploy", "发布");
+        if (allowActive == null) return;
+        deployStatus.textContent = "正在发布...";
         const response = await fetch("/admin/api/deploy", {
           method: "POST",
           headers: authHeaders({ "content-type": "application/json" }),
-          body: JSON.stringify({
-            ref,
-            allow_active: allowActive
-          })
+          body: JSON.stringify({ ref, allow_active: allowActive })
         });
         const payload = await parseResponse(response);
         render(payload.status);
-        deployStatus.innerHTML = '<span style="color:var(--good)">DEPLOYED ' + esc(ref) + "</span>";
+        deployStatus.innerHTML = '<span style="color:var(--green)">已发布 ' + esc(ref) + " · 操作 " + esc(payload.operation?.id || "") + '</span>';
       } catch (error) {
-        deployStatus.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        deployStatus.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       }
     }
-
     async function rollbackRelease() {
-      const activeCount = Number(latestStatus?.state?.activeCount || 0);
-      const allowActive =
-        activeCount > 0 ? window.confirm("ACTIVE SESSIONS EXIST. ROLLBACK WILL INTERRUPT THEM. CONTINUE?") : false;
-      if (activeCount > 0 && !allowActive) {
-        return;
-      }
-      deployStatus.textContent = "ROLLING BACK...";
       try {
+        const allowActive = await confirmInterruptRisk("rollback", "回滚");
+        if (allowActive == null) return;
+        deployStatus.textContent = "正在回滚...";
         const response = await fetch("/admin/api/rollback", {
           method: "POST",
           headers: authHeaders({ "content-type": "application/json" }),
-          body: JSON.stringify({
-            allow_active: allowActive
-          })
+          body: JSON.stringify({ allow_active: allowActive })
         });
         const payload = await parseResponse(response);
         render(payload.status);
-        deployStatus.innerHTML = '<span style="color:var(--good)">ROLLED BACK</span>';
+        deployStatus.innerHTML = '<span style="color:var(--green)">已回滚 · 操作 ' + esc(payload.operation?.id || "") + '</span>';
       } catch (error) {
-        deployStatus.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        deployStatus.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       }
     }
-
-    async function refresh() {
-      refreshButton.disabled = true;
-      try {
-        const res = await fetch("/admin/api/status", { headers: authHeaders() });
-        const p = await parseResponse(res);
-        render(p);
-        lastRefresh.textContent = "SYNCED: " + new Date().toLocaleTimeString();
-      } catch (e) { lastRefresh.textContent = "ERROR: " + (e instanceof Error ? e.message : String(e)); }
-      finally { refreshButton.disabled = false; }
-    }
-
     async function submitGitHubAuthorMapping() {
       const slackUserId = document.getElementById("github-author-slack-user-id").value.trim();
       const githubAuthor = document.getElementById("github-author-value").value.trim();
       const status = document.getElementById("github-author-dialog-status");
       const submitButton = document.getElementById("submit-github-author-dialog");
-      status.textContent = "SAVING...";
+      status.textContent = "正在保存...";
       submitButton.disabled = true;
-
       try {
-        if (!slackUserId || !githubAuthor) {
-          throw new Error("SLACK USER ID AND GITHUB AUTHOR ARE REQUIRED");
-        }
-
+        if (!slackUserId || !githubAuthor) throw new Error("必须填写 Slack 用户 ID 和 GitHub 作者");
         const response = await fetch("/admin/api/github-authors", {
           method: "POST",
           headers: authHeaders({ "content-type": "application/json" }),
-          body: JSON.stringify({
-            slack_user_id: slackUserId,
-            github_author: githubAuthor
-          })
+          body: JSON.stringify({ slack_user_id: slackUserId, github_author: githubAuthor })
         });
         const payload = await parseResponse(response);
         render(payload.status);
-        githubAuthorsStatus.innerHTML = '<span style="color:var(--good)">MAPPING SAVED</span>';
-        status.innerHTML = '<span style="color:var(--good)">MAPPING SAVED</span>';
+        githubAuthorsStatus.innerHTML = '<span style="color:var(--green)">作者映射已保存</span>';
+        status.innerHTML = '<span style="color:var(--green)">作者映射已保存</span>';
         githubAuthorDialog.close();
       } catch (error) {
-        status.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        status.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       } finally {
         submitButton.disabled = false;
       }
     }
-
     async function deleteGitHubAuthorMapping(slackUserId) {
-      githubAuthorsStatus.textContent = "DELETING MAPPING...";
+      githubAuthorsStatus.textContent = "正在删除作者映射...";
       try {
-        const response = await fetch("/admin/api/github-authors/" + encodeURIComponent(slackUserId), {
-          method: "DELETE",
-          headers: authHeaders()
-        });
+        const response = await fetch("/admin/api/github-authors/" + encodeURIComponent(slackUserId), { method: "DELETE", headers: authHeaders() });
         const payload = await parseResponse(response);
         render(payload.status);
-        githubAuthorsStatus.innerHTML = '<span style="color:var(--good)">MAPPING DELETED</span>';
+        githubAuthorsStatus.innerHTML = '<span style="color:var(--green)">作者映射已删除</span>';
       } catch (error) {
-        githubAuthorsStatus.innerHTML = '<span style="color:var(--danger)">' + esc(error instanceof Error ? error.message : String(error)) + "</span>";
+        githubAuthorsStatus.innerHTML = '<span style="color:var(--red)">' + esc(error instanceof Error ? error.message : String(error)) + '</span>';
       }
     }
 
     sessionSearch.value = uiState.sessionSearch;
     sessionFilter.value = uiState.sessionFilter;
-
     refreshButton.onclick = refresh;
     sessionSearch.oninput = () => {
       updateUiState({ sessionSearch: sessionSearch.value }, { deferPersist: true });
       if (latestStatus) renderSessions(latestStatus);
     };
-    sessionSearch.onblur = () => {
-      persistUiState();
-    };
+    sessionSearch.onblur = () => persistUiState();
     sessionFilter.onchange = () => {
       updateUiState({ sessionFilter: sessionFilter.value });
       if (latestStatus) renderSessions(latestStatus);
@@ -1090,18 +1347,10 @@ export function renderAdminPage(options: {
     document.getElementById("close-github-author-dialog").onclick = () => githubAuthorDialog.close();
     document.getElementById("submit-add-profile-dialog").onclick = submitAddProfile;
     document.getElementById("submit-github-author-dialog").onclick = submitGitHubAuthorMapping;
-    addProfileDialog.onclick = (event) => {
-      if (event.target === addProfileDialog) {
-        addProfileDialog.close();
-      }
-    };
-    githubAuthorDialog.onclick = (event) => {
-      if (event.target === githubAuthorDialog) {
-        githubAuthorDialog.close();
-      }
-    };
-
-    refresh(); setInterval(refresh, 10000);
+    addProfileDialog.onclick = (event) => { if (event.target === addProfileDialog) addProfileDialog.close(); };
+    githubAuthorDialog.onclick = (event) => { if (event.target === githubAuthorDialog) githubAuthorDialog.close(); };
+    refresh();
+    window.setInterval(refresh, 10000);
   </script>
 </body>
 </html>`;

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -36,6 +36,48 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "GET" && url.pathname === "/admin/api/overview") {
+    respondJson(response, 200, await options.adminService.getOverview());
+    return true;
+  }
+
+  if (method === "GET" && url.pathname === "/admin/api/sessions") {
+    respondJson(response, 200, await options.adminService.listSessionSummaries());
+    return true;
+  }
+
+  if (method === "GET" && url.pathname.startsWith("/admin/api/sessions/") && url.pathname.endsWith("/timeline")) {
+    const sessionKey = decodeURIComponent(url.pathname.slice(
+      "/admin/api/sessions/".length,
+      -"/timeline".length
+    ));
+    if (!sessionKey || sessionKey.includes("/")) {
+      return false;
+    }
+
+    respondJson(response, 200, await options.adminService.getSessionTimeline(sessionKey));
+    return true;
+  }
+
+  if (method === "GET" && url.pathname === "/admin/api/preflight") {
+    respondJson(response, 200, await options.adminService.getOperationPreflight({
+      operation: readString(url.searchParams.get("operation")) ?? "unknown"
+    }));
+    return true;
+  }
+
+  if (method === "GET" && url.pathname === "/admin/api/operations") {
+    respondJson(response, 200, await options.adminService.listAdminOperations());
+    return true;
+  }
+
+  if (method === "GET" && url.pathname === "/admin/api/audit") {
+    respondJson(response, 200, await options.adminService.listAdminAuditEvents({
+      operationId: readString(url.searchParams.get("operation_id")) ?? undefined
+    }));
+    return true;
+  }
+
   if (method === "GET" && url.pathname === "/admin/api/status") {
     respondJson(response, 200, await options.adminService.getStatus());
     return true;

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -1,9 +1,18 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { AppConfig } from "../config.js";
 import { getBrokerLogDirectory } from "../logger.js";
-import type { PersistedBackgroundJob, PersistedInboundMessage, SlackSessionRecord } from "../types.js";
+import type {
+  AdminOperationKind,
+  JsonLike,
+  PersistedAdminAuditEvent,
+  PersistedAdminOperation,
+  PersistedBackgroundJob,
+  PersistedInboundMessage,
+  SlackSessionRecord
+} from "../types.js";
 import type { SessionManager } from "./session-manager.js";
 import type { AuthProfileService } from "./auth-profile-service.js";
 import type { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
@@ -31,6 +40,46 @@ interface FileInfo {
   readonly mtime?: string | undefined;
 }
 
+interface SessionSnapshot {
+  readonly allSessions: readonly SlackSessionRecord[];
+  readonly activeSessions: readonly SlackSessionRecord[];
+  readonly openInbound: readonly PersistedInboundMessage[];
+  readonly backgroundJobs: readonly PersistedBackgroundJob[];
+  readonly openInboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>;
+  readonly jobsBySession: ReadonlyMap<string, readonly PersistedBackgroundJob[]>;
+}
+
+interface RuntimeStatus {
+  readonly account: SerializedAccountStatus;
+  readonly rateLimits: SerializedRateLimitsStatus;
+  readonly deployment: unknown;
+  readonly authProfiles: unknown;
+  readonly githubAuthorMappings: {
+    readonly count: number;
+    readonly mappings: readonly unknown[];
+  };
+}
+
+interface OperationPreflight {
+  readonly operation: string;
+  readonly safe: boolean;
+  readonly requiresAllowActive: boolean;
+  readonly activeCount: number;
+  readonly openInboundCount: number;
+  readonly runningBackgroundJobCount: number;
+  readonly impacts: readonly Record<string, JsonLike>[];
+}
+
+interface AdminOperationStore {
+  readonly listAdminOperations?: ((limit?: number) => PersistedAdminOperation[]) | undefined;
+  readonly upsertAdminOperation?: ((record: PersistedAdminOperation) => Promise<void>) | undefined;
+  readonly listAdminAuditEvents?: ((options?: {
+    readonly operationId?: string | undefined;
+    readonly limit?: number | undefined;
+  }) => PersistedAdminAuditEvent[]) | undefined;
+  readonly appendAdminAuditEvent?: ((record: PersistedAdminAuditEvent) => Promise<void>) | undefined;
+}
+
 export class AdminService {
   constructor(
     private readonly options: {
@@ -55,28 +104,336 @@ export class AdminService {
   }
 
   async getStatus(): Promise<Record<string, unknown>> {
-    await this.#refreshSessions();
-    await this.options.githubAuthorMappings.load();
-    const allSessions = this.options.sessions
-      .listSessions()
-      .sort((left, right) => compareSessions(left, right));
-    const activeSessions = allSessions.filter((session) => Boolean(session.activeTurnId));
-    const openInbound = this.options.sessions
-      .listInboundMessages({
-        status: ["pending", "inflight"]
-      })
-      .sort((left, right) => String(left.updatedAt ?? "").localeCompare(String(right.updatedAt ?? "")));
-    const backgroundJobs = this.options.sessions
-      .listBackgroundJobs()
-      .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
-    const openInboundBySession = groupBySession(openInbound);
-    const jobsBySession = groupBySession(backgroundJobs);
-    const sessionSummaries = allSessions.slice(0, 50).map((session) =>
+    const snapshot = await this.#readSessionSnapshot();
+    const runtime = await this.#readRuntimeStatus();
+    const sessionSummaries = snapshot.allSessions.slice(0, 50).map((session) =>
       this.#summarizeSession(session, {
-        inbound: openInboundBySession.get(session.key) ?? [],
-        jobs: jobsBySession.get(session.key) ?? []
+        inbound: snapshot.openInboundBySession.get(session.key) ?? [],
+        jobs: snapshot.jobsBySession.get(session.key) ?? []
       })
     );
+    const stateCounts = this.#summarizeStateCounts(snapshot);
+
+    return {
+      service: this.#serviceInfo(),
+      authFiles: {
+        authJson: await this.#fileInfo(path.join(this.options.config.codexHome, "auth.json")),
+        credentialsJson: await this.#fileInfo(path.join(this.options.config.codexHome, ".credentials.json")),
+        configToml: await this.#fileInfo(path.join(this.options.config.codexHome, "config.toml"))
+      },
+      authProfiles: runtime.authProfiles,
+      githubAuthorMappings: runtime.githubAuthorMappings,
+      account: runtime.account,
+      rateLimits: runtime.rateLimits,
+      deployment: runtime.deployment,
+      operations: this.#listAdminOperations(10),
+      auditEvents: this.#listAdminAuditEvents({ limit: 10 }),
+      state: {
+        ...stateCounts,
+        activeSessions: snapshot.activeSessions,
+        openInbound: snapshot.openInbound.slice(0, 25).map((message) => this.#summarizeInbound(message)),
+        sessions: sessionSummaries,
+        recentBrokerLogs: await this.#readRecentBrokerLogs(40)
+      }
+    };
+  }
+
+  async getOverview(): Promise<Record<string, unknown>> {
+    const snapshot = await this.#readSessionSnapshot();
+    const runtime = await this.#readRuntimeStatus();
+    return {
+      ok: true,
+      service: this.#serviceInfo(),
+      authProfiles: runtime.authProfiles,
+      githubAuthorMappings: runtime.githubAuthorMappings,
+      account: runtime.account,
+      rateLimits: runtime.rateLimits,
+      deployment: runtime.deployment,
+      operations: this.#listAdminOperations(10),
+      auditEvents: this.#listAdminAuditEvents({ limit: 10 }),
+      state: this.#summarizeStateCounts(snapshot)
+    };
+  }
+
+  async listSessionSummaries(): Promise<Record<string, unknown>> {
+    const snapshot = await this.#readSessionSnapshot();
+    return {
+      ok: true,
+      sessions: snapshot.allSessions.slice(0, 100).map((session) =>
+        this.#summarizeSession(session, {
+          inbound: snapshot.openInboundBySession.get(session.key) ?? [],
+          jobs: snapshot.jobsBySession.get(session.key) ?? []
+        })
+      )
+    };
+  }
+
+  async getSessionTimeline(sessionKey: string): Promise<Record<string, unknown>> {
+    await this.#refreshSessions();
+    const session = this.options.sessions.getSessionByKey(sessionKey);
+    if (!session) {
+      return {
+        ok: false,
+        error: "session_not_found",
+        sessionKey
+      };
+    }
+
+    const inbound = this.options.sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs
+    });
+    const openInbound = this.options.sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      status: ["pending", "inflight"]
+    });
+    const jobs = this.options.sessions.listBackgroundJobs({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs
+    });
+
+    const events: Array<Record<string, JsonLike>> = [
+      {
+        type: "session_created",
+        at: session.createdAt,
+        status: session.activeTurnId ? "active" : "idle",
+        summary: session.workspacePath
+      }
+    ];
+
+    for (const message of inbound) {
+      events.push({
+        type: "inbound_message",
+        at: message.updatedAt ?? message.createdAt,
+        status: message.status,
+        summary: message.text.slice(0, 160),
+        sessionKey: message.sessionKey,
+        messageTs: message.messageTs,
+        source: message.source,
+        userId: message.userId
+      });
+    }
+
+    for (const job of jobs) {
+      events.push({
+        type: "background_job",
+        at: job.updatedAt ?? job.createdAt,
+        status: job.status,
+        summary: job.kind,
+        sessionKey: job.sessionKey,
+        jobId: job.id
+      });
+    }
+
+    if (session.lastTurnSignalKind) {
+      events.push({
+        type: "turn_signal",
+        at: session.lastTurnSignalAt ?? session.updatedAt,
+        status: session.lastTurnSignalKind,
+        summary: session.lastTurnSignalReason ?? session.lastTurnSignalKind,
+        sessionKey: session.key,
+        turnId: session.lastTurnSignalTurnId ?? null
+      });
+    }
+
+    return {
+      ok: true,
+      session: this.#summarizeSession(session, {
+        inbound: openInbound,
+        jobs
+      }),
+      events: events.sort(compareTimelineEvents)
+    };
+  }
+
+  async getOperationPreflight(options: {
+    readonly operation: string;
+  }): Promise<Record<string, unknown>> {
+    return {
+      ok: true,
+      ...await this.#readOperationPreflight(options.operation)
+    };
+  }
+
+  async listAdminOperations(): Promise<Record<string, unknown>> {
+    return {
+      ok: true,
+      operations: this.#listAdminOperations(50)
+    };
+  }
+
+  async listAdminAuditEvents(options?: {
+    readonly operationId?: string | undefined;
+  }): Promise<Record<string, unknown>> {
+    return {
+      ok: true,
+      events: this.#listAdminAuditEvents({
+        operationId: options?.operationId,
+        limit: 50
+      })
+    };
+  }
+
+  async addAuthProfile(options: {
+    readonly name?: string | undefined;
+    readonly authJsonContent: string;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "auth_profile_add",
+      {
+        name: options.name ?? null,
+        authJsonBytes: Buffer.byteLength(options.authJsonContent, "utf8")
+      },
+      async () => {
+        const profile = await this.options.authProfiles.addProfile(options);
+        return {
+          ok: true,
+          profile
+        };
+      }
+    );
+  }
+
+  async deleteAuthProfile(options: {
+    readonly name: string;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "auth_profile_delete",
+      {
+        name: options.name
+      },
+      async () => {
+        await this.options.authProfiles.deleteProfile(options.name);
+        return {
+          ok: true,
+          deletedProfile: options.name
+        };
+      }
+    );
+  }
+
+  async activateAuthProfile(options: {
+    readonly name: string;
+    readonly allowActive: boolean;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "auth_profile_activate",
+      {
+        name: options.name,
+        allowActive: options.allowActive
+      },
+      async () => {
+        await this.#assertSafeToInterrupt(options.allowActive, "auth profile switch");
+        const activated = await this.options.authProfiles.activateProfile(options.name);
+        await this.options.runtime.restartRuntime(`admin auth profile switch: ${activated.name}`);
+        return {
+          ok: true,
+          activatedProfile: activated.name
+        };
+      }
+    );
+  }
+
+  async deployRelease(options: {
+    readonly ref: string;
+    readonly allowActive: boolean;
+  }): Promise<Record<string, unknown>> {
+    if (!this.options.deployment) {
+      throw new Error("Release deployment is not configured for this runtime.");
+    }
+
+    return await this.#runTrackedOperation(
+      "deploy",
+      {
+        ref: options.ref,
+        allowActive: options.allowActive
+      },
+      async () => {
+        await this.#assertSafeToInterrupt(options.allowActive, "deploy");
+        const deployment = await this.options.deployment!.deploy({
+          ref: options.ref
+        } satisfies DeployReleaseOptions);
+        return {
+          ok: true,
+          deployment
+        };
+      }
+    );
+  }
+
+  async rollbackRelease(options: {
+    readonly ref?: string | undefined;
+    readonly allowActive: boolean;
+  }): Promise<Record<string, unknown>> {
+    if (!this.options.deployment) {
+      throw new Error("Release deployment is not configured for this runtime.");
+    }
+
+    return await this.#runTrackedOperation(
+      "rollback",
+      {
+        ref: options.ref ?? null,
+        allowActive: options.allowActive
+      },
+      async () => {
+        await this.#assertSafeToInterrupt(options.allowActive, "rollback");
+        const deployment = await this.options.deployment!.rollback({
+          ref: options.ref
+        } satisfies RollbackReleaseOptions);
+        return {
+          ok: true,
+          deployment
+        };
+      }
+    );
+  }
+
+  async upsertGitHubAuthorMapping(options: {
+    readonly slackUserId: string;
+    readonly githubAuthor: string;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "github_author_upsert",
+      {
+        slackUserId: options.slackUserId,
+        githubAuthor: options.githubAuthor
+      },
+      async () => {
+        await this.options.githubAuthorMappings.load();
+        const mapping = await this.options.githubAuthorMappings.upsertManualMapping({
+          slackUserId: options.slackUserId,
+          githubAuthor: options.githubAuthor
+        });
+        return {
+          ok: true,
+          mapping
+        };
+      }
+    );
+  }
+
+  async deleteGitHubAuthorMapping(options: {
+    readonly slackUserId: string;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "github_author_delete",
+      {
+        slackUserId: options.slackUserId
+      },
+      async () => {
+        await this.options.githubAuthorMappings.load();
+        await this.options.githubAuthorMappings.deleteMapping(options.slackUserId);
+        return {
+          ok: true,
+          slackUserId: options.slackUserId
+        };
+      }
+    );
+  }
+
+  async #readRuntimeStatus(): Promise<RuntimeStatus> {
+    await this.options.githubAuthorMappings.load();
     const [account, rateLimits, deployment] = await Promise.all([
       this.#readAccountSummary(),
       this.#readAccountRateLimits(),
@@ -93,158 +450,246 @@ export class AdminService {
             }
           : undefined
     });
-    const backgroundJobCount = backgroundJobs.length;
-    const runningBackgroundJobCount = backgroundJobs.filter((job) => job.status === "running").length;
-    const failedBackgroundJobCount = backgroundJobs.filter((job) => job.status === "failed").length;
-    const openHumanInboundCount = openInbound.filter(isHumanInboundMessage).length;
-    const openSystemInboundCount = openInbound.length - openHumanInboundCount;
-
+    const mappings = this.options.githubAuthorMappings.listMappings();
     return {
-      service: {
-        name: this.options.config.serviceName,
-        mode: this.options.deployment ? "admin" : "combined",
-        pid: process.pid,
-        uptimeSeconds: Math.round(process.uptime()),
-        startedAt: this.options.startedAt.toISOString(),
-        port: this.options.config.port,
-        brokerHttpBaseUrl: this.options.config.brokerHttpBaseUrl,
-        workerBaseUrl: this.options.config.workerBaseUrl,
-        sessionsRoot: this.options.config.sessionsRoot,
-        reposRoot: this.options.config.reposRoot,
-        codexHome: this.options.config.codexHome,
-        adminTokenConfigured: Boolean(this.options.config.brokerAdminToken)
-      },
-      authFiles: {
-        authJson: await this.#fileInfo(path.join(this.options.config.codexHome, "auth.json")),
-        credentialsJson: await this.#fileInfo(path.join(this.options.config.codexHome, ".credentials.json")),
-        configToml: await this.#fileInfo(path.join(this.options.config.codexHome, "config.toml"))
-      },
-      authProfiles,
-      githubAuthorMappings: {
-        count: this.options.githubAuthorMappings.listMappings().length,
-        mappings: this.options.githubAuthorMappings.listMappings()
-      },
       account,
       rateLimits,
       deployment,
-      state: {
-        sessionCount: allSessions.length,
-        activeCount: activeSessions.length,
-        activeSessions,
-        openInboundCount: openInbound.length,
-        openHumanInboundCount,
-        openSystemInboundCount,
-        openInbound: openInbound.slice(0, 25).map((message) => this.#summarizeInbound(message)),
-        backgroundJobCount,
-        runningBackgroundJobCount,
-        failedBackgroundJobCount,
-        sessions: sessionSummaries,
-        recentBrokerLogs: await this.#readRecentBrokerLogs(40)
+      authProfiles,
+      githubAuthorMappings: {
+        count: mappings.length,
+        mappings
       }
     };
   }
 
-  async addAuthProfile(options: {
-    readonly name?: string | undefined;
-    readonly authJsonContent: string;
-  }): Promise<Record<string, unknown>> {
-    const profile = await this.options.authProfiles.addProfile(options);
+  async #readSessionSnapshot(): Promise<SessionSnapshot> {
+    await this.#refreshSessions();
+    const allSessions = this.options.sessions
+      .listSessions()
+      .sort((left, right) => compareSessions(left, right));
+    const activeSessions = allSessions.filter((session) => Boolean(session.activeTurnId));
+    const openInbound = this.options.sessions
+      .listInboundMessages({
+        status: ["pending", "inflight"]
+      })
+      .sort((left, right) => String(left.updatedAt ?? "").localeCompare(String(right.updatedAt ?? "")));
+    const backgroundJobs = this.options.sessions
+      .listBackgroundJobs()
+      .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
+
     return {
-      ok: true,
-      profile,
-      status: await this.getStatus()
+      allSessions,
+      activeSessions,
+      openInbound,
+      backgroundJobs,
+      openInboundBySession: groupBySession(openInbound),
+      jobsBySession: groupBySession(backgroundJobs)
     };
   }
 
-  async deleteAuthProfile(options: {
-    readonly name: string;
-  }): Promise<Record<string, unknown>> {
-    await this.options.authProfiles.deleteProfile(options.name);
+  #summarizeStateCounts(snapshot: SessionSnapshot): Record<string, unknown> {
+    const runningBackgroundJobCount = snapshot.backgroundJobs.filter((job) => job.status === "running").length;
+    const failedBackgroundJobCount = snapshot.backgroundJobs.filter((job) => job.status === "failed").length;
+    const openHumanInboundCount = snapshot.openInbound.filter(isHumanInboundMessage).length;
     return {
-      ok: true,
-      deletedProfile: options.name,
-      status: await this.getStatus()
+      sessionCount: snapshot.allSessions.length,
+      activeCount: snapshot.activeSessions.length,
+      openInboundCount: snapshot.openInbound.length,
+      openHumanInboundCount,
+      openSystemInboundCount: snapshot.openInbound.length - openHumanInboundCount,
+      backgroundJobCount: snapshot.backgroundJobs.length,
+      runningBackgroundJobCount,
+      failedBackgroundJobCount
     };
   }
 
-  async activateAuthProfile(options: {
-    readonly name: string;
-    readonly allowActive: boolean;
-  }): Promise<Record<string, unknown>> {
-    await this.#assertSafeToInterrupt(options.allowActive, "auth profile switch");
-    const activated = await this.options.authProfiles.activateProfile(options.name);
-    await this.options.runtime.restartRuntime(`admin auth profile switch: ${activated.name}`);
+  #serviceInfo(): Record<string, unknown> {
     return {
-      ok: true,
-      activatedProfile: activated.name,
-      status: await this.getStatus()
+      name: this.options.config.serviceName,
+      mode: this.options.deployment ? "admin" : "combined",
+      pid: process.pid,
+      uptimeSeconds: Math.round(process.uptime()),
+      startedAt: this.options.startedAt.toISOString(),
+      port: this.options.config.port,
+      brokerHttpBaseUrl: this.options.config.brokerHttpBaseUrl,
+      workerBaseUrl: this.options.config.workerBaseUrl,
+      sessionsRoot: this.options.config.sessionsRoot,
+      reposRoot: this.options.config.reposRoot,
+      codexHome: this.options.config.codexHome,
+      adminTokenConfigured: Boolean(this.options.config.brokerAdminToken)
     };
   }
 
-  async deployRelease(options: {
-    readonly ref: string;
-    readonly allowActive: boolean;
-  }): Promise<Record<string, unknown>> {
-    if (!this.options.deployment) {
-      throw new Error("Release deployment is not configured for this runtime.");
+  async #readOperationPreflight(operation: string): Promise<OperationPreflight> {
+    const snapshot = await this.#readSessionSnapshot();
+    const runningJobs = snapshot.backgroundJobs.filter((job) => job.status === "running");
+    const impacts: Array<Record<string, JsonLike>> = [];
+
+    for (const session of snapshot.activeSessions) {
+      impacts.push({
+        type: "active_turn",
+        sessionKey: session.key,
+        channelId: session.channelId,
+        rootThreadTs: session.rootThreadTs,
+        turnId: session.activeTurnId ?? null,
+        startedAt: session.activeTurnStartedAt ?? null
+      });
     }
 
-    await this.#assertSafeToInterrupt(options.allowActive, "deploy");
-    const deployment = await this.options.deployment.deploy({
-      ref: options.ref
-    } satisfies DeployReleaseOptions);
-    return {
-      ok: true,
-      deployment,
-      status: await this.getStatus()
-    };
-  }
-
-  async rollbackRelease(options: {
-    readonly ref?: string | undefined;
-    readonly allowActive: boolean;
-  }): Promise<Record<string, unknown>> {
-    if (!this.options.deployment) {
-      throw new Error("Release deployment is not configured for this runtime.");
+    for (const message of snapshot.openInbound) {
+      impacts.push({
+        type: "open_inbound",
+        sessionKey: message.sessionKey,
+        channelId: message.channelId,
+        rootThreadTs: message.rootThreadTs,
+        messageTs: message.messageTs,
+        source: message.source,
+        status: message.status,
+        summary: message.text.slice(0, 160)
+      });
     }
 
-    await this.#assertSafeToInterrupt(options.allowActive, "rollback");
-    const deployment = await this.options.deployment.rollback({
-      ref: options.ref
-    } satisfies RollbackReleaseOptions);
+    for (const job of runningJobs) {
+      impacts.push({
+        type: "running_background_job",
+        sessionKey: job.sessionKey,
+        channelId: job.channelId,
+        rootThreadTs: job.rootThreadTs,
+        jobId: job.id,
+        kind: job.kind,
+        status: job.status,
+        updatedAt: job.updatedAt
+      });
+    }
+
     return {
-      ok: true,
-      deployment,
-      status: await this.getStatus()
+      operation,
+      safe: impacts.length === 0,
+      requiresAllowActive: impacts.length > 0,
+      activeCount: snapshot.activeSessions.length,
+      openInboundCount: snapshot.openInbound.length,
+      runningBackgroundJobCount: runningJobs.length,
+      impacts
     };
   }
 
-  async upsertGitHubAuthorMapping(options: {
-    readonly slackUserId: string;
-    readonly githubAuthor: string;
-  }): Promise<Record<string, unknown>> {
-    await this.options.githubAuthorMappings.load();
-    const mapping = await this.options.githubAuthorMappings.upsertManualMapping({
-      slackUserId: options.slackUserId,
-      githubAuthor: options.githubAuthor
+  async #runTrackedOperation<T extends Record<string, unknown>>(
+    kind: AdminOperationKind,
+    request: JsonLike,
+    operationBody: () => Promise<T>
+  ): Promise<T & { readonly operation: PersistedAdminOperation }> {
+    const startedAt = new Date().toISOString();
+    let operation: PersistedAdminOperation = {
+      id: randomUUID(),
+      kind,
+      status: "running",
+      request,
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      startedAt
+    };
+
+    await this.#persistAdminOperation(operation);
+    await this.#appendAdminAuditEvent({
+      id: randomUUID(),
+      operationId: operation.id,
+      action: kind,
+      status: "started",
+      detail: {
+        request
+      },
+      createdAt: startedAt
+    });
+
+    let payload: T;
+    try {
+      payload = await operationBody();
+    } catch (error) {
+      const completedAt = new Date().toISOString();
+      const message = error instanceof Error ? error.message : String(error);
+      operation = {
+        ...operation,
+        status: "failed",
+        error: message,
+        updatedAt: completedAt,
+        completedAt
+      };
+      await this.#persistAdminOperation(operation);
+      await this.#appendAdminAuditEvent({
+        id: randomUUID(),
+        operationId: operation.id,
+        action: kind,
+        status: "failed",
+        detail: {
+          error: message
+        },
+        createdAt: completedAt
+      });
+      throw error;
+    }
+
+    const completedAt = new Date().toISOString();
+    operation = {
+      ...operation,
+      status: "succeeded",
+      result: {
+        ok: true
+      },
+      updatedAt: completedAt,
+      completedAt
+    };
+    await this.#persistAdminOperation(operation);
+    await this.#appendAdminAuditEvent({
+      id: randomUUID(),
+      operationId: operation.id,
+      action: kind,
+      status: "succeeded",
+      detail: {
+        result: {
+          ok: true
+        }
+      },
+      createdAt: completedAt
     });
     return {
-      ok: true,
-      mapping,
+      ...payload,
+      operation,
       status: await this.getStatus()
-    };
+    } as T & { readonly operation: PersistedAdminOperation };
   }
 
-  async deleteGitHubAuthorMapping(options: {
-    readonly slackUserId: string;
-  }): Promise<Record<string, unknown>> {
-    await this.options.githubAuthorMappings.load();
-    await this.options.githubAuthorMappings.deleteMapping(options.slackUserId);
-    return {
-      ok: true,
-      slackUserId: options.slackUserId,
-      status: await this.getStatus()
-    };
+  async #persistAdminOperation(operation: PersistedAdminOperation): Promise<void> {
+    const store = this.#operationStore();
+    if (!store.upsertAdminOperation) {
+      return;
+    }
+    await store.upsertAdminOperation.call(this.options.sessions, operation);
+  }
+
+  async #appendAdminAuditEvent(event: PersistedAdminAuditEvent): Promise<void> {
+    const store = this.#operationStore();
+    if (!store.appendAdminAuditEvent) {
+      return;
+    }
+    await store.appendAdminAuditEvent.call(this.options.sessions, event);
+  }
+
+  #listAdminOperations(limit: number): readonly PersistedAdminOperation[] {
+    const store = this.#operationStore();
+    return store.listAdminOperations?.call(this.options.sessions, limit) ?? [];
+  }
+
+  #listAdminAuditEvents(options: {
+    readonly operationId?: string | undefined;
+    readonly limit: number;
+  }): readonly PersistedAdminAuditEvent[] {
+    const store = this.#operationStore();
+    return store.listAdminAuditEvents?.call(this.options.sessions, options) ?? [];
+  }
+
+  #operationStore(): AdminOperationStore {
+    return this.options.sessions as unknown as AdminOperationStore;
   }
 
   async #readAccountSummary(): Promise<SerializedAccountStatus> {
@@ -268,11 +713,10 @@ export class AdminService {
       return;
     }
 
-    await this.#refreshSessions();
-    const activeCount = this.options.sessions.listSessions().filter((session) => Boolean(session.activeTurnId)).length;
-    if (activeCount > 0) {
+    const preflight = await this.#readOperationPreflight(action);
+    if (preflight.requiresAllowActive) {
       throw new Error(
-        `Refusing ${action} while active sessions exist (activeCount=${activeCount}). Retry with allow_active=true if you really want to interrupt them.`
+        `Refusing ${action} while admin work is in flight (activeCount=${preflight.activeCount}, openInboundCount=${preflight.openInboundCount}, runningBackgroundJobCount=${preflight.runningBackgroundJobCount}). Retry with allow_active=true if you really want to interrupt it.`
       );
     }
   }
@@ -374,6 +818,10 @@ export class AdminService {
       updatedAt: session.updatedAt,
       createdAt: session.createdAt,
       activeTurnId: session.activeTurnId ?? null,
+      activeTurnStartedAt: session.activeTurnStartedAt ?? null,
+      lastTurnSignalKind: session.lastTurnSignalKind ?? null,
+      lastTurnSignalReason: session.lastTurnSignalReason ?? null,
+      lastTurnSignalAt: session.lastTurnSignalAt ?? null,
       lastSlackReplyAt: session.lastSlackReplyAt ?? null,
       lastObservedMessageTs: session.lastObservedMessageTs ?? null,
       lastDeliveredMessageTs: session.lastDeliveredMessageTs ?? null,
@@ -396,6 +844,16 @@ function compareSessions(left: SlackSessionRecord, right: SlackSessionRecord): n
     return rightActive - leftActive;
   }
   return String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? ""));
+}
+
+function compareTimelineEvents(left: Record<string, JsonLike>, right: Record<string, JsonLike>): number {
+  if (left.type === "session_created" && right.type !== "session_created") {
+    return -1;
+  }
+  if (right.type === "session_created" && left.type !== "session_created") {
+    return 1;
+  }
+  return String(left.at ?? "").localeCompare(String(right.at ?? ""));
 }
 
 async function listJsonlFiles(directoryPath: string): Promise<Array<{

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import type {
   JsonLike,
+  PersistedAdminAuditEvent,
+  PersistedAdminOperation,
   PersistedBackgroundJob,
   PersistedInboundMessage,
   PersistedInboundMessageStatus,
@@ -349,6 +351,29 @@ export class SessionManager {
 
   async upsertBackgroundJob(record: PersistedBackgroundJob): Promise<void> {
     await this.#stateStore.upsertBackgroundJob(record);
+  }
+
+  listAdminOperations(limit?: number): PersistedAdminOperation[] {
+    return this.#stateStore.listAdminOperations(limit);
+  }
+
+  getAdminOperation(id: string): PersistedAdminOperation | undefined {
+    return this.#stateStore.getAdminOperation(id);
+  }
+
+  async upsertAdminOperation(record: PersistedAdminOperation): Promise<void> {
+    await this.#stateStore.upsertAdminOperation(record);
+  }
+
+  listAdminAuditEvents(options?: {
+    readonly operationId?: string | undefined;
+    readonly limit?: number | undefined;
+  }): PersistedAdminAuditEvent[] {
+    return this.#stateStore.listAdminAuditEvents(options);
+  }
+
+  async appendAdminAuditEvent(record: PersistedAdminAuditEvent): Promise<void> {
+    await this.#stateStore.appendAdminAuditEvent(record);
   }
 
   #requireSession(channelId: string, rootThreadTs: string): SlackSessionRecord {

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -2,6 +2,8 @@ import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 
 import type {
+  PersistedAdminAuditEvent,
+  PersistedAdminOperation,
   JsonLike,
   PersistedBackgroundJob,
   PersistedInboundMessage,
@@ -13,7 +15,7 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 1;
+export const CURRENT_STATE_SCHEMA_VERSION = 2;
 
 type SqlValue = string | number | bigint | null;
 type SqlRow = Record<string, unknown>;
@@ -128,6 +130,42 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
         CREATE INDEX IF NOT EXISTS idx_inbound_source ON inbound_messages(session_key, source, message_ts);
         CREATE INDEX IF NOT EXISTS idx_jobs_session_status ON background_jobs(session_key, status);
         CREATE INDEX IF NOT EXISTS idx_slack_events_status ON slack_events(status, created_at);
+      `);
+    }
+  },
+  {
+    version: 2,
+    name: "admin_operations",
+    up(database) {
+      database.exec(`
+        CREATE TABLE IF NOT EXISTS admin_operations (
+          id TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          status TEXT NOT NULL,
+          request TEXT NOT NULL,
+          result TEXT,
+          error TEXT,
+          actor TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS admin_audit_events (
+          sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+          id TEXT NOT NULL UNIQUE,
+          operation_id TEXT REFERENCES admin_operations(id) ON DELETE SET NULL,
+          action TEXT NOT NULL,
+          status TEXT NOT NULL,
+          detail TEXT,
+          actor TEXT,
+          created_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_admin_operations_updated ON admin_operations(updated_at);
+        CREATE INDEX IF NOT EXISTS idx_admin_audit_created ON admin_audit_events(sequence);
+        CREATE INDEX IF NOT EXISTS idx_admin_audit_operation ON admin_audit_events(operation_id, sequence);
       `);
     }
   }
@@ -461,6 +499,75 @@ export class StateStore {
     });
   }
 
+  listAdminOperations(limit = 50): PersistedAdminOperation[] {
+    return this.#databaseRequired()
+      .prepare(`
+        SELECT * FROM admin_operations
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT ?
+      `)
+      .all(limit)
+      .map((row) => this.#rowToAdminOperation(row as SqlRow));
+  }
+
+  getAdminOperation(id: string): PersistedAdminOperation | undefined {
+    const row = this.#databaseRequired()
+      .prepare("SELECT * FROM admin_operations WHERE id = ?")
+      .get(id) as SqlRow | undefined;
+    return row ? this.#rowToAdminOperation(row) : undefined;
+  }
+
+  async upsertAdminOperation(record: PersistedAdminOperation): Promise<void> {
+    const normalized = this.#normalizeAdminOperation(record);
+    this.#transaction(() => {
+      this.#upsertAdminOperation(normalized);
+    });
+  }
+
+  listAdminAuditEvents(options?: {
+    readonly operationId?: string | undefined;
+    readonly limit?: number | undefined;
+  }): PersistedAdminAuditEvent[] {
+    const where: string[] = [];
+    const params: SqlValue[] = [];
+    if (options?.operationId) {
+      where.push("operation_id = ?");
+      params.push(options.operationId);
+    }
+    params.push(options?.limit ?? 50);
+
+    const sql = [
+      "SELECT * FROM admin_audit_events",
+      where.length > 0 ? `WHERE ${where.join(" AND ")}` : "",
+      "ORDER BY sequence DESC",
+      "LIMIT ?"
+    ].filter(Boolean).join(" ");
+
+    return this.#databaseRequired()
+      .prepare(sql)
+      .all(...params)
+      .map((row) => this.#rowToAdminAuditEvent(row as SqlRow));
+  }
+
+  async appendAdminAuditEvent(record: PersistedAdminAuditEvent): Promise<void> {
+    const normalized = this.#normalizeAdminAuditEvent(record);
+    this.#transaction(() => {
+      this.#databaseRequired().prepare(`
+        INSERT INTO admin_audit_events (
+          id, operation_id, action, status, detail, actor, created_at
+        ) VALUES (${placeholders(7)})
+      `).run(
+        normalized.id,
+        normalized.operationId ?? null,
+        normalized.action,
+        normalized.status,
+        jsonOrNull(normalized.detail),
+        normalized.actor ?? null,
+        normalized.createdAt
+      );
+    });
+  }
+
   #openDatabase(): void {
     if (this.#database) {
       return;
@@ -679,6 +786,38 @@ export class StateStore {
     );
   }
 
+  #upsertAdminOperation(record: PersistedAdminOperation): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO admin_operations (
+        id, kind, status, request, result, error, actor,
+        created_at, updated_at, started_at, completed_at
+      ) VALUES (${placeholders(11)})
+      ON CONFLICT(id) DO UPDATE SET
+        kind = excluded.kind,
+        status = excluded.status,
+        request = excluded.request,
+        result = excluded.result,
+        error = excluded.error,
+        actor = excluded.actor,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        started_at = excluded.started_at,
+        completed_at = excluded.completed_at
+    `).run(
+      record.id,
+      record.kind,
+      record.status,
+      JSON.stringify(record.request),
+      jsonOrNull(record.result),
+      record.error ?? null,
+      record.actor ?? null,
+      record.createdAt,
+      record.updatedAt,
+      record.startedAt ?? null,
+      record.completedAt ?? null
+    );
+  }
+
   #markProcessedEvent(eventId: string): void {
     this.#databaseRequired()
       .prepare("INSERT OR IGNORE INTO processed_events (event_id) VALUES (?)")
@@ -798,6 +937,34 @@ export class StateStore {
     })!;
   }
 
+  #rowToAdminOperation(row: SqlRow): PersistedAdminOperation {
+    return this.#normalizeAdminOperation({
+      id: stringColumn(row, "id"),
+      kind: stringColumn(row, "kind") as PersistedAdminOperation["kind"],
+      status: stringColumn(row, "status") as PersistedAdminOperation["status"],
+      request: readJsonColumn<JsonLike>(row, "request", null),
+      result: readJsonColumn<JsonLike | undefined>(row, "result", undefined),
+      error: optionalStringColumn(row, "error"),
+      actor: optionalStringColumn(row, "actor"),
+      createdAt: stringColumn(row, "created_at"),
+      updatedAt: stringColumn(row, "updated_at"),
+      startedAt: optionalStringColumn(row, "started_at"),
+      completedAt: optionalStringColumn(row, "completed_at")
+    });
+  }
+
+  #rowToAdminAuditEvent(row: SqlRow): PersistedAdminAuditEvent {
+    return this.#normalizeAdminAuditEvent({
+      id: stringColumn(row, "id"),
+      operationId: optionalStringColumn(row, "operation_id"),
+      action: stringColumn(row, "action"),
+      status: stringColumn(row, "status") as PersistedAdminAuditEvent["status"],
+      detail: readJsonColumn<JsonLike | undefined>(row, "detail", undefined),
+      actor: optionalStringColumn(row, "actor"),
+      createdAt: stringColumn(row, "created_at")
+    });
+  }
+
   #normalizeSession(session: Partial<SlackSessionRecord>): SlackSessionRecord {
     const workspacePath = session.workspacePath
       ? String(session.workspacePath)
@@ -907,6 +1074,42 @@ export class StateStore {
       lastEventAt: raw.lastEventAt,
       lastEventKind: raw.lastEventKind,
       lastEventSummary: raw.lastEventSummary
+    };
+  }
+
+  #normalizeAdminOperation(raw: Partial<PersistedAdminOperation>): PersistedAdminOperation {
+    if (!raw.id || !raw.kind || !raw.status || !raw.createdAt) {
+      throw new Error(`Invalid admin operation: ${raw.id ?? "unknown"}`);
+    }
+
+    return {
+      id: String(raw.id),
+      kind: raw.kind,
+      status: raw.status,
+      request: raw.request ?? null,
+      result: raw.result,
+      error: raw.error,
+      actor: raw.actor,
+      createdAt: String(raw.createdAt),
+      updatedAt: String(raw.updatedAt ?? raw.createdAt),
+      startedAt: raw.startedAt,
+      completedAt: raw.completedAt
+    };
+  }
+
+  #normalizeAdminAuditEvent(raw: Partial<PersistedAdminAuditEvent>): PersistedAdminAuditEvent {
+    if (!raw.id || !raw.action || !raw.status || !raw.createdAt) {
+      throw new Error(`Invalid admin audit event: ${raw.id ?? "unknown"}`);
+    }
+
+    return {
+      id: String(raw.id),
+      operationId: raw.operationId,
+      action: String(raw.action),
+      status: raw.status,
+      detail: raw.detail,
+      actor: raw.actor,
+      createdAt: String(raw.createdAt)
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,41 @@ export interface PersistedBackgroundJob {
   readonly lastEventSummary?: string | undefined;
 }
 
+export type AdminOperationKind =
+  | "deploy"
+  | "rollback"
+  | "auth_profile_add"
+  | "auth_profile_delete"
+  | "auth_profile_activate"
+  | "github_author_upsert"
+  | "github_author_delete";
+
+export type AdminOperationStatus = "running" | "succeeded" | "failed";
+
+export interface PersistedAdminOperation {
+  readonly id: string;
+  readonly kind: AdminOperationKind;
+  readonly status: AdminOperationStatus;
+  readonly request: JsonLike;
+  readonly result?: JsonLike | undefined;
+  readonly error?: string | undefined;
+  readonly actor?: string | undefined;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly startedAt?: string | undefined;
+  readonly completedAt?: string | undefined;
+}
+
+export interface PersistedAdminAuditEvent {
+  readonly id: string;
+  readonly operationId?: string | undefined;
+  readonly action: AdminOperationKind | string;
+  readonly status: AdminOperationStatus | "started";
+  readonly detail?: JsonLike | undefined;
+  readonly actor?: string | undefined;
+  readonly createdAt: string;
+}
+
 export interface SlackInputMessage {
   readonly channelId: string;
   readonly channelType?: string | undefined;

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -1,0 +1,457 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+import { createHttpHandler } from "../src/http/router.js";
+import { AdminService } from "../src/services/admin-service.js";
+import { SessionManager } from "../src/services/session-manager.js";
+import { StateStore } from "../src/store/state-store.js";
+import type { AppConfig } from "../src/config.js";
+import type { PersistedBackgroundJob, PersistedInboundMessage } from "../src/types.js";
+
+describe("admin control plane e2e", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("exposes overview, sessions, timeline, and preflight as separate control-plane resources", async () => {
+    const { baseUrl, sessions } = await startAdminFixture();
+    await seedActiveSession(sessions);
+
+    const overview = await readJson(`${baseUrl}/admin/api/overview`);
+    expect(overview).toMatchObject({
+      ok: true,
+      state: {
+        activeCount: 1,
+        openInboundCount: 1,
+        runningBackgroundJobCount: 1
+      }
+    });
+    expect((overview.state as Record<string, unknown>).sessions).toBeUndefined();
+    expect((overview.state as Record<string, unknown>).recentBrokerLogs).toBeUndefined();
+
+    const sessionList = await readJson(`${baseUrl}/admin/api/sessions`);
+    expect(sessionList).toMatchObject({
+      ok: true,
+      sessions: [
+        {
+          key: "C123:111.222",
+          activeTurnId: "turn-1",
+          openInboundCount: 1,
+          runningBackgroundJobCount: 1
+        }
+      ]
+    });
+
+    const timeline = await readJson(`${baseUrl}/admin/api/sessions/${encodeURIComponent("C123:111.222")}/timeline`);
+    expect(timeline).toMatchObject({
+      ok: true,
+      session: {
+        key: "C123:111.222",
+        lastTurnSignalKind: "wait"
+      }
+    });
+    expect((timeline.events as Array<{ type: string; summary?: string }>).map((event) => event.type)).toEqual([
+      "session_created",
+      "inbound_message",
+      "background_job",
+      "turn_signal"
+    ]);
+    expect(timeline.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "inbound_message",
+          status: "pending",
+          summary: "follow up"
+        }),
+        expect.objectContaining({
+          type: "background_job",
+          status: "running",
+          summary: "watch_ci"
+        }),
+        expect.objectContaining({
+          type: "turn_signal",
+          status: "wait",
+          summary: "waiting on CI"
+        })
+      ])
+    );
+
+    const preflight = await readJson(`${baseUrl}/admin/api/preflight?operation=deploy`);
+    expect(preflight).toMatchObject({
+      ok: true,
+      operation: "deploy",
+      safe: false,
+      requiresAllowActive: true,
+      activeCount: 1,
+      openInboundCount: 1,
+      runningBackgroundJobCount: 1
+    });
+    expect(preflight.impacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "active_turn", sessionKey: "C123:111.222" }),
+        expect.objectContaining({ type: "open_inbound", sessionKey: "C123:111.222" }),
+        expect.objectContaining({ type: "running_background_job", sessionKey: "C123:111.222" })
+      ])
+    );
+  });
+
+  it("records deploy requests as durable admin operations with audit events", async () => {
+    const { baseUrl, deploymentCalls } = await startAdminFixture();
+
+    const deploy = await postJson(`${baseUrl}/admin/api/deploy`, {
+      ref: "main",
+      allow_active: false
+    });
+    expect(deploy).toMatchObject({
+      ok: true,
+      operation: {
+        kind: "deploy",
+        status: "succeeded",
+        request: {
+          ref: "main"
+        }
+      }
+    });
+    expect(deploymentCalls).toEqual([{ kind: "deploy", ref: "main" }]);
+
+    const operations = await readJson(`${baseUrl}/admin/api/operations`);
+    expect(operations).toMatchObject({
+      ok: true,
+      operations: [
+        {
+          id: deploy.operation.id,
+          kind: "deploy",
+          status: "succeeded",
+          request: {
+            ref: "main"
+          }
+        }
+      ]
+    });
+
+    const audit = await readJson(`${baseUrl}/admin/api/audit`);
+    expect(audit).toMatchObject({
+      ok: true,
+      events: [
+        {
+          operationId: deploy.operation.id,
+          action: "deploy",
+          status: "succeeded"
+        },
+        {
+          operationId: deploy.operation.id,
+          action: "deploy",
+          status: "started"
+        }
+      ]
+    });
+  });
+
+  it("records refused deploy preflight checks as failed admin operations", async () => {
+    const { baseUrl, deploymentCalls, sessions } = await startAdminFixture();
+    await seedActiveSession(sessions);
+
+    const response = await fetch(`${baseUrl}/admin/api/deploy`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        ref: "main",
+        allow_active: false
+      })
+    });
+    const payload = await response.json() as Record<string, unknown>;
+    expect(response.status).toBe(500);
+    expect(payload).toMatchObject({
+      ok: false
+    });
+    expect(String(payload.error)).toContain("Refusing deploy");
+    expect(deploymentCalls).toEqual([]);
+
+    const operations = await readJson(`${baseUrl}/admin/api/operations`);
+    expect(operations).toMatchObject({
+      ok: true,
+      operations: [
+        {
+          kind: "deploy",
+          status: "failed",
+          request: {
+            ref: "main"
+          }
+        }
+      ]
+    });
+    const operation = (operations.operations as Array<{ id: string }>)[0];
+    expect(operation?.id).toBeTruthy();
+
+    const audit = await readJson(`${baseUrl}/admin/api/audit`);
+    expect(audit).toMatchObject({
+      ok: true,
+      events: [
+        {
+          operationId: operation?.id,
+          action: "deploy",
+          status: "failed"
+        },
+        {
+          operationId: operation?.id,
+          action: "deploy",
+          status: "started"
+        }
+      ]
+    });
+  });
+
+  async function startAdminFixture(): Promise<{
+    readonly baseUrl: string;
+    readonly sessions: SessionManager;
+    readonly deploymentCalls: Array<Record<string, unknown>>;
+  }> {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-control-plane-"));
+    cleanups.push(async () => {
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    });
+
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot,
+      SERVICE_ROOT: dataRoot,
+      ADMIN_LAUNCHD_LABEL: "admin.test",
+      WORKER_LAUNCHD_LABEL: "worker.test",
+      ADMIN_PLIST_PATH: path.join(dataRoot, "admin.plist"),
+      WORKER_PLIST_PATH: path.join(dataRoot, "worker.plist")
+    } as NodeJS.ProcessEnv);
+    await fs.mkdir(config.codexHome, { recursive: true });
+    await fs.mkdir(config.logDir, { recursive: true });
+
+    const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot: config.sessionsRoot
+    });
+    await sessions.load();
+    cleanups.push(async () => {
+      stateStore.close();
+    });
+
+    const deploymentCalls: Array<Record<string, unknown>> = [];
+    const adminService = new AdminService({
+      config,
+      sessions,
+      startedAt: new Date("2026-03-19T00:00:00.000Z"),
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
+          activeProfile: null,
+          activeAuthPath: path.join(config.codexHome, "auth.json"),
+          profiles: []
+        }),
+        addProfile: async () => ({ name: "profile" }),
+        deleteProfile: async () => {},
+        activateProfile: async (name: string) => ({ name })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => [],
+        upsertManualMapping: async () => ({}),
+        deleteMapping: async () => {}
+      } as never,
+      runtime: {
+        restartRuntime: async () => {},
+        readAccountSummary: async () => ({
+          account: {
+            email: "admin@example.com",
+            type: "chatgpt",
+            planType: "team"
+          },
+          requiresOpenaiAuth: false
+        }),
+        readAccountRateLimits: async () => ({
+          rateLimits: null,
+          rateLimitsByLimitId: {}
+        })
+      } as never,
+      deployment: {
+        getStatus: async () => deploymentStatus(config),
+        deploy: async ({ ref }: { readonly ref: string }) => {
+          deploymentCalls.push({ kind: "deploy", ref });
+          return deploymentStatus(config);
+        },
+        rollback: async ({ ref }: { readonly ref?: string | undefined }) => {
+          deploymentCalls.push({ kind: "rollback", ref: ref ?? null });
+          return deploymentStatus(config);
+        },
+        restartWorker: async () => {}
+      } as never
+    });
+
+    const server = http.createServer(
+      createHttpHandler({
+        adminService,
+        config
+      })
+    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start admin fixture");
+    }
+
+    return {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      sessions,
+      deploymentCalls
+    };
+  }
+});
+
+async function seedActiveSession(sessions: SessionManager): Promise<void> {
+  const session = await sessions.ensureSession("C123", "111.222");
+  await sessions.setActiveTurnId("C123", "111.222", "turn-1");
+  await sessions.recordTurnSignal("C123", "111.222", {
+    turnId: "turn-1",
+    kind: "wait",
+    reason: "waiting on CI",
+    occurredAt: "2026-03-19T00:00:04.000Z"
+  });
+  await sessions.upsertInboundMessage(inboundMessage({
+    sessionKey: session.key,
+    status: "pending",
+    text: "follow up",
+    updatedAt: "2026-03-19T00:00:01.000Z"
+  }));
+  await sessions.upsertBackgroundJob(backgroundJob({
+    sessionKey: session.key,
+    status: "running",
+    updatedAt: "2026-03-19T00:00:02.000Z",
+    startedAt: "2026-03-19T00:00:02.000Z",
+    heartbeatAt: "2026-03-19T00:00:03.000Z"
+  }));
+}
+
+function inboundMessage(patch: Partial<PersistedInboundMessage>): PersistedInboundMessage {
+  return {
+    key: "C123:111.222:111.223",
+    sessionKey: "C123:111.222",
+    channelId: "C123",
+    rootThreadTs: "111.222",
+    messageTs: "111.223",
+    source: "thread_reply",
+    userId: "U123",
+    text: "hello",
+    status: "done",
+    createdAt: "2026-03-19T00:00:01.000Z",
+    updatedAt: "2026-03-19T00:00:01.000Z",
+    ...patch
+  };
+}
+
+function backgroundJob(patch: Partial<PersistedBackgroundJob>): PersistedBackgroundJob {
+  return {
+    id: "job-1",
+    token: "job-token",
+    sessionKey: "C123:111.222",
+    channelId: "C123",
+    rootThreadTs: "111.222",
+    kind: "watch_ci",
+    shell: "/bin/sh",
+    cwd: "/tmp/workspace",
+    scriptPath: "/tmp/job.sh",
+    restartOnBoot: true,
+    status: "registered",
+    createdAt: "2026-03-19T00:00:02.000Z",
+    updatedAt: "2026-03-19T00:00:02.000Z",
+    ...patch
+  };
+}
+
+function deploymentStatus(config: AppConfig): Record<string, unknown> {
+  return {
+    serviceRoot: config.serviceRoot ?? "",
+    repoRoot: config.serviceRoot ?? "",
+    repoUrl: "https://github.com/HOOLC/slack-codex-broker.git",
+    currentRelease: {
+      linkPath: config.currentReleasePath ?? "",
+      targetPath: path.join(config.serviceRoot ?? "", "releases", "current"),
+      exists: true,
+      metadata: {
+        revision: "abc123",
+        shortRevision: "abc123",
+        branch: "main",
+        builtAt: "2026-03-19T00:00:00.000Z",
+        builtBy: "test",
+        builtFromHost: "test-host",
+        stateSchemaVersion: 1
+      }
+    },
+    previousRelease: {
+      linkPath: config.previousReleasePath ?? "",
+      targetPath: null,
+      exists: false,
+      metadata: null
+    },
+    failedRelease: {
+      linkPath: config.failedReleasePath ?? "",
+      targetPath: null,
+      exists: false,
+      metadata: null
+    },
+    recentReleases: [],
+    admin: {
+      launchdLoaded: true,
+      healthOk: true,
+      healthBody: "{\"ok\":true}"
+    },
+    worker: {
+      launchdLoaded: true,
+      healthOk: true,
+      readyOk: true,
+      healthBody: "{\"ok\":true}",
+      readyError: null
+    }
+  };
+}
+
+async function readJson(url: string): Promise<Record<string, unknown>> {
+  const response = await fetch(url);
+  const payload = await response.json() as Record<string, unknown>;
+  expect(response.status).toBe(200);
+  return payload;
+}
+
+async function postJson(url: string, body: Record<string, unknown>): Promise<Record<string, any>> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+  const payload = await response.json() as Record<string, any>;
+  expect(response.status).toBe(200);
+  return payload;
+}

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -98,18 +98,18 @@ describe("admin routes", () => {
 
     expect(html).toContain("open-add-profile-dialog");
     expect(html).toContain("auth-profiles-panel");
-    expect(html).toContain("Auth Profiles");
+    expect(html).toContain("认证档案");
     expect(html).toContain("github-authors-panel");
-    expect(html).toContain("GitHub Authors");
-    expect(html).toContain("Deploy");
+    expect(html).toContain("GitHub 作者映射");
+    expect(html).toContain("发布");
     expect(html).toContain("deploy-release-button");
-    expect(html).toContain("Runtime Info");
+    expect(html).toContain("运行信息");
     expect(html).toContain("add-profile-dialog");
     expect(html).toContain("session-search");
-    expect(html).toContain("System Logs");
-    expect(html).toContain("OPEN: ");
-    expect(html).toContain("(H:");
-    expect(html).toContain(" S:");
+    expect(html).toContain("系统日志");
+    expect(html).toContain("待处理：");
+    expect(html).toContain("人：");
+    expect(html).toContain("系统：");
     expect(html).not.toContain("MSG: ");
     expect(html).not.toContain("profile-name-input");
     expect(html).not.toContain("Account Quota");

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -144,8 +144,12 @@ describe("StateStore", () => {
 
       expect(rows).toEqual([
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 1,
           name: "initial_sqlite_state"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "admin_operations"
         }
       ]);
     } finally {


### PR DESCRIPTION
## What changed

- Added e2e coverage for the admin control-plane resource split before refactoring the implementation.
- Split admin status into explicit overview, sessions, session timeline, preflight, operations, and audit API resources.
- Added persisted admin operations and audit events in SQLite, including success and refused-preflight failure paths.
- Updated deploy/rollback UI flow to use preflight checks and show recent operations/audit entries.

## Why

CF Access handles perimeter access, so the admin redesign should not add another browser-side access-control layer. The real gap was control-plane shape: the old admin API was a large status blob plus ad hoc mutation responses, which made deploy risk, session detail, and operation history hard to reason about.

## Validation

- `pnpm build`
- `pnpm vitest run test/admin-control-plane.e2e.test.ts test/admin-routes.test.ts test/admin-service.test.ts test/state-store.test.ts`
- `pnpm test`
