### PR TITLE
Add admin token usage monitoring

### DIFF
--- a/src/http/admin-page.ts
+++ b/src/http/admin-page.ts
@@ -263,7 +263,7 @@ export function renderAdminPage(options: {
 
     .workspace {
       display: grid;
-      grid-template-columns: minmax(620px, 1fr) 420px;
+      grid-template-columns: minmax(820px, 1fr) 360px;
       gap: 16px;
       align-items: start;
     }
@@ -295,7 +295,7 @@ export function renderAdminPage(options: {
     .session-table-header,
     .session-summary {
       display: grid;
-      grid-template-columns: minmax(180px, 1.2fr) 120px minmax(150px, 0.8fr) minmax(220px, 1fr) 76px;
+      grid-template-columns: minmax(220px, 1.35fr) 108px minmax(140px, 0.72fr) minmax(145px, 0.72fr) minmax(220px, 1fr) 72px;
       gap: 12px;
       align-items: center;
     }
@@ -331,6 +331,20 @@ export function renderAdminPage(options: {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    .session-token-value {
+      color: var(--text);
+      font-size: 16px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .session-token-detail {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 11px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     .session-body {
       padding: 14px 12px 16px;
       border-top: 1px solid var(--line);
@@ -338,7 +352,7 @@ export function renderAdminPage(options: {
     }
     .session-inspector {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 12px;
       margin-top: 12px;
     }
@@ -608,12 +622,14 @@ export function renderAdminPage(options: {
               <option value="inbound">有待处理消息</option>
               <option value="jobs">有运行任务</option>
               <option value="issues">有问题</option>
+              <option value="usage">有消耗记录</option>
             </select>
           </div>
           <div class="session-table-header">
             <div>会话 / 频道</div>
             <div>状态 / Slack</div>
             <div>消息 / 任务</div>
+            <div>Token 消耗</div>
             <div>当前线索</div>
             <div>操作</div>
           </div>
@@ -724,7 +740,7 @@ export function renderAdminPage(options: {
     }
     function normalizeUiState(value) {
       const next = value && typeof value === "object" ? value : {};
-      const sessionFilterValue = ["all", "active", "inbound", "jobs", "issues"].includes(String(next.sessionFilter || "")) ? String(next.sessionFilter) : "all";
+      const sessionFilterValue = ["all", "active", "inbound", "jobs", "issues", "usage"].includes(String(next.sessionFilter || "")) ? String(next.sessionFilter) : "all";
       const sessionSearchValue = typeof next.sessionSearch === "string" ? next.sessionSearch : "";
       const expandedSessionKeys = Array.isArray(next.expandedSessionKeys) ? [...new Set(next.expandedSessionKeys.map((item) => String(item)).filter(Boolean))] : [];
       return { sessionSearch: sessionSearchValue, sessionFilter: sessionFilterValue, expandedSessionKeys };
@@ -1145,6 +1161,7 @@ export function renderAdminPage(options: {
         if (mode === "inbound" && !s.openInboundCount) return false;
         if (mode === "jobs" && !s.runningBackgroundJobCount) return false;
         if (mode === "issues" && !s.failedBackgroundJobCount) return false;
+        if (mode === "usage" && !s.usage?.turnCount) return false;
         if (!query) return true;
         return [s.key, s.channelId, s.workspacePath].some((v) => String(v || "").toLowerCase().includes(query));
       });
@@ -1156,11 +1173,13 @@ export function renderAdminPage(options: {
         const isActive = !!s.activeTurnId;
         const lead = summarizeSessionLead(s);
         const expanded = isSessionExpanded(s.key);
+        const usage = s.usage || {};
         return '<details class="session-row" data-session-key="' + esc(s.key) + '"' + (expanded ? " open" : "") + '>' +
           '<summary class="session-summary">' +
             '<div><div class="session-key">' + esc(s.key) + '</div><div class="session-channel">' + esc(s.channelId) + ' · ' + esc(s.workspacePath || "") + '</div></div>' +
             '<div>' + renderBadge(isActive ? "active" : "idle", isActive ? "good" : "warn") + '<div class="summary-detail">更新：' + esc(fmtTime(s.updatedAt)) + '</div></div>' +
             '<div><strong>待处理：' + (s.openInboundCount || 0) + '（人：' + (s.openHumanInboundCount || 0) + ' 系统：' + (s.openSystemInboundCount || 0) + '）</strong><div class="summary-detail">任务：' + (s.runningBackgroundJobCount || 0) + '</div></div>' +
+            '<div><div class="session-token-value">' + esc(fmtTokens(usage.totalTokens)) + '</div><div class="session-token-detail">回合 ' + esc(usage.turnCount || 0) + ' · 缺失 ' + esc(usage.missingTurns || 0) + '</div></div>' +
             '<div class="summary-detail" title="' + esc(lead) + '">' + esc(lead) + '</div>' +
             '<div>' + renderBadge("inspect", "info") + '</div>' +
           '</summary>' +
@@ -1168,6 +1187,7 @@ export function renderAdminPage(options: {
             '<div class="summary-detail">工作目录：' + esc(s.workspacePath) + '</div>' +
             '<div class="session-inspector">' +
               '<div class="mini-panel"><div class="mini-title">时间线</div><div class="mini-body"><div class="timeline" data-session-timeline="' + esc(s.key) + '">' + renderTimelinePlaceholder(s) + '</div></div></div>' +
+              '<div class="mini-panel"><div class="mini-title">Token 消耗</div><div class="mini-body">' + renderSessionUsage(usage) + '</div></div>' +
               '<div class="mini-panel"><div class="mini-title">消息 / 任务</div><div class="mini-body">' + renderInboundTable(s.openInbound) + renderJobsTable(s.backgroundJobs) + '</div></div>' +
             '</div>' +
           '</div>' +
@@ -1195,6 +1215,18 @@ export function renderAdminPage(options: {
           '<strong>' + esc(event.summary || event.type) + '</strong>' +
         '</div>'
       ).join("");
+    }
+    function renderSessionUsage(usage) {
+      const exact = Number(usage?.exactTurns || 0);
+      const total = Number(usage?.turnCount || 0);
+      if (!total) return '<div class="summary-detail">这个会话还没有用量记录</div>';
+      return '<div class="quota-grid">' +
+        '<div class="quota-line"><span>总量</span><strong>' + esc(fmtTokens(usage.totalTokens)) + '</strong><span>' + esc(total + " 回合") + '</span></div>' +
+        '<div class="quota-line"><span>输入</span><strong>' + esc(fmtTokens(usage.inputTokens)) + '</strong><span>缓存 ' + esc(fmtTokens(usage.cachedInputTokens)) + '</span></div>' +
+        '<div class="quota-line"><span>输出</span><strong>' + esc(fmtTokens(usage.outputTokens)) + '</strong><span>推理 ' + esc(fmtTokens(usage.reasoningTokens)) + '</span></div>' +
+        '<div class="quota-line"><span>精确</span><strong>' + esc(exact + "/" + total) + '</strong><span>缺失 ' + esc(usage.missingTurns || 0) + '</span></div>' +
+        '<div class="summary-detail">最近：' + esc(fmtDateTime(usage.lastTurnAt)) + '</div>' +
+      '</div>';
     }
     async function loadSessionTimeline(sessionKey, row) {
       if (!sessionKey) return;

--- a/src/http/admin-page.ts
+++ b/src/http/admin-page.ts
@@ -100,7 +100,7 @@ export function renderAdminPage(options: {
 
     .command-grid {
       display: grid;
-      grid-template-columns: minmax(360px, 1fr) minmax(360px, 1.1fr) minmax(320px, 0.9fr);
+      grid-template-columns: repeat(4, minmax(260px, 1fr));
       gap: 12px;
       margin: 16px 0;
     }
@@ -227,6 +227,22 @@ export function renderAdminPage(options: {
       margin-top: 10px;
       color: var(--muted);
       font-size: 11px;
+    }
+    .usage-list {
+      display: grid;
+      gap: 7px;
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 11px;
+    }
+    .usage-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px;
+      align-items: center;
+      min-height: 24px;
+      border-top: 1px solid rgba(255,255,255,0.04);
+      padding-top: 7px;
     }
     .badge {
       display: inline-flex;
@@ -525,6 +541,38 @@ export function renderAdminPage(options: {
 
       <section class="panel">
         <div class="panel-head">
+          <div class="panel-title">消耗监控</div>
+          <span id="usage-badge" class="badge info">同步中</span>
+        </div>
+        <div class="panel-body">
+          <div class="metric-grid">
+            <div class="metric">
+              <div class="metric-label">总 token</div>
+              <div class="metric-value" id="usage-total">--</div>
+              <div class="metric-detail" id="usage-total-detail">...</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">24 小时</div>
+              <div class="metric-value good" id="usage-day">--</div>
+              <div class="metric-detail" id="usage-day-detail">...</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">1 小时</div>
+              <div class="metric-value" id="usage-hour">--</div>
+              <div class="metric-detail" id="usage-hour-detail">...</div>
+            </div>
+            <div class="metric">
+              <div class="metric-label">缺失用量</div>
+              <div class="metric-value warn" id="usage-missing">--</div>
+              <div class="metric-detail" id="usage-missing-detail">...</div>
+            </div>
+          </div>
+          <div id="usage-list" class="usage-list"></div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
           <div class="panel-title">发布风险门禁</div>
           <span id="risk-badge" class="badge info">检查中</span>
         </div>
@@ -759,6 +807,12 @@ export function renderAdminPage(options: {
       const rel = formatRelativeDuration(delta);
       return delta > 0 ? rel + "后" : rel + "前";
     }
+    function fmtTokens(value) {
+      const n = Math.max(0, Number(value || 0));
+      if (n >= 1000000) return (n / 1000000).toFixed(2).replace(/\\.00$/, "") + "M";
+      if (n >= 1000) return (n / 1000).toFixed(1).replace(/\\.0$/, "") + "K";
+      return String(Math.round(n));
+    }
     function clampPercent(value) {
       return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
     }
@@ -796,6 +850,9 @@ export function renderAdminPage(options: {
         session: "会话",
         admin: "管理",
         audit: "审计",
+        exact: "精确",
+        estimated: "估算",
+        missing: "缺失",
         unknown: "未知",
         combined: "合并模式"
       };
@@ -847,6 +904,41 @@ export function renderAdminPage(options: {
       document.getElementById("session-open-count").textContent = st.openInboundCount || 0;
       document.getElementById("session-human-count").textContent = st.openHumanInboundCount || 0;
       document.getElementById("session-system-count").textContent = st.openSystemInboundCount || 0;
+    }
+
+    function renderUsage(data) {
+      const usage = data.usage || {};
+      const totals = usage.totals || {};
+      const windows = usage.windows || {};
+      const lastDay = windows.lastDay || {};
+      const lastHour = windows.lastHour || {};
+      const recentTurns = usage.recentTurns || [];
+      const bySession = usage.bySession || [];
+      const totalTurns = Number(totals.totalTurns || 0);
+      const exactTurns = Number(totals.exactTurns || 0);
+      const missingTurns = Number(totals.missingTurns || 0);
+      const badge = document.getElementById("usage-badge");
+      badge.textContent = totalTurns ? ("精确 " + exactTurns + "/" + totalTurns) : "暂无数据";
+      badge.className = "badge " + (!totalTurns || missingTurns ? "warn" : "good");
+      document.getElementById("usage-total").textContent = fmtTokens(totals.totalTokens);
+      document.getElementById("usage-total-detail").textContent = "输入 " + fmtTokens(totals.inputTokens) + " · 输出 " + fmtTokens(totals.outputTokens);
+      document.getElementById("usage-day").textContent = fmtTokens(lastDay.totalTokens);
+      document.getElementById("usage-day-detail").textContent = "回合 " + (lastDay.totalTurns || 0) + " · 推理 " + fmtTokens(lastDay.reasoningTokens);
+      document.getElementById("usage-hour").textContent = fmtTokens(lastHour.totalTokens);
+      document.getElementById("usage-hour-detail").textContent = "回合 " + (lastHour.totalTurns || 0) + " · 缓存 " + fmtTokens(lastHour.cachedInputTokens);
+      document.getElementById("usage-missing").textContent = missingTurns;
+      document.getElementById("usage-missing-detail").textContent = "估算 " + (totals.estimatedTurns || 0) + " · 精确 " + exactTurns;
+
+      const list = document.getElementById("usage-list");
+      if (!totalTurns) {
+        list.innerHTML = '<div class="summary-detail">还没有完成的 Codex 回合用量记录</div>';
+        return;
+      }
+      const leader = bySession[0];
+      const latest = recentTurns[0];
+      list.innerHTML =
+        '<div class="usage-row"><span>' + esc(leader ? ("最高会话：" + leader.sessionKey) : "最高会话：--") + '</span><strong>' + esc(fmtTokens(leader?.totalTokens || 0)) + '</strong></div>' +
+        '<div class="usage-row"><span>' + esc(latest ? ("最近回合：" + latest.sessionKey + " · " + statusLabel(latest.source)) : "最近回合：--") + '</span><strong>' + esc(fmtTokens(latest?.totalTokens || 0)) + '</strong></div>';
     }
 
     function renderRiskPanel(data) {
@@ -1151,6 +1243,7 @@ export function renderAdminPage(options: {
     function render(data) {
       latestStatus = data;
       renderSummary(data);
+      renderUsage(data);
       renderRiskPanel(data);
       renderOperations(data);
       renderService(data);

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -71,6 +71,11 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "GET" && url.pathname === "/admin/api/usage") {
+    respondJson(response, 200, await options.adminService.getUsageOverview());
+    return true;
+  }
+
   if (method === "GET" && url.pathname === "/admin/api/audit") {
     respondJson(response, 200, await options.adminService.listAdminAuditEvents({
       operationId: readString(url.searchParams.get("operation_id")) ?? undefined

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -48,6 +48,7 @@ interface SessionSnapshot {
   readonly backgroundJobs: readonly PersistedBackgroundJob[];
   readonly openInboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>;
   readonly jobsBySession: ReadonlyMap<string, readonly PersistedBackgroundJob[]>;
+  readonly usageBySession: ReadonlyMap<string, SessionUsageSummary>;
 }
 
 interface RuntimeStatus {
@@ -94,6 +95,26 @@ interface CodexUsageTotals {
   readonly totalTokens: number;
 }
 
+interface SessionUsageSummary {
+  readonly sessionKey: string;
+  readonly channelId: string;
+  readonly rootThreadTs: string;
+  readonly turnCount: number;
+  readonly exactTurns: number;
+  readonly estimatedTurns: number;
+  readonly missingTurns: number;
+  readonly inputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly outputTokens: number;
+  readonly reasoningTokens: number;
+  readonly totalTokens: number;
+  readonly updatedAt: string;
+  readonly lastTurnAt: string | null;
+  readonly model: string | null;
+  readonly effort: string | null;
+}
+type MutableSessionUsageSummary = { -readonly [Key in keyof SessionUsageSummary]: SessionUsageSummary[Key] };
+
 export class AdminService {
   constructor(
     private readonly options: {
@@ -124,7 +145,8 @@ export class AdminService {
     const sessionSummaries = snapshot.allSessions.slice(0, 50).map((session) =>
       this.#summarizeSession(session, {
         inbound: snapshot.openInboundBySession.get(session.key) ?? [],
-        jobs: snapshot.jobsBySession.get(session.key) ?? []
+        jobs: snapshot.jobsBySession.get(session.key) ?? [],
+        usage: snapshot.usageBySession.get(session.key)
       })
     );
     const stateCounts = this.#summarizeStateCounts(snapshot);
@@ -188,7 +210,8 @@ export class AdminService {
       sessions: snapshot.allSessions.slice(0, 100).map((session) =>
         this.#summarizeSession(session, {
           inbound: snapshot.openInboundBySession.get(session.key) ?? [],
-          jobs: snapshot.jobsBySession.get(session.key) ?? []
+          jobs: snapshot.jobsBySession.get(session.key) ?? [],
+          usage: snapshot.usageBySession.get(session.key)
         })
       )
     };
@@ -267,7 +290,8 @@ export class AdminService {
       ok: true,
       session: this.#summarizeSession(session, {
         inbound: openInbound,
-        jobs
+        jobs,
+        usage: summarizeUsageBySessionMap(this.#listCodexTurnUsage(1000)).get(session.key)
       }),
       events: events.sort(compareTimelineEvents)
     };
@@ -503,6 +527,7 @@ export class AdminService {
     const backgroundJobs = this.options.sessions
       .listBackgroundJobs()
       .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
+    const usageBySession = summarizeUsageBySessionMap(this.#listCodexTurnUsage(1000));
 
     return {
       allSessions,
@@ -510,7 +535,8 @@ export class AdminService {
       openInbound,
       backgroundJobs,
       openInboundBySession: groupBySession(openInbound),
-      jobsBySession: groupBySession(backgroundJobs)
+      jobsBySession: groupBySession(backgroundJobs),
+      usageBySession
     };
   }
 
@@ -545,7 +571,7 @@ export class AdminService {
         .sort(compareUsageRecordsDescending)
         .slice(0, 25)
         .map(summarizeUsageRecord),
-      bySession: summarizeUsageBySession(records)
+      bySession: summarizeUsageBySession(records, 25)
     };
   }
 
@@ -854,6 +880,7 @@ export class AdminService {
     related: {
       readonly inbound: readonly PersistedInboundMessage[];
       readonly jobs: readonly PersistedBackgroundJob[];
+      readonly usage?: SessionUsageSummary | undefined;
     }
   ): Record<string, unknown> {
     const runningBackgroundJobCount = related.jobs.filter((job) => job.status === "running").length;
@@ -882,7 +909,8 @@ export class AdminService {
       backgroundJobCount: related.jobs.length,
       runningBackgroundJobCount,
       failedBackgroundJobCount,
-      backgroundJobs: related.jobs.slice(0, 5).map((job) => this.#summarizeJob(job))
+      backgroundJobs: related.jobs.slice(0, 5).map((job) => this.#summarizeJob(job)),
+      usage: related.usage ?? emptySessionUsageSummary(session)
     };
   }
 }
@@ -955,25 +983,15 @@ function summarizeUsageRecord(record: PersistedCodexTurnUsage): Record<string, u
   };
 }
 
-function summarizeUsageBySession(records: readonly PersistedCodexTurnUsage[]): readonly Record<string, unknown>[] {
-  const groups = new Map<string, {
-    sessionKey: string;
-    channelId: string;
-    rootThreadTs: string;
-    turnCount: number;
-    exactTurns: number;
-    estimatedTurns: number;
-    missingTurns: number;
-    inputTokens: number;
-    cachedInputTokens: number;
-    outputTokens: number;
-    reasoningTokens: number;
-    totalTokens: number;
-    updatedAt: string;
-    lastTurnAt: string | null;
-    model: string | null;
-    effort: string | null;
-  }>();
+function summarizeUsageBySessionMap(records: readonly PersistedCodexTurnUsage[]): ReadonlyMap<string, SessionUsageSummary> {
+  return new Map(summarizeUsageBySession(records).map((entry) => [entry.sessionKey, entry]));
+}
+
+function summarizeUsageBySession(
+  records: readonly PersistedCodexTurnUsage[],
+  limit?: number
+): readonly SessionUsageSummary[] {
+  const groups = new Map<string, MutableSessionUsageSummary>();
 
   for (const record of records) {
     const existing = groups.get(record.sessionKey) ?? {
@@ -1012,9 +1030,30 @@ function summarizeUsageBySession(records: readonly PersistedCodexTurnUsage[]): r
     groups.set(record.sessionKey, existing);
   }
 
-  return [...groups.values()]
-    .sort((left, right) => right.totalTokens - left.totalTokens || right.turnCount - left.turnCount)
-    .slice(0, 25);
+  const sorted = [...groups.values()]
+    .sort((left, right) => right.totalTokens - left.totalTokens || right.turnCount - left.turnCount);
+  return limit === undefined ? sorted : sorted.slice(0, limit);
+}
+
+function emptySessionUsageSummary(session: SlackSessionRecord): SessionUsageSummary {
+  return {
+    sessionKey: session.key,
+    channelId: session.channelId,
+    rootThreadTs: session.rootThreadTs,
+    turnCount: 0,
+    exactTurns: 0,
+    estimatedTurns: 0,
+    missingTurns: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+    updatedAt: session.updatedAt,
+    lastTurnAt: null,
+    model: null,
+    effort: null
+  };
 }
 
 function compareUsageRecordsDescending(left: PersistedCodexTurnUsage, right: PersistedCodexTurnUsage): number {

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -10,6 +10,7 @@ import type {
   PersistedAdminAuditEvent,
   PersistedAdminOperation,
   PersistedBackgroundJob,
+  PersistedCodexTurnUsage,
   PersistedInboundMessage,
   SlackSessionRecord
 } from "../types.js";
@@ -78,6 +79,19 @@ interface AdminOperationStore {
     readonly limit?: number | undefined;
   }) => PersistedAdminAuditEvent[]) | undefined;
   readonly appendAdminAuditEvent?: ((record: PersistedAdminAuditEvent) => Promise<void>) | undefined;
+  readonly listCodexTurnUsage?: ((limit?: number) => PersistedCodexTurnUsage[]) | undefined;
+}
+
+interface CodexUsageTotals {
+  readonly totalTurns: number;
+  readonly exactTurns: number;
+  readonly estimatedTurns: number;
+  readonly missingTurns: number;
+  readonly inputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly outputTokens: number;
+  readonly reasoningTokens: number;
+  readonly totalTokens: number;
 }
 
 export class AdminService {
@@ -106,6 +120,7 @@ export class AdminService {
   async getStatus(): Promise<Record<string, unknown>> {
     const snapshot = await this.#readSessionSnapshot();
     const runtime = await this.#readRuntimeStatus();
+    const usage = this.#readUsageOverview();
     const sessionSummaries = snapshot.allSessions.slice(0, 50).map((session) =>
       this.#summarizeSession(session, {
         inbound: snapshot.openInboundBySession.get(session.key) ?? [],
@@ -126,6 +141,7 @@ export class AdminService {
       account: runtime.account,
       rateLimits: runtime.rateLimits,
       deployment: runtime.deployment,
+      usage,
       operations: this.#listAdminOperations(10),
       auditEvents: this.#listAdminAuditEvents({ limit: 10 }),
       state: {
@@ -141,6 +157,7 @@ export class AdminService {
   async getOverview(): Promise<Record<string, unknown>> {
     const snapshot = await this.#readSessionSnapshot();
     const runtime = await this.#readRuntimeStatus();
+    const usage = this.#readUsageOverview();
     return {
       ok: true,
       service: this.#serviceInfo(),
@@ -149,9 +166,18 @@ export class AdminService {
       account: runtime.account,
       rateLimits: runtime.rateLimits,
       deployment: runtime.deployment,
+      usage,
       operations: this.#listAdminOperations(10),
       auditEvents: this.#listAdminAuditEvents({ limit: 10 }),
       state: this.#summarizeStateCounts(snapshot)
+    };
+  }
+
+  async getUsageOverview(): Promise<Record<string, unknown>> {
+    await this.#refreshSessions();
+    return {
+      ok: true,
+      ...this.#readUsageOverview()
     };
   }
 
@@ -504,6 +530,25 @@ export class AdminService {
     };
   }
 
+  #readUsageOverview(): Record<string, unknown> {
+    const records = this.#listCodexTurnUsage(1000);
+    const totals = summarizeUsageTotals(records);
+    const windows = {
+      lastHour: summarizeUsageTotals(filterUsageWindow(records, 60 * 60 * 1000)),
+      lastDay: summarizeUsageTotals(filterUsageWindow(records, 24 * 60 * 60 * 1000))
+    };
+    return {
+      totals,
+      windows,
+      recentTurns: records
+        .slice()
+        .sort(compareUsageRecordsDescending)
+        .slice(0, 25)
+        .map(summarizeUsageRecord),
+      bySession: summarizeUsageBySession(records)
+    };
+  }
+
   #serviceInfo(): Record<string, unknown> {
     return {
       name: this.options.config.serviceName,
@@ -688,6 +733,11 @@ export class AdminService {
     return store.listAdminAuditEvents?.call(this.options.sessions, options) ?? [];
   }
 
+  #listCodexTurnUsage(limit: number): readonly PersistedCodexTurnUsage[] {
+    const store = this.#operationStore();
+    return store.listCodexTurnUsage?.call(this.options.sessions, limit) ?? [];
+  }
+
   #operationStore(): AdminOperationStore {
     return this.options.sessions as unknown as AdminOperationStore;
   }
@@ -835,6 +885,145 @@ export class AdminService {
       backgroundJobs: related.jobs.slice(0, 5).map((job) => this.#summarizeJob(job))
     };
   }
+}
+
+function summarizeUsageTotals(records: readonly PersistedCodexTurnUsage[]): CodexUsageTotals {
+  let totalTurns = 0;
+  let exactTurns = 0;
+  let estimatedTurns = 0;
+  let missingTurns = 0;
+  let inputTokens = 0;
+  let cachedInputTokens = 0;
+  let outputTokens = 0;
+  let reasoningTokens = 0;
+  let totalTokens = 0;
+
+  for (const record of records) {
+    totalTurns += 1;
+    if (record.source === "exact") {
+      exactTurns += 1;
+    } else if (record.source === "estimated") {
+      estimatedTurns += 1;
+    } else {
+      missingTurns += 1;
+    }
+
+    inputTokens += record.inputTokens;
+    cachedInputTokens += record.cachedInputTokens;
+    outputTokens += record.outputTokens;
+    reasoningTokens += record.reasoningTokens;
+    totalTokens += record.totalTokens;
+  }
+
+  return {
+    totalTurns,
+    exactTurns,
+    estimatedTurns,
+    missingTurns,
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    reasoningTokens,
+    totalTokens
+  };
+}
+
+function filterUsageWindow(records: readonly PersistedCodexTurnUsage[], windowMs: number): PersistedCodexTurnUsage[] {
+  const cutoff = Date.now() - windowMs;
+  return records.filter((record) => usageTimestampMs(record) >= cutoff);
+}
+
+function summarizeUsageRecord(record: PersistedCodexTurnUsage): Record<string, unknown> {
+  return {
+    turnId: record.turnId,
+    sessionKey: record.sessionKey,
+    channelId: record.channelId,
+    rootThreadTs: record.rootThreadTs,
+    codexThreadId: record.codexThreadId ?? null,
+    status: record.status,
+    source: record.source,
+    model: record.model ?? null,
+    effort: record.effort ?? null,
+    inputTokens: record.inputTokens,
+    cachedInputTokens: record.cachedInputTokens,
+    outputTokens: record.outputTokens,
+    reasoningTokens: record.reasoningTokens,
+    totalTokens: record.totalTokens,
+    startedAt: record.startedAt ?? null,
+    completedAt: record.completedAt ?? null,
+    updatedAt: record.updatedAt
+  };
+}
+
+function summarizeUsageBySession(records: readonly PersistedCodexTurnUsage[]): readonly Record<string, unknown>[] {
+  const groups = new Map<string, {
+    sessionKey: string;
+    channelId: string;
+    rootThreadTs: string;
+    turnCount: number;
+    exactTurns: number;
+    estimatedTurns: number;
+    missingTurns: number;
+    inputTokens: number;
+    cachedInputTokens: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    totalTokens: number;
+    updatedAt: string;
+    lastTurnAt: string | null;
+    model: string | null;
+    effort: string | null;
+  }>();
+
+  for (const record of records) {
+    const existing = groups.get(record.sessionKey) ?? {
+      sessionKey: record.sessionKey,
+      channelId: record.channelId,
+      rootThreadTs: record.rootThreadTs,
+      turnCount: 0,
+      exactTurns: 0,
+      estimatedTurns: 0,
+      missingTurns: 0,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 0,
+      updatedAt: record.updatedAt,
+      lastTurnAt: record.completedAt ?? record.updatedAt,
+      model: record.model ?? null,
+      effort: record.effort ?? null
+    };
+    existing.turnCount += 1;
+    existing.exactTurns += record.source === "exact" ? 1 : 0;
+    existing.estimatedTurns += record.source === "estimated" ? 1 : 0;
+    existing.missingTurns += record.source === "missing" ? 1 : 0;
+    existing.inputTokens += record.inputTokens;
+    existing.cachedInputTokens += record.cachedInputTokens;
+    existing.outputTokens += record.outputTokens;
+    existing.reasoningTokens += record.reasoningTokens;
+    existing.totalTokens += record.totalTokens;
+    if (usageTimestampMs(record) >= Date.parse(existing.lastTurnAt ?? "")) {
+      existing.updatedAt = record.updatedAt;
+      existing.lastTurnAt = record.completedAt ?? record.updatedAt;
+      existing.model = record.model ?? existing.model;
+      existing.effort = record.effort ?? existing.effort;
+    }
+    groups.set(record.sessionKey, existing);
+  }
+
+  return [...groups.values()]
+    .sort((left, right) => right.totalTokens - left.totalTokens || right.turnCount - left.turnCount)
+    .slice(0, 25);
+}
+
+function compareUsageRecordsDescending(left: PersistedCodexTurnUsage, right: PersistedCodexTurnUsage): number {
+  return usageTimestampMs(right) - usageTimestampMs(left) || right.updatedAt.localeCompare(left.updatedAt);
+}
+
+function usageTimestampMs(record: PersistedCodexTurnUsage): number {
+  const parsed = Date.parse(record.completedAt ?? record.updatedAt ?? record.createdAt);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function compareSessions(left: SlackSessionRecord, right: SlackSessionRecord): number {

--- a/src/services/codex/app-server-client.ts
+++ b/src/services/codex/app-server-client.ts
@@ -5,8 +5,10 @@ import WebSocket from "ws";
 
 import { logger } from "../../logger.js";
 import type {
+  CodexTurnTokenUsage,
   CodexTurnResult,
   GeneratedImageArtifact,
+  JsonLike,
   SlackUserIdentity
 } from "../../types.js";
 import { buildSlackThreadBaseInstructions } from "./slack-thread-base-instructions.js";
@@ -44,6 +46,7 @@ interface ActiveTurn {
   readonly turnId: string;
   text: string;
   generatedImages: GeneratedImageArtifact[];
+  usage?: CodexTurnTokenUsage | undefined;
   resolve: (result: CodexTurnResult) => void;
   reject: (error: Error) => void;
 }
@@ -52,6 +55,7 @@ interface BufferedTurnEvents {
   text: string;
   terminalState: "completed" | "aborted" | null;
   generatedImages: GeneratedImageArtifact[];
+  usage?: CodexTurnTokenUsage | undefined;
 }
 
 export interface StartedTurn {
@@ -83,6 +87,7 @@ export interface ReadTurnResult {
   readonly finalMessage: string;
   readonly errorMessage?: string | undefined;
   readonly generatedImages: readonly GeneratedImageArtifact[];
+  readonly usage?: CodexTurnTokenUsage | undefined;
 }
 
 export interface ReadTurnResultOptions {
@@ -453,6 +458,9 @@ export class AppServerClient extends EventEmitter {
         turns?: Array<{
           id?: string;
           status?: string;
+          usage?: unknown;
+          token_usage?: unknown;
+          tokenUsage?: unknown;
           error?: {
             message?: string;
             additionalDetails?: string | null;
@@ -487,8 +495,9 @@ export class AppServerClient extends EventEmitter {
       .map((item, index) => normalizeGeneratedImageArtifact(item, index))
       .filter((item): item is GeneratedImageArtifact => item !== null);
     const status = normalizeTurnStatus(turn.status);
+    const usage = normalizeCodexTurnUsageFromThreadTurn(turn);
 
-    const normalizedResult = {
+    const normalizedResult: ReadTurnResult = {
       status,
       finalMessage: String(lastAgentMessage?.text ?? "").trim(),
       generatedImages,
@@ -497,12 +506,13 @@ export class AppServerClient extends EventEmitter {
         turn.error?.message ??
         undefined
     };
+    const resultWithUsage = usage ? { ...normalizedResult, usage } : normalizedResult;
 
     if (options?.syncActiveTurn) {
-      this.#syncActiveTurn(turnId, normalizedResult);
+      this.#syncActiveTurn(turnId, resultWithUsage);
     }
 
-    return normalizedResult;
+    return resultWithUsage;
   }
 
   async request(method: string, params?: JsonValue): Promise<JsonValue> {
@@ -629,17 +639,21 @@ export class AppServerClient extends EventEmitter {
     }
 
     if (method === "turn/completed") {
-      const turnId = params.turn?.id as string | undefined;
+      const turnId = (params.turn?.id ?? params.turnId) as string | undefined;
       if (!turnId) {
         return;
       }
+      const usage = normalizeCodexTurnUsageFromTurnEvent(params);
 
       const turn = this.#activeTurns.get(turnId);
       if (!turn) {
-        this.#bufferTurnTerminalState(turnId, "completed");
+        this.#bufferTurnTerminalState(turnId, "completed", usage);
         return;
       }
 
+      if (usage) {
+        turn.usage = usage;
+      }
       this.#resolveActiveTurn(turn, false);
       return;
     }
@@ -698,24 +712,24 @@ export class AppServerClient extends EventEmitter {
     this.#bufferedTurnEvents.delete(turnId);
 
     if (result.status === "completed") {
-      turn.resolve({
+      turn.resolve(withOptionalUsage({
         threadId: turn.threadId,
         turnId,
         finalMessage: result.finalMessage,
         aborted: false,
         generatedImages: result.generatedImages
-      });
+      }, result.usage));
       return;
     }
 
     if (result.status === "interrupted") {
-      turn.resolve({
+      turn.resolve(withOptionalUsage({
         threadId: turn.threadId,
         turnId,
         finalMessage: result.finalMessage,
         aborted: true,
         generatedImages: result.generatedImages
-      });
+      }, result.usage));
       return;
     }
 
@@ -743,13 +757,20 @@ export class AppServerClient extends EventEmitter {
     this.#bufferedTurnEvents.set(turnId, buffered);
   }
 
-  #bufferTurnTerminalState(turnId: string, terminalState: "completed" | "aborted"): void {
+  #bufferTurnTerminalState(
+    turnId: string,
+    terminalState: "completed" | "aborted",
+    usage?: CodexTurnTokenUsage | undefined
+  ): void {
     const buffered = this.#bufferedTurnEvents.get(turnId) ?? {
       text: "",
       terminalState: null,
       generatedImages: []
     };
     buffered.terminalState = terminalState;
+    if (usage) {
+      buffered.usage = usage;
+    }
     this.#bufferedTurnEvents.set(turnId, buffered);
   }
 
@@ -781,6 +802,9 @@ export class AppServerClient extends EventEmitter {
     for (const image of buffered.generatedImages) {
       upsertGeneratedImage(turn.generatedImages, image);
     }
+    if (buffered.usage) {
+      turn.usage = buffered.usage;
+    }
 
     if (buffered.terminalState === "completed") {
       this.#resolveActiveTurn(turn, false);
@@ -795,13 +819,13 @@ export class AppServerClient extends EventEmitter {
   #resolveActiveTurn(turn: ActiveTurn, aborted: boolean): void {
     this.#activeTurns.delete(turn.turnId);
     this.#bufferedTurnEvents.delete(turn.turnId);
-    turn.resolve({
+    turn.resolve(withOptionalUsage({
       threadId: turn.threadId,
       turnId: turn.turnId,
       finalMessage: turn.text.trim(),
       aborted,
       generatedImages: [...turn.generatedImages]
-    });
+    }, turn.usage));
   }
 
   #startHeartbeat(socket: WebSocket, intervalMs = 30_000): void {
@@ -835,6 +859,179 @@ export class AppServerClient extends EventEmitter {
     clearInterval(this.#heartbeatTimer);
     this.#heartbeatTimer = undefined;
   }
+}
+
+function withOptionalUsage(
+  result: Omit<CodexTurnResult, "usage">,
+  usage: CodexTurnTokenUsage | undefined
+): CodexTurnResult {
+  return usage ? { ...result, usage } : result;
+}
+
+function normalizeCodexTurnUsageFromTurnEvent(params: Record<string, any>): CodexTurnTokenUsage | undefined {
+  const turn = isRecord(params.turn) ? params.turn : {};
+  return (
+    normalizeCodexTurnTokenUsage(turn.usage) ??
+    normalizeCodexTurnTokenUsage(turn.token_usage) ??
+    normalizeCodexTurnTokenUsage(turn.tokenUsage) ??
+    normalizeCodexTurnTokenUsage(params.usage) ??
+    normalizeCodexTurnTokenUsage(params.token_usage) ??
+    normalizeCodexTurnTokenUsage(params.tokenUsage)
+  );
+}
+
+function normalizeCodexTurnUsageFromThreadTurn(turn: {
+  readonly usage?: unknown;
+  readonly token_usage?: unknown;
+  readonly tokenUsage?: unknown;
+}): CodexTurnTokenUsage | undefined {
+  return (
+    normalizeCodexTurnTokenUsage(turn.usage) ??
+    normalizeCodexTurnTokenUsage(turn.token_usage) ??
+    normalizeCodexTurnTokenUsage(turn.tokenUsage)
+  );
+}
+
+function normalizeCodexTurnTokenUsage(value: unknown): CodexTurnTokenUsage | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const inputTokenValue = readTokenNumber(value, [
+    "input_tokens",
+    "inputTokens",
+    "prompt_tokens",
+    "promptTokens"
+  ]);
+  const cachedTokenValue =
+    readTokenNumber(value, [
+      "cached_input_tokens",
+      "cachedInputTokens",
+      "cached_tokens",
+      "cachedTokens"
+    ]) ??
+    readNestedTokenNumber(value, [
+      ["input_token_details", "cached_tokens"],
+      ["inputTokenDetails", "cachedTokens"],
+      ["input_tokens_details", "cached_tokens"],
+      ["inputTokensDetails", "cachedTokens"]
+    ]);
+  const outputTokenValue = readTokenNumber(value, [
+    "output_tokens",
+    "outputTokens",
+    "completion_tokens",
+    "completionTokens"
+  ]);
+  const reasoningTokenValue =
+    readTokenNumber(value, [
+      "reasoning_tokens",
+      "reasoningTokens"
+    ]) ??
+    readNestedTokenNumber(value, [
+      ["output_token_details", "reasoning_tokens"],
+      ["outputTokenDetails", "reasoningTokens"],
+      ["output_tokens_details", "reasoning_tokens"],
+      ["outputTokensDetails", "reasoningTokens"]
+    ]);
+  const totalTokenValue = readTokenNumber(value, [
+    "total_tokens",
+    "totalTokens"
+  ]);
+
+  if (
+    inputTokenValue === undefined &&
+    cachedTokenValue === undefined &&
+    outputTokenValue === undefined &&
+    reasoningTokenValue === undefined &&
+    totalTokenValue === undefined
+  ) {
+    return undefined;
+  }
+
+  const computedTotal = (inputTokenValue ?? 0) + (outputTokenValue ?? 0) + (reasoningTokenValue ?? 0);
+  const totalTokens = totalTokenValue ?? (computedTotal > 0 ? computedTotal : cachedTokenValue ?? 0);
+
+  return {
+    source: "exact",
+    inputTokens: inputTokenValue ?? 0,
+    cachedInputTokens: cachedTokenValue ?? 0,
+    outputTokens: outputTokenValue ?? 0,
+    reasoningTokens: reasoningTokenValue ?? 0,
+    totalTokens,
+    model: normalizeOptionalString(value.model) ?? normalizeOptionalString(value.modelName),
+    effort:
+      normalizeOptionalString(value.effort) ??
+      normalizeOptionalString(value.reasoning_effort) ??
+      normalizeOptionalString(value.reasoningEffort),
+    rawUsage: toJsonLike(value)
+  };
+}
+
+function readTokenNumber(record: Record<string, unknown>, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const normalized = normalizeTokenNumber(record[key]);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+function readNestedTokenNumber(
+  record: Record<string, unknown>,
+  paths: readonly (readonly [string, string])[]
+): number | undefined {
+  for (const [objectKey, valueKey] of paths) {
+    const container = record[objectKey];
+    if (!isRecord(container)) {
+      continue;
+    }
+    const normalized = normalizeTokenNumber(container[valueKey]);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+function normalizeTokenNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value));
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.trunc(parsed));
+    }
+  }
+  return undefined;
+}
+
+function toJsonLike(value: unknown): JsonLike | undefined {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => toJsonLike(entry) ?? null);
+  }
+  if (isRecord(value)) {
+    const normalized: Record<string, JsonLike> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const normalizedEntry = toJsonLike(entry);
+      if (normalizedEntry !== undefined) {
+        normalized[key] = normalizedEntry;
+      }
+    }
+    return normalized;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function normalizeTurnStatus(status: unknown): ReadTurnResult["status"] {

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -6,6 +6,7 @@ import type {
   PersistedAdminAuditEvent,
   PersistedAdminOperation,
   PersistedBackgroundJob,
+  PersistedCodexTurnUsage,
   PersistedInboundMessage,
   PersistedInboundMessageStatus,
   PersistedInboundSource,
@@ -374,6 +375,14 @@ export class SessionManager {
 
   async appendAdminAuditEvent(record: PersistedAdminAuditEvent): Promise<void> {
     await this.#stateStore.appendAdminAuditEvent(record);
+  }
+
+  listCodexTurnUsage(limit?: number): PersistedCodexTurnUsage[] {
+    return this.#stateStore.listCodexTurnUsage(limit);
+  }
+
+  async upsertCodexTurnUsage(record: PersistedCodexTurnUsage): Promise<void> {
+    await this.#stateStore.upsertCodexTurnUsage(record);
   }
 
   #requireSession(channelId: string, rootThreadTs: string): SlackSessionRecord {

--- a/src/services/slack/slack-turn-runner.ts
+++ b/src/services/slack/slack-turn-runner.ts
@@ -3,6 +3,8 @@ import { CodexBroker } from "../codex/codex-broker.js";
 import { logger } from "../../logger.js";
 import type {
   CodexTurnResult,
+  PersistedCodexTurnStatus,
+  PersistedCodexTurnUsage,
   SlackInputMessage,
   SlackSessionRecord
 } from "../../types.js";
@@ -110,6 +112,7 @@ export class SlackTurnRunner {
           aborted: result.aborted,
           attempt: attempt + 1
         });
+        await this.#persistTurnUsage(session, result);
         session = await this.#inboundStore.markTurnBatchDone(session, startedTurn.turnId);
         session = await this.#sessions.setActiveTurnId(session.channelId, session.rootThreadTs, undefined);
         return {
@@ -126,6 +129,7 @@ export class SlackTurnRunner {
             turnId: startedTurn.turnId,
             recoveredStatus: recovered.aborted ? "interrupted" : "completed"
           });
+          await this.#persistTurnUsage(session, recovered);
           session = await this.#inboundStore.markTurnBatchDone(session, startedTurn.turnId);
           session = await this.#sessions.setActiveTurnId(session.channelId, session.rootThreadTs, undefined);
           return {
@@ -134,10 +138,15 @@ export class SlackTurnRunner {
           };
         }
 
+        const shouldStop = attempt === 1 || !isRecoverableCodexTurnFailure(error);
+        if (shouldStop) {
+          await this.#persistMissingTurnUsage(session, startedTurn.turnId, "failed");
+        }
+
         await this.#inboundStore.resetTurnBatchToPending(session, startedTurn.turnId);
         session = await this.#sessions.setActiveTurnId(session.channelId, session.rootThreadTs, undefined);
 
-        if (attempt === 1 || !isRecoverableCodexTurnFailure(error)) {
+        if (shouldStop) {
           throw error;
         }
 
@@ -273,7 +282,8 @@ export class SlackTurnRunner {
           turnId,
           finalMessage: snapshot.finalMessage,
           aborted: false,
-          generatedImages: snapshot.generatedImages
+          generatedImages: snapshot.generatedImages,
+          usage: snapshot.usage
         };
       }
 
@@ -283,7 +293,8 @@ export class SlackTurnRunner {
           turnId,
           finalMessage: snapshot.finalMessage,
           aborted: true,
-          generatedImages: snapshot.generatedImages
+          generatedImages: snapshot.generatedImages,
+          usage: snapshot.usage
         };
       }
 
@@ -300,6 +311,68 @@ export class SlackTurnRunner {
       });
       return null;
     }
+  }
+
+  async #persistTurnUsage(session: SlackSessionRecord, result: CodexTurnResult): Promise<void> {
+    const status: PersistedCodexTurnStatus = result.aborted ? "interrupted" : "completed";
+    const usage = result.usage;
+    await this.#upsertTurnUsage({
+      turnId: result.turnId,
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      codexThreadId: result.threadId || session.codexThreadId,
+      status,
+      source: usage?.source ?? "missing",
+      model: usage?.model,
+      effort: usage?.effort,
+      inputTokens: usage?.inputTokens ?? 0,
+      cachedInputTokens: usage?.cachedInputTokens ?? 0,
+      outputTokens: usage?.outputTokens ?? 0,
+      reasoningTokens: usage?.reasoningTokens ?? 0,
+      totalTokens: usage?.totalTokens ?? 0,
+      rawUsage: usage?.rawUsage,
+      startedAt: session.activeTurnId === result.turnId ? session.activeTurnStartedAt : undefined
+    });
+  }
+
+  async #persistMissingTurnUsage(
+    session: SlackSessionRecord,
+    turnId: string,
+    status: PersistedCodexTurnStatus
+  ): Promise<void> {
+    await this.#upsertTurnUsage({
+      turnId,
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      codexThreadId: session.codexThreadId,
+      status,
+      source: "missing",
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 0,
+      startedAt: session.activeTurnId === turnId ? session.activeTurnStartedAt : undefined
+    });
+  }
+
+  async #upsertTurnUsage(record: Omit<PersistedCodexTurnUsage, "createdAt" | "updatedAt" | "completedAt">): Promise<void> {
+    const upsert = (this.#sessions as unknown as {
+      readonly upsertCodexTurnUsage?: ((usage: PersistedCodexTurnUsage) => Promise<void>) | undefined;
+    }).upsertCodexTurnUsage;
+    if (typeof upsert !== "function") {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    await upsert.call(this.#sessions, {
+      ...record,
+      completedAt: now,
+      createdAt: record.startedAt ?? now,
+      updatedAt: now
+    });
   }
 }
 

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -6,6 +6,7 @@ import type {
   PersistedAdminOperation,
   JsonLike,
   PersistedBackgroundJob,
+  PersistedCodexTurnUsage,
   PersistedInboundMessage,
   PersistedInboundMessageStatus,
   PersistedInboundSource,
@@ -15,7 +16,7 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 2;
+export const CURRENT_STATE_SCHEMA_VERSION = 3;
 
 type SqlValue = string | number | bigint | null;
 type SqlRow = Record<string, unknown>;
@@ -166,6 +167,39 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
         CREATE INDEX IF NOT EXISTS idx_admin_operations_updated ON admin_operations(updated_at);
         CREATE INDEX IF NOT EXISTS idx_admin_audit_created ON admin_audit_events(sequence);
         CREATE INDEX IF NOT EXISTS idx_admin_audit_operation ON admin_audit_events(operation_id, sequence);
+      `);
+    }
+  },
+  {
+    version: 3,
+    name: "codex_turn_usage",
+    up(database) {
+      database.exec(`
+        CREATE TABLE IF NOT EXISTS codex_turn_usage (
+          turn_id TEXT PRIMARY KEY,
+          session_key TEXT NOT NULL REFERENCES sessions(key) ON DELETE CASCADE,
+          channel_id TEXT NOT NULL,
+          root_thread_ts TEXT NOT NULL,
+          codex_thread_id TEXT,
+          status TEXT NOT NULL,
+          source TEXT NOT NULL,
+          model TEXT,
+          effort TEXT,
+          input_tokens INTEGER NOT NULL DEFAULT 0,
+          cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+          output_tokens INTEGER NOT NULL DEFAULT 0,
+          reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+          total_tokens INTEGER NOT NULL DEFAULT 0,
+          raw_usage TEXT,
+          started_at TEXT,
+          completed_at TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_codex_turn_usage_session ON codex_turn_usage(session_key, completed_at);
+        CREATE INDEX IF NOT EXISTS idx_codex_turn_usage_completed ON codex_turn_usage(completed_at);
+        CREATE INDEX IF NOT EXISTS idx_codex_turn_usage_total ON codex_turn_usage(total_tokens);
       `);
     }
   }
@@ -568,6 +602,24 @@ export class StateStore {
     });
   }
 
+  listCodexTurnUsage(limit = 1000): PersistedCodexTurnUsage[] {
+    return this.#databaseRequired()
+      .prepare(`
+        SELECT * FROM codex_turn_usage
+        ORDER BY COALESCE(completed_at, updated_at, created_at) DESC, updated_at DESC
+        LIMIT ?
+      `)
+      .all(limit)
+      .map((row) => this.#rowToCodexTurnUsage(row as SqlRow));
+  }
+
+  async upsertCodexTurnUsage(record: PersistedCodexTurnUsage): Promise<void> {
+    const normalized = this.#normalizeCodexTurnUsage(record);
+    this.#transaction(() => {
+      this.#upsertCodexTurnUsage(normalized);
+    });
+  }
+
   #openDatabase(): void {
     if (this.#database) {
       return;
@@ -818,6 +870,56 @@ export class StateStore {
     );
   }
 
+  #upsertCodexTurnUsage(record: PersistedCodexTurnUsage): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO codex_turn_usage (
+        turn_id, session_key, channel_id, root_thread_ts, codex_thread_id,
+        status, source, model, effort, input_tokens, cached_input_tokens,
+        output_tokens, reasoning_tokens, total_tokens, raw_usage,
+        started_at, completed_at, created_at, updated_at
+      ) VALUES (${placeholders(19)})
+      ON CONFLICT(turn_id) DO UPDATE SET
+        session_key = excluded.session_key,
+        channel_id = excluded.channel_id,
+        root_thread_ts = excluded.root_thread_ts,
+        codex_thread_id = excluded.codex_thread_id,
+        status = excluded.status,
+        source = excluded.source,
+        model = excluded.model,
+        effort = excluded.effort,
+        input_tokens = excluded.input_tokens,
+        cached_input_tokens = excluded.cached_input_tokens,
+        output_tokens = excluded.output_tokens,
+        reasoning_tokens = excluded.reasoning_tokens,
+        total_tokens = excluded.total_tokens,
+        raw_usage = excluded.raw_usage,
+        started_at = excluded.started_at,
+        completed_at = excluded.completed_at,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `).run(
+      record.turnId,
+      record.sessionKey,
+      record.channelId,
+      record.rootThreadTs,
+      record.codexThreadId ?? null,
+      record.status,
+      record.source,
+      record.model ?? null,
+      record.effort ?? null,
+      record.inputTokens,
+      record.cachedInputTokens,
+      record.outputTokens,
+      record.reasoningTokens,
+      record.totalTokens,
+      jsonOrNull(record.rawUsage),
+      record.startedAt ?? null,
+      record.completedAt ?? null,
+      record.createdAt,
+      record.updatedAt
+    );
+  }
+
   #markProcessedEvent(eventId: string): void {
     this.#databaseRequired()
       .prepare("INSERT OR IGNORE INTO processed_events (event_id) VALUES (?)")
@@ -962,6 +1064,30 @@ export class StateStore {
       detail: readJsonColumn<JsonLike | undefined>(row, "detail", undefined),
       actor: optionalStringColumn(row, "actor"),
       createdAt: stringColumn(row, "created_at")
+    });
+  }
+
+  #rowToCodexTurnUsage(row: SqlRow): PersistedCodexTurnUsage {
+    return this.#normalizeCodexTurnUsage({
+      turnId: stringColumn(row, "turn_id"),
+      sessionKey: stringColumn(row, "session_key"),
+      channelId: stringColumn(row, "channel_id"),
+      rootThreadTs: stringColumn(row, "root_thread_ts"),
+      codexThreadId: optionalStringColumn(row, "codex_thread_id"),
+      status: stringColumn(row, "status") as PersistedCodexTurnUsage["status"],
+      source: stringColumn(row, "source") as PersistedCodexTurnUsage["source"],
+      model: optionalStringColumn(row, "model"),
+      effort: optionalStringColumn(row, "effort"),
+      inputTokens: optionalNumberColumn(row, "input_tokens") ?? 0,
+      cachedInputTokens: optionalNumberColumn(row, "cached_input_tokens") ?? 0,
+      outputTokens: optionalNumberColumn(row, "output_tokens") ?? 0,
+      reasoningTokens: optionalNumberColumn(row, "reasoning_tokens") ?? 0,
+      totalTokens: optionalNumberColumn(row, "total_tokens") ?? 0,
+      rawUsage: readJsonColumn<JsonLike | undefined>(row, "raw_usage", undefined),
+      startedAt: optionalStringColumn(row, "started_at"),
+      completedAt: optionalStringColumn(row, "completed_at"),
+      createdAt: stringColumn(row, "created_at"),
+      updatedAt: stringColumn(row, "updated_at")
     });
   }
 
@@ -1113,6 +1239,35 @@ export class StateStore {
     };
   }
 
+  #normalizeCodexTurnUsage(raw: Partial<PersistedCodexTurnUsage>): PersistedCodexTurnUsage {
+    if (!raw.turnId || !raw.sessionKey || !raw.channelId || !raw.rootThreadTs || !raw.status || !raw.source) {
+      throw new Error(`Invalid Codex turn usage: ${raw.turnId ?? "unknown"}`);
+    }
+
+    const now = new Date().toISOString();
+    return {
+      turnId: String(raw.turnId),
+      sessionKey: String(raw.sessionKey),
+      channelId: String(raw.channelId),
+      rootThreadTs: String(raw.rootThreadTs),
+      codexThreadId: typeof raw.codexThreadId === "string" ? raw.codexThreadId : undefined,
+      status: raw.status,
+      source: raw.source,
+      model: typeof raw.model === "string" ? raw.model : undefined,
+      effort: typeof raw.effort === "string" ? raw.effort : undefined,
+      inputTokens: normalizeTokenCount(raw.inputTokens),
+      cachedInputTokens: normalizeTokenCount(raw.cachedInputTokens),
+      outputTokens: normalizeTokenCount(raw.outputTokens),
+      reasoningTokens: normalizeTokenCount(raw.reasoningTokens),
+      totalTokens: normalizeTokenCount(raw.totalTokens),
+      rawUsage: raw.rawUsage,
+      startedAt: typeof raw.startedAt === "string" ? raw.startedAt : undefined,
+      completedAt: typeof raw.completedAt === "string" ? raw.completedAt : undefined,
+      createdAt: String(raw.createdAt ?? now),
+      updatedAt: String(raw.updatedAt ?? raw.createdAt ?? now)
+    };
+  }
+
   #databaseRequired(): DatabaseSync {
     if (!this.#database) {
       throw new Error("StateStore has not been loaded");
@@ -1238,4 +1393,9 @@ function normalizeFiniteNumber(value: unknown): number | undefined {
   }
 
   return undefined;
+}
+
+function normalizeTokenCount(value: unknown): number {
+  const parsed = normalizeFiniteNumber(value) ?? 0;
+  return Math.max(0, Math.trunc(parsed));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,6 +163,43 @@ export interface PersistedAdminAuditEvent {
   readonly createdAt: string;
 }
 
+export type CodexTurnUsageSource = "exact" | "estimated" | "missing";
+export type PersistedCodexTurnStatus = "completed" | "interrupted" | "failed";
+
+export interface CodexTurnTokenUsage {
+  readonly source: CodexTurnUsageSource;
+  readonly inputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly outputTokens: number;
+  readonly reasoningTokens: number;
+  readonly totalTokens: number;
+  readonly model?: string | undefined;
+  readonly effort?: string | undefined;
+  readonly rawUsage?: JsonLike | undefined;
+}
+
+export interface PersistedCodexTurnUsage {
+  readonly turnId: string;
+  readonly sessionKey: string;
+  readonly channelId: string;
+  readonly rootThreadTs: string;
+  readonly codexThreadId?: string | undefined;
+  readonly status: PersistedCodexTurnStatus;
+  readonly source: CodexTurnUsageSource;
+  readonly model?: string | undefined;
+  readonly effort?: string | undefined;
+  readonly inputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly outputTokens: number;
+  readonly reasoningTokens: number;
+  readonly totalTokens: number;
+  readonly rawUsage?: JsonLike | undefined;
+  readonly startedAt?: string | undefined;
+  readonly completedAt?: string | undefined;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
 export interface SlackInputMessage {
   readonly channelId: string;
   readonly channelType?: string | undefined;
@@ -262,6 +299,7 @@ export interface CodexTurnResult {
   readonly finalMessage: string;
   readonly aborted: boolean;
   readonly generatedImages?: readonly GeneratedImageArtifact[] | undefined;
+  readonly usage?: CodexTurnTokenUsage | undefined;
 }
 
 export interface GeneratedImageArtifact {

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+import { createHttpHandler } from "../src/http/router.js";
+import { AdminService } from "../src/services/admin-service.js";
+import { createCodexBroker } from "../src/services/service-components.js";
+import { SessionManager } from "../src/services/session-manager.js";
+import { SlackInboundStore } from "../src/services/slack/slack-inbound-store.js";
+import { SlackTurnRunner } from "../src/services/slack/slack-turn-runner.js";
+import { StateStore } from "../src/store/state-store.js";
+import { MockCodexAppServer } from "./helpers/mock-codex-app-server.js";
+
+describe("admin token usage e2e", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("records exact Codex turn token usage and exposes it through admin resources", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-token-usage-"));
+    cleanups.push(async () => {
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    });
+
+    const mockCodex = new MockCodexAppServer({
+      onTurnStart: (context) => {
+        (context.complete as (message: string, usage: unknown) => void)("turn finished", {
+          input_tokens: 1_200,
+          cached_input_tokens: 300,
+          output_tokens: 450,
+          reasoning_tokens: 75,
+          total_tokens: 1_725,
+          model: "gpt-5.5",
+          effort: "xhigh"
+        });
+      }
+    });
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+    });
+
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot,
+      CODEX_APP_SERVER_URL: codexUrl,
+      SERVICE_ROOT: dataRoot,
+      ADMIN_LAUNCHD_LABEL: "admin.test",
+      WORKER_LAUNCHD_LABEL: "worker.test",
+      ADMIN_PLIST_PATH: path.join(dataRoot, "admin.plist"),
+      WORKER_PLIST_PATH: path.join(dataRoot, "worker.plist")
+    } as NodeJS.ProcessEnv);
+    await fs.mkdir(config.codexHome, { recursive: true });
+    await fs.mkdir(config.logDir, { recursive: true });
+
+    const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot: config.sessionsRoot
+    });
+    await sessions.load();
+    cleanups.push(async () => {
+      stateStore.close();
+    });
+
+    const codex = createCodexBroker(config);
+    await codex.start();
+    cleanups.push(async () => {
+      await codex.stop();
+    });
+
+    const slackApi = {
+      getUserIdentity: async () => ({
+        userId: "U123",
+        mention: "<@U123>",
+        realName: "User One"
+      }),
+      downloadImageAsDataUrl: async () => "data:image/png;base64,"
+    } as never;
+    const inboundStore = new SlackInboundStore({
+      sessions,
+      slackApi
+    });
+    const runner = new SlackTurnRunner({
+      codex,
+      slackApi,
+      sessions,
+      inboundStore
+    });
+
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await runner.ensureCodexThread(session);
+    await runner.runTurnWithRecovery({
+      session,
+      sessionKey: session.key,
+      senderUserId: "U123",
+      input: [
+        {
+          type: "text",
+          text: "请检查 PR",
+          text_elements: []
+        }
+      ],
+      messageTsList: []
+    });
+
+    const adminService = new AdminService({
+      config,
+      sessions,
+      startedAt: new Date("2026-03-19T00:00:00.000Z"),
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
+          activeProfile: "primary",
+          activeAuthPath: path.join(config.codexHome, "auth.json"),
+          profiles: []
+        }),
+        addProfile: async () => ({ name: "profile" }),
+        deleteProfile: async () => {},
+        activateProfile: async (name: string) => ({ name })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => [],
+        upsertManualMapping: async () => ({}),
+        deleteMapping: async () => {}
+      } as never,
+      runtime: {
+        restartRuntime: async () => {},
+        readAccountSummary: async () => ({
+          account: {
+            email: "usage@example.com",
+            type: "chatgpt",
+            planType: "team"
+          },
+          requiresOpenaiAuth: false
+        }),
+        readAccountRateLimits: async () => ({
+          rateLimits: {
+            limitId: "codex",
+            limitName: "Codex",
+            primary: {
+              usedPercent: 20,
+              windowDurationMins: 300,
+              resetsAt: 1_777_777_777
+            },
+            secondary: null,
+            credits: null,
+            planType: "team"
+          },
+          rateLimitsByLimitId: {}
+        })
+      } as never
+    });
+
+    const server = http.createServer(
+      createHttpHandler({
+        adminService,
+        config
+      })
+    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start admin usage fixture");
+    }
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const usage = await readJson(`${baseUrl}/admin/api/usage`);
+    expect(usage).toMatchObject({
+      ok: true,
+      totals: {
+        totalTurns: 1,
+        exactTurns: 1,
+        totalTokens: 1_725,
+        inputTokens: 1_200,
+        cachedInputTokens: 300,
+        outputTokens: 450,
+        reasoningTokens: 75
+      },
+      recentTurns: [
+        {
+          sessionKey: "C123:111.222",
+          channelId: "C123",
+          rootThreadTs: "111.222",
+          source: "exact",
+          model: "gpt-5.5",
+          effort: "xhigh",
+          totalTokens: 1_725
+        }
+      ],
+      bySession: [
+        {
+          sessionKey: "C123:111.222",
+          totalTokens: 1_725,
+          turnCount: 1
+        }
+      ]
+    });
+
+    const status = await readJson(`${baseUrl}/admin/api/status`);
+    expect(status).toMatchObject({
+      usage: {
+        totals: {
+          totalTokens: 1_725
+        }
+      }
+    });
+
+    const page = await fetch(`${baseUrl}/admin`);
+    expect(await page.text()).toContain("消耗监控");
+  });
+});
+
+async function readJson(url: string): Promise<Record<string, any>> {
+  const response = await fetch(url);
+  const payload = await response.json() as Record<string, any>;
+  expect(response.status).toBe(200);
+  return payload;
+}

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -226,11 +226,26 @@ describe("admin token usage e2e", () => {
         totals: {
           totalTokens: 1_725
         }
+      },
+      state: {
+        sessions: [
+          {
+            key: "C123:111.222",
+            usage: {
+              totalTokens: 1_725,
+              turnCount: 1,
+              exactTurns: 1,
+              missingTurns: 0
+            }
+          }
+        ]
       }
     });
 
     const page = await fetch(`${baseUrl}/admin`);
-    expect(await page.text()).toContain("消耗监控");
+    const html = await page.text();
+    expect(html).toContain("消耗监控");
+    expect(html).toContain("Token 消耗");
   });
 });
 

--- a/test/app-server-client.test.ts
+++ b/test/app-server-client.test.ts
@@ -207,6 +207,78 @@ describe("AppServerClient disconnect handling", () => {
     });
   });
 
+  it("captures exact token usage from turn completion notifications", async () => {
+    const server = await createServer((socket, message) => {
+      if (message.method === "initialize") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: { ok: true }
+        }));
+        return;
+      }
+
+      if (message.method === "turn/start") {
+        socket.send(JSON.stringify({
+          id: message.id,
+          result: {
+            turn: {
+              id: "turn-usage"
+            }
+          }
+        }));
+        socket.send(JSON.stringify({
+          method: "turn/completed",
+          params: {
+            turn: {
+              id: "turn-usage",
+              usage: {
+                input_tokens: 1200,
+                cached_input_tokens: 300,
+                output_tokens: 450,
+                reasoning_tokens: 75,
+                total_tokens: 1725,
+                model: "gpt-5.5",
+                effort: "xhigh"
+              }
+            }
+          }
+        }));
+      }
+    });
+    servers.push(server);
+
+    const client = new AppServerClient({
+      url: server.url,
+      serviceName: "test",
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      reposRoot: "/tmp/repos"
+    });
+
+    await client.connect();
+    const started = await client.startTurn("thread-1", "/tmp", [
+      {
+        type: "text",
+        text: "hello",
+        text_elements: []
+      }
+    ]);
+
+    await expect(started.completion).resolves.toMatchObject({
+      threadId: "thread-1",
+      turnId: "turn-usage",
+      usage: {
+        source: "exact",
+        inputTokens: 1200,
+        cachedInputTokens: 300,
+        outputTokens: 450,
+        reasoningTokens: 75,
+        totalTokens: 1725,
+        model: "gpt-5.5",
+        effort: "xhigh"
+      }
+    });
+  });
+
   it("does not emit an unhandled rejection when a turn disconnects before completion is awaited", async () => {
     const server = await createServer((socket, message) => {
       if (message.method === "initialize") {

--- a/test/helpers/mock-codex-app-server.ts
+++ b/test/helpers/mock-codex-app-server.ts
@@ -13,6 +13,7 @@ interface MockTurnRecord {
   status: "inProgress" | "completed" | "interrupted" | "failed";
   finalMessage: string;
   errorMessage?: string | undefined;
+  usage?: unknown;
 }
 
 interface MockThreadRecord {
@@ -29,7 +30,7 @@ export interface MockTurnContext {
   readonly cwd: string;
   readonly input: readonly CodexInputItem[];
   readonly thread: MockThreadRecord;
-  complete: (message?: string) => void;
+  complete: (message?: string, usage?: unknown) => void;
   interrupt: (message?: string) => void;
 }
 
@@ -275,6 +276,7 @@ export class MockCodexAppServer {
               id: turn.turnId,
               status: turn.status,
               error: turn.errorMessage ? { message: turn.errorMessage } : null,
+              usage: turn.usage,
               items: turn.finalMessage
                 ? [
                   {
@@ -300,13 +302,14 @@ export class MockCodexAppServer {
       cwd: turn.cwd,
       input: turn.input,
       thread,
-      complete: (message = "") => {
+      complete: (message = "", usage?: unknown) => {
         if (turn.status !== "inProgress") {
           return;
         }
 
         turn.status = "completed";
         turn.finalMessage = message;
+        turn.usage = usage;
         thread.activeTurnId = undefined;
         if (message) {
           socket.send(JSON.stringify({
@@ -321,8 +324,10 @@ export class MockCodexAppServer {
           method: "turn/completed",
           params: {
             turn: {
-              id: turn.turnId
-            }
+              id: turn.turnId,
+              usage
+            },
+            usage
           }
         }));
       },

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -129,6 +129,61 @@ describe("StateStore", () => {
     store.close();
   });
 
+  it("persists Codex turn token usage and cascades it with the owning session", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-usage-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const store = new StateStore(stateDir, sessionsRoot);
+    await store.load();
+    await store.upsertSession({
+      key: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      workspacePath: "/tmp/sessions/C123-111.222/workspace",
+      createdAt: "2026-03-15T00:00:00.000Z",
+      updatedAt: "2026-03-15T00:00:00.000Z"
+    });
+
+    await store.upsertCodexTurnUsage({
+      turnId: "turn-1",
+      sessionKey: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      codexThreadId: "thread-1",
+      status: "completed",
+      source: "exact",
+      model: "gpt-5.5",
+      effort: "xhigh",
+      inputTokens: 1200,
+      cachedInputTokens: 300,
+      outputTokens: 450,
+      reasoningTokens: 75,
+      totalTokens: 1725,
+      rawUsage: {
+        total_tokens: 1725
+      },
+      startedAt: "2026-03-15T00:00:01.000Z",
+      completedAt: "2026-03-15T00:00:09.000Z",
+      createdAt: "2026-03-15T00:00:01.000Z",
+      updatedAt: "2026-03-15T00:00:09.000Z"
+    });
+
+    expect(store.listCodexTurnUsage()).toEqual([
+      expect.objectContaining({
+        turnId: "turn-1",
+        sessionKey: "C123:111.222",
+        source: "exact",
+        totalTokens: 1725,
+        rawUsage: {
+          total_tokens: 1725
+        }
+      })
+    ]);
+
+    await store.deleteSession("C123:111.222");
+    expect(store.listCodexTurnUsage()).toHaveLength(0);
+    store.close();
+  });
+
   it("records explicit schema migrations and does not treat ad hoc DDL as the migration state", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-migrations-"));
     const sessionsRoot = path.join(stateDir, "sessions");
@@ -148,8 +203,12 @@ describe("StateStore", () => {
           name: "initial_sqlite_state"
         },
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 2,
           name: "admin_operations"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "codex_turn_usage"
         }
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- persist per-Codex-turn token usage in SQLite and expose usage totals through admin APIs
- capture exact usage from turn completion/thread snapshots and record missing usage for failed/unknown turns
- add a Chinese admin UI panel for total, hourly, daily, missing, recent, and per-session usage

## Tests
- pnpm vitest run test/admin-token-usage.e2e.test.ts
- pnpm vitest run test/app-server-client.test.ts test/slack-turn-runner.test.ts test/state-store.test.ts test/admin-routes.test.ts test/admin-control-plane.e2e.test.ts test/admin-service.test.ts
- pnpm build
- pnpm test