### PR TITLE
[codex] Hide token usage from admin timeline

### DIFF
--- a/src/admin-ui/admin-legacy.js
+++ b/src/admin-ui/admin-legacy.js
@@ -716,10 +716,13 @@ export function initAdminPage(options = {}) {
       return '<div class="timeline"><div class="timeline-event"><span>' + esc(fmtTime(session.createdAt)) + '</span>' + renderBadge("session", "info") + '<div class="timeline-main"><strong>已创建</strong></div></div></div>';
     }
     function renderTimelineEvents(payload) {
-      const events = Array.isArray(payload) ? payload : (payload?.events || []);
+      const events = (Array.isArray(payload) ? payload : (payload?.events || [])).filter(isVisibleTimelineEvent);
       const trace = Array.isArray(payload) ? null : payload?.trace;
       if (!events?.length) return '<div class="summary-detail">暂无时间线事件</div>';
       return renderTraceSummary(trace) + '<div class="timeline">' + events.map(renderTimelineEvent).join("") + '</div>';
+    }
+    function isVisibleTimelineEvent(event) {
+      return String(event?.type || "").toLowerCase() !== "agent_token_count";
     }
     function renderTraceSummary(trace) {
       if (!trace) return "";

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState, useSyncExternalStore } fro
 
 import { getAdminStatusSnapshot, subscribeAdminStatus } from "./admin-status-store";
 import { stableSessionOrder } from "./session-order";
-import { getTimelineEventDisplay, statusLabel, type TimelineEvent } from "./timeline-display";
+import { getTimelineEventDisplay, isTimelineEventVisible, statusLabel, type TimelineEvent } from "./timeline-display";
 
 type UiState = {
   readonly adminView: string;
@@ -249,7 +249,7 @@ function SessionTimeline({ session, refreshVersion }: {
 }
 
 function TimelinePayloadView({ payload }: { readonly payload: TimelinePayload }): React.JSX.Element {
-  const events = Array.isArray(payload) ? payload : (payload.events || []);
+  const events = (Array.isArray(payload) ? payload : (payload.events || [])).filter(isTimelineEventVisible);
   const trace = Array.isArray(payload) ? null : payload.trace;
   if (!events.length) return <div className="summary-detail">暂无时间线事件</div>;
   return (

--- a/src/admin-ui/timeline-display.ts
+++ b/src/admin-ui/timeline-display.ts
@@ -6,6 +6,10 @@ export type TimelineEventDisplay = {
   readonly summary: string;
 };
 
+export function isTimelineEventVisible(event: TimelineEvent): boolean {
+  return String(event.type || "").toLowerCase() !== "agent_token_count";
+}
+
 export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisplay {
   const type = String(event.type || "").toLowerCase();
   const rawTitle = nonEmptyString(event.title) || statusLabel(type || event.status || "event");
@@ -16,7 +20,6 @@ export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisp
     case "agent_input_delivered":
     case "agent_turn_started":
     case "agent_turn_completed":
-    case "agent_token_count":
     case "inbound_message":
     case "turn_signal":
       if (rawSummary) return { badgeLabel, title: rawSummary, summary: "" };
@@ -44,7 +47,6 @@ function timelineCategoryLabel(type: string, event: TimelineEvent): string {
     agent_input_delivered: "输入",
     agent_turn_started: "回合",
     agent_turn_completed: "回合",
-    agent_token_count: "Token",
     inbound_message: "Slack",
     agent_assistant_message: "Assistant",
     agent_user_message: "用户",

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -292,7 +292,9 @@ export class AdminService {
       });
     }
 
-    const agentEvents = this.options.sessions.listAgentTraceEvents(session.key, 1000);
+    const agentEvents = this.options.sessions
+      .listAgentTraceEvents(session.key, 1000)
+      .filter(isVisibleTimelineTraceEvent);
 
     return {
       ok: true,
@@ -1128,6 +1130,10 @@ function summarizeAgentTrace(events: readonly PersistedAgentTraceEvent[]): Recor
     categories,
     sources
   };
+}
+
+function isVisibleTimelineTraceEvent(event: PersistedAgentTraceEvent): boolean {
+  return event.type !== "agent_token_count";
 }
 
 function agentTraceEventToTimelineEvent(event: PersistedAgentTraceEvent): Record<string, JsonLike> {

--- a/src/services/agent-runtime/codex-app-server-runtime.ts
+++ b/src/services/agent-runtime/codex-app-server-runtime.ts
@@ -259,6 +259,32 @@ function codexNotificationToAgentEvents(
 
   const at = notificationAt(params);
   const turnId = normalizeCodexTurnId(params) ?? session.activeTurnId ?? "";
+  const item = asRecord(params.item);
+  if (method === "item/started" && turnId && item?.type === "commandExecution") {
+    return [{
+      type: "agent.tool.started",
+      agentSessionId,
+      turnId,
+      brokerSessionKey: session.key,
+      callId: normalizeNonEmptyString(item.id) ?? `${turnId}:command:${at}`,
+      name: "exec_command",
+      input: commandExecutionTracePayload(item),
+      at
+    }];
+  }
+  if (method === "item/completed" && turnId && item?.type === "commandExecution") {
+    return [{
+      type: "agent.tool.completed",
+      agentSessionId,
+      turnId,
+      brokerSessionKey: session.key,
+      callId: normalizeNonEmptyString(item.id) ?? `${turnId}:command:${at}`,
+      name: "exec_command",
+      output: commandExecutionTracePayload(item),
+      status: commandExecutionFailed(item) ? "failed" : "completed",
+      at
+    }];
+  }
   if ((method === "tool_start" || method === "codex/event/tool_start") && turnId) {
     return [{
       type: "agent.tool.started",
@@ -627,6 +653,34 @@ function collectInputText(input: readonly AgentInputItem[]): string {
 
 function summarizeText(text: string): string {
   return text.replace(/\s+/g, " ").trim().slice(0, 220);
+}
+
+function commandExecutionTracePayload(item: Record<string, unknown>): Record<string, unknown> {
+  return compactRecord({
+    type: item.type,
+    id: item.id,
+    command: item.command,
+    cwd: item.cwd,
+    source: item.source,
+    processId: item.processId,
+    status: item.status,
+    exitCode: item.exitCode,
+    durationMs: item.durationMs,
+    commandActions: item.commandActions,
+    aggregatedOutput: item.aggregatedOutput,
+    error: item.error
+  });
+}
+
+function commandExecutionFailed(item: Record<string, unknown>): boolean {
+  const exitCode = normalizeFiniteNumber(item.exitCode);
+  return toolFailed(item) || (exitCode !== undefined && exitCode !== 0);
+}
+
+function compactRecord(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined && value !== null)
+  );
 }
 
 function toolFailed(params: Record<string, unknown>): boolean {

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -87,7 +87,11 @@ describe("admin control plane e2e", () => {
     });
     expect(timeline.trace).not.toHaveProperty("rolloutPath");
     expect(JSON.stringify(timeline)).not.toContain(".jsonl");
+    const trace = timeline.trace as { readonly categories?: Record<string, unknown> };
     const eventTypes = (timeline.events as Array<{ type: string; summary?: string }>).map((event) => event.type);
+    expect(eventTypes).not.toContain("agent_token_count");
+    expect(trace.categories).not.toHaveProperty("agent_token_count");
+    expect(JSON.stringify(timeline.events)).not.toContain("tokenUsage");
     expect(eventTypes).toEqual(expect.arrayContaining([
       "session_created",
       "inbound_message",
@@ -492,6 +496,37 @@ async function seedAgentTraceFixture(sessions: SessionManager, sessionKey: strin
       toolName: "exec_command",
       callId: "call-1",
       turnId: "turn-1"
+    },
+    {
+      id: `${sessionKey}:runtime:token-count`,
+      source: "agent_runtime",
+      type: "agent_token_count",
+      at: "2026-03-19T00:00:04.500Z",
+      sequence: 4500,
+      title: "Token 用量",
+      summary: "180704 tokens",
+      detail: JSON.stringify({
+        tokenUsage: {
+          last: {
+            totalTokens: 180704,
+            inputTokens: 180698,
+            cachedInputTokens: 180096,
+            outputTokens: 6
+          },
+          total: {
+            totalTokens: 16720576
+          }
+        }
+      }),
+      status: "completed",
+      turnId: "turn-1",
+      metadata: {
+        totalTokens: 180704,
+        inputTokens: 180698,
+        outputTokens: 6,
+        reasoningTokens: 0,
+        source: "exact"
+      }
     },
     {
       id: `${sessionKey}:runtime:tool-result`,

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getTimelineEventDisplay } from "../src/admin-ui/timeline-display.js";
+import { getTimelineEventDisplay, isTimelineEventVisible } from "../src/admin-ui/timeline-display.js";
 
 describe("admin session timeline display", () => {
   it("uses category badges instead of duplicating the event title", () => {
@@ -11,16 +11,6 @@ describe("admin session timeline display", () => {
     })).toEqual({
       badgeLabel: "回合",
       title: "开始处理输入",
-      summary: ""
-    });
-
-    expect(getTimelineEventDisplay({
-      type: "agent_token_count",
-      title: "Token 用量",
-      summary: "14784 tokens"
-    })).toEqual({
-      badgeLabel: "Token",
-      title: "14784 tokens",
       summary: ""
     });
 
@@ -56,5 +46,19 @@ describe("admin session timeline display", () => {
       title: "exec_command",
       summary: ""
     });
+  });
+
+  it("does not treat token usage records as visible timeline activity", () => {
+    expect(isTimelineEventVisible({
+      type: "agent_token_count",
+      title: "Token 用量",
+      summary: "14784 tokens"
+    })).toBe(false);
+
+    expect(isTimelineEventVisible({
+      type: "agent_tool_call",
+      title: "工具调用",
+      summary: "exec_command"
+    })).toBe(true);
   });
 });

--- a/test/codex-app-server-runtime.test.ts
+++ b/test/codex-app-server-runtime.test.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { CodexAppServerRuntime } from "../src/services/agent-runtime/codex-app-server-runtime.js";
+import type { AgentRuntimeEvent } from "../src/services/agent-runtime/types.js";
+import type { SlackSessionRecord } from "../src/types.js";
+
+const TEST_SESSION: SlackSessionRecord = {
+  key: "C123:111.222",
+  channelId: "C123",
+  rootThreadTs: "111.222",
+  workspacePath: "/tmp/workspace",
+  agentSessionId: "thread-1",
+  activeTurnId: "turn-1",
+  createdAt: "2026-05-09T00:00:00.000Z",
+  updatedAt: "2026-05-09T00:00:00.000Z"
+};
+
+describe("CodexAppServerRuntime", () => {
+  it("records app-server commandExecution items as tool calls and results", () => {
+    const { codex, events } = createRuntimeFixture();
+
+    codex.emit("notification", "item/started", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        type: "commandExecution",
+        id: "call-1",
+        command: "/bin/zsh -lc \"pnpm test\"",
+        cwd: "/repo",
+        processId: "123",
+        source: "unifiedExecStartup",
+        status: "inProgress",
+        commandActions: [{ type: "keyboard", key: "ctrl-c" }],
+        aggregatedOutput: null,
+        exitCode: null,
+        durationMs: null
+      }
+    });
+    codex.emit("notification", "item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        type: "commandExecution",
+        id: "call-1",
+        command: "/bin/zsh -lc \"pnpm test\"",
+        cwd: "/repo",
+        processId: "123",
+        source: "unifiedExecStartup",
+        status: "completed",
+        aggregatedOutput: "PASS test",
+        exitCode: 0,
+        durationMs: 240
+      }
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      type: "agent.tool.started",
+      agentSessionId: "thread-1",
+      brokerSessionKey: TEST_SESSION.key,
+      turnId: "turn-1",
+      callId: "call-1",
+      name: "exec_command",
+      input: {
+        type: "commandExecution",
+        id: "call-1",
+        command: "/bin/zsh -lc \"pnpm test\"",
+        cwd: "/repo",
+        processId: "123",
+        source: "unifiedExecStartup",
+        status: "inProgress",
+        commandActions: [{ type: "keyboard", key: "ctrl-c" }]
+      }
+    });
+    expect(events[1]).toMatchObject({
+      type: "agent.tool.completed",
+      agentSessionId: "thread-1",
+      brokerSessionKey: TEST_SESSION.key,
+      turnId: "turn-1",
+      callId: "call-1",
+      name: "exec_command",
+      status: "completed",
+      output: {
+        type: "commandExecution",
+        id: "call-1",
+        command: "/bin/zsh -lc \"pnpm test\"",
+        cwd: "/repo",
+        processId: "123",
+        source: "unifiedExecStartup",
+        status: "completed",
+        aggregatedOutput: "PASS test",
+        exitCode: 0,
+        durationMs: 240
+      }
+    });
+  });
+
+  it("marks failed commandExecution completions as failed tool results", () => {
+    const { codex, events } = createRuntimeFixture();
+
+    codex.emit("notification", "item/completed", {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        type: "commandExecution",
+        id: "call-2",
+        command: "/bin/zsh -lc \"pnpm lint\"",
+        status: "completed",
+        aggregatedOutput: "lint failed",
+        exitCode: 1
+      }
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "agent.tool.completed",
+        callId: "call-2",
+        name: "exec_command",
+        status: "failed",
+        output: expect.objectContaining({
+          command: "/bin/zsh -lc \"pnpm lint\"",
+          exitCode: 1,
+          aggregatedOutput: "lint failed"
+        })
+      })
+    ]);
+  });
+});
+
+function createRuntimeFixture(): {
+  readonly codex: EventEmitter;
+  readonly events: AgentRuntimeEvent[];
+} {
+  const codex = Object.assign(new EventEmitter(), {
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    setSlackBotIdentity: vi.fn(),
+    ensureThread: vi.fn(async () => "thread-1"),
+    steer: vi.fn(async () => undefined),
+    startTurn: vi.fn(async () => ({
+      turnId: "turn-1",
+      completion: Promise.resolve({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        finalMessage: "",
+        aborted: false
+      })
+    })),
+    interrupt: vi.fn(async () => undefined),
+    readTurnResult: vi.fn(async () => null)
+  });
+  const runtime = new CodexAppServerRuntime({
+    codex: codex as never,
+    sessions: {
+      findSessionByWorkspace: vi.fn(() => undefined),
+      listSessions: vi.fn(() => [TEST_SESSION])
+    } as never
+  });
+  const events: AgentRuntimeEvent[] = [];
+  runtime.on("event", (event: AgentRuntimeEvent) => {
+    events.push(event);
+  });
+  return { codex, events };
+}


### PR DESCRIPTION
## Summary
- filter agent_token_count records out of the admin timeline API
- defensively filter token usage records in both React and legacy timeline rendering
- record app-server item/started and item/completed commandExecution notifications as exec_command tool calls/results
- keep token records available in DB/usage accounting instead of treating them as readable activity rows

## Why
Token usage updates are model accounting snapshots, often emitted once per model request while a turn is running. They are not the user-visible activity. Rendering them directly in the timeline hides the actual tool calls, tool results, assistant messages, and Slack inputs.

Live app-server currently emits shell work as item/started and item/completed commandExecution notifications, not as the older tool_start/tool_end or function_call forms. Without mapping those item notifications, the admin DB contains token updates but no agent_tool_call or agent_tool_result records for the real work.

## Validation
- pnpm exec vitest run test/codex-app-server-runtime.test.ts test/admin-control-plane.e2e.test.ts test/admin-session-view.test.ts
- pnpm build
- pnpm test