### PR TITLE
[codex] Add realtime admin event stream

### DIFF
--- a/src/admin-ui/admin-legacy.js
+++ b/src/admin-ui/admin-legacy.js
@@ -1,3 +1,5 @@
+import { applyAdminRealtimeEventToStatus, publishTimelineRealtimeEvent } from "./admin-status-store";
+
 export function initAdminPage(options = {}) {
     const useReactSessions = options.useReactSessions === true;
     const refreshButton = document.getElementById("refresh-button");
@@ -17,6 +19,7 @@ export function initAdminPage(options = {}) {
     let latestStatus = null;
     let uiState = loadUiState();
     let uiStatePersistTimer = null;
+    let realtimeSource = null;
 
     async function requestJson(path, init = {}) {
       const response = await fetch(path, Object.assign({}, init, { headers: authHeaders(init.headers) }));
@@ -857,12 +860,36 @@ export function initAdminPage(options = {}) {
           sessions: sessionsPayload.sessions || []
         });
         render(status);
+        startRealtime();
         lastRefresh.textContent = "已同步：" + fmtTime(new Date());
       } catch (error) {
         lastRefresh.textContent = "错误：" + (error instanceof Error ? error.message : String(error));
       } finally {
         refreshButton.disabled = false;
       }
+    }
+    function startRealtime() {
+      if (realtimeSource || typeof window.EventSource === "undefined") return;
+      const cursor = Number(latestStatus?.realtime?.cursor || 0);
+      const source = new window.EventSource("/admin/api/events?after=" + encodeURIComponent(String(cursor)));
+      realtimeSource = source;
+      source.addEventListener("admin-event", (message) => {
+        try {
+          const payload = JSON.parse(message.data);
+          if (!payload?.event) return;
+          latestStatus = applyAdminRealtimeEventToStatus(latestStatus, payload.event);
+          publishTimelineRealtimeEvent(payload.event);
+          render(latestStatus);
+          lastRefresh.textContent = "实时同步：" + fmtTime(new Date());
+        } catch (error) {
+          lastRefresh.textContent = "实时事件错误：" + (error instanceof Error ? error.message : String(error));
+        }
+      });
+      source.addEventListener("error", () => {
+        if (source.readyState === window.EventSource.CLOSED && realtimeSource === source) {
+          realtimeSource = null;
+        }
+      });
     }
     async function activateProfile(name, allowActive) {
       replaceStatus.textContent = "正在切换认证档案...";
@@ -1030,6 +1057,5 @@ export function initAdminPage(options = {}) {
     addProfileDialog.onclick = (event) => { if (event.target === addProfileDialog) addProfileDialog.close(); };
     githubAuthorDialog.onclick = (event) => { if (event.target === githubAuthorDialog) githubAuthorDialog.close(); };
     refresh();
-    window.setInterval(refresh, 10000);
 
 }

--- a/src/admin-ui/admin-shell.ts
+++ b/src/admin-ui/admin-shell.ts
@@ -7,7 +7,7 @@ export function renderAdminShellHtml(serviceName: string): string {
       </nav>
       <div class="topbar-center" id="topbar-quota"></div>
       <div class="top-actions">
-        <span class="pill">刷新：10 秒</span>
+        <span class="pill">实时</span>
         <span class="pill" id="last-refresh">就绪</span>
         <button id="refresh-button" class="secondary">刷新</button>
       </div>

--- a/src/admin-ui/admin-status-store.ts
+++ b/src/admin-ui/admin-status-store.ts
@@ -5,12 +5,82 @@ export interface AdminStatusSnapshot {
   readonly version: number;
 }
 
+export interface AdminRealtimeEvent {
+  readonly sequence: number;
+  readonly kind: string;
+  readonly scope: "global" | "session";
+  readonly sessionKey?: string | null | undefined;
+  readonly entityId?: string | null | undefined;
+  readonly payload?: unknown;
+  readonly createdAt: string;
+  readonly session?: Record<string, unknown> | null | undefined;
+  readonly timelineEvent?: Record<string, unknown> | undefined;
+  readonly trace?: Record<string, unknown> | undefined;
+  readonly operation?: Record<string, unknown> | undefined;
+  readonly auditEvent?: Record<string, unknown> | undefined;
+}
+
+export interface TimelineSnapshot {
+  readonly payload: unknown;
+  readonly version: number;
+}
+
 let snapshot: AdminStatusSnapshot = { status: null, version: 0 };
+let lastEventSequence = 0;
+let realtimeSource: EventSource | null = null;
+const emptyTimelineSnapshot: TimelineSnapshot = { payload: null, version: 0 };
 const listeners = new Set<Listener>();
+const timelineSnapshots = new Map<string, TimelineSnapshot>();
+const timelineListeners = new Map<string, Set<Listener>>();
 
 export function publishAdminStatus(status: unknown): void {
+  lastEventSequence = Math.max(lastEventSequence, readRealtimeCursor(status));
   snapshot = { status, version: snapshot.version + 1 };
   listeners.forEach((listener) => listener());
+}
+
+export function applyAdminRealtimeEvent(event: AdminRealtimeEvent): void {
+  lastEventSequence = Math.max(lastEventSequence, Number(event.sequence || 0));
+  snapshot = {
+    status: applyAdminRealtimeEventToStatus(snapshot.status, event),
+    version: snapshot.version + 1
+  };
+  publishTimelineRealtimeEvent(event);
+  listeners.forEach((listener) => listener());
+}
+
+export function connectAdminRealtime(): () => void {
+  if (typeof EventSource === "undefined") {
+    return () => {};
+  }
+  if (realtimeSource) {
+    return () => {};
+  }
+
+  const source = new EventSource("/admin/api/events?after=" + encodeURIComponent(String(lastEventSequence)));
+  realtimeSource = source;
+  source.addEventListener("admin-event", (message) => {
+    try {
+      const payload = JSON.parse((message as MessageEvent).data) as { readonly event?: AdminRealtimeEvent };
+      if (payload.event) {
+        applyAdminRealtimeEvent(payload.event);
+      }
+    } catch {
+      // The connection will keep running; the next event can still be applied.
+    }
+  });
+  source.addEventListener("error", () => {
+    if (source.readyState === EventSource.CLOSED && realtimeSource === source) {
+      realtimeSource = null;
+    }
+  });
+
+  return () => {
+    if (realtimeSource === source) {
+      realtimeSource = null;
+    }
+    source.close();
+  };
 }
 
 export function subscribeAdminStatus(listener: Listener): () => void {
@@ -22,4 +92,233 @@ export function subscribeAdminStatus(listener: Listener): () => void {
 
 export function getAdminStatusSnapshot(): AdminStatusSnapshot {
   return snapshot;
+}
+
+export function publishTimelinePayload(sessionKey: string, payload: unknown): void {
+  const previous = timelineSnapshots.get(sessionKey);
+  timelineSnapshots.set(sessionKey, {
+    payload,
+    version: (previous?.version ?? 0) + 1
+  });
+  notifyTimelineListeners(sessionKey);
+}
+
+export function publishTimelineRealtimeEvent(event: AdminRealtimeEvent): void {
+  const sessionKey = String(event.sessionKey || "");
+  if (!sessionKey || !event.timelineEvent) {
+    return;
+  }
+  const previous = timelineSnapshots.get(sessionKey);
+  if (!previous) {
+    return;
+  }
+  timelineSnapshots.set(sessionKey, {
+    payload: applyTimelineRealtimeEvent(previous.payload, event),
+    version: previous.version + 1
+  });
+  notifyTimelineListeners(sessionKey);
+}
+
+export function subscribeTimeline(sessionKey: string, listener: Listener): () => void {
+  let listenersForSession = timelineListeners.get(sessionKey);
+  if (!listenersForSession) {
+    listenersForSession = new Set();
+    timelineListeners.set(sessionKey, listenersForSession);
+  }
+  listenersForSession.add(listener);
+  return () => {
+    listenersForSession?.delete(listener);
+    if (listenersForSession?.size === 0) {
+      timelineListeners.delete(sessionKey);
+    }
+  };
+}
+
+export function getTimelineSnapshot(sessionKey: string): TimelineSnapshot {
+  return timelineSnapshots.get(sessionKey) ?? emptyTimelineSnapshot;
+}
+
+export function applyAdminRealtimeEventToStatus(status: unknown, event: AdminRealtimeEvent): unknown {
+  if (!status || typeof status !== "object" || Array.isArray(status)) {
+    return status;
+  }
+
+  const current = status as Record<string, any>;
+  const next: Record<string, any> = {
+    ...current,
+    realtime: {
+      ...(current.realtime || {}),
+      cursor: Math.max(Number(current.realtime?.cursor || 0), Number(event.sequence || 0))
+    }
+  };
+
+  if (event.session !== undefined || event.kind === "session.delete") {
+    const state = current.state && typeof current.state === "object" ? current.state : {};
+    const sessions = Array.isArray(state.sessions) ? state.sessions as Array<Record<string, unknown>> : [];
+    const nextSessions = event.kind === "session.delete"
+      ? sessions.filter((session) => String(session.key || "") !== String(event.sessionKey || event.entityId || ""))
+      : upsertSessionSummary(sessions, event.session);
+    next.state = {
+      ...state,
+      sessions: nextSessions,
+      ...summarizeSessionCounts(nextSessions)
+    };
+  }
+
+  if (event.operation) {
+    next.operations = upsertById(Array.isArray(current.operations) ? current.operations : [], event.operation, "id").slice(0, 10);
+  }
+  if (event.auditEvent) {
+    next.auditEvents = prependUnique(Array.isArray(current.auditEvents) ? current.auditEvents : [], event.auditEvent, "id").slice(0, 10);
+  }
+
+  return next;
+}
+
+export function applyTimelineRealtimeEvent(payload: unknown, event: AdminRealtimeEvent): unknown {
+  if (!event.timelineEvent) {
+    return payload;
+  }
+
+  const current = Array.isArray(payload)
+    ? { events: payload, trace: null }
+    : (payload && typeof payload === "object" ? payload as Record<string, any> : { events: [] });
+  const events = Array.isArray(current.events) ? current.events as Array<Record<string, unknown>> : [];
+  const nextEvents = appendUniqueTimelineEvent(events, event.timelineEvent);
+
+  if (Array.isArray(payload)) {
+    return nextEvents;
+  }
+
+  return {
+    ...current,
+    events: nextEvents,
+    trace: event.trace || summarizeTraceFromEvents(nextEvents)
+  };
+}
+
+function upsertSessionSummary(
+  sessions: readonly Record<string, unknown>[],
+  session: Record<string, unknown> | null | undefined
+): Array<Record<string, unknown>> {
+  if (!session?.key) {
+    return [...sessions];
+  }
+  const key = String(session.key);
+  let replaced = false;
+  const next = sessions.map((existing) => {
+    if (String(existing.key || "") !== key) {
+      return existing;
+    }
+    replaced = true;
+    return session;
+  });
+  if (!replaced) {
+    next.push(session);
+  }
+  return next;
+}
+
+function upsertById(
+  records: readonly Record<string, unknown>[],
+  record: Record<string, unknown>,
+  keyName: string
+): Array<Record<string, unknown>> {
+  const key = String(record[keyName] || "");
+  if (!key) {
+    return [record, ...records];
+  }
+  const next = records.filter((item) => String(item[keyName] || "") !== key);
+  return [record, ...next];
+}
+
+function prependUnique(
+  records: readonly Record<string, unknown>[],
+  record: Record<string, unknown>,
+  keyName: string
+): Array<Record<string, unknown>> {
+  const key = String(record[keyName] || "");
+  return [record, ...records.filter((item) => String(item[keyName] || "") !== key)];
+}
+
+function appendUniqueTimelineEvent(
+  events: readonly Record<string, unknown>[],
+  event: Record<string, unknown>
+): Array<Record<string, unknown>> {
+  const key = timelineEventIdentity(event);
+  if (key && events.some((existing) => timelineEventIdentity(existing) === key)) {
+    return [...events];
+  }
+  return [...events, event];
+}
+
+function timelineEventIdentity(event: Record<string, unknown>): string {
+  return [
+    event.id,
+    event.at,
+    event.type,
+    event.callId,
+    event.turnId,
+    event.toolName,
+    event.title,
+    event.summary
+  ].filter(Boolean).join("\u001f");
+}
+
+function summarizeSessionCounts(sessions: readonly Record<string, unknown>[]): Record<string, number> {
+  let activeCount = 0;
+  let openInboundCount = 0;
+  let openHumanInboundCount = 0;
+  let openSystemInboundCount = 0;
+  let backgroundJobCount = 0;
+  let runningBackgroundJobCount = 0;
+  let failedBackgroundJobCount = 0;
+
+  for (const session of sessions) {
+    if (session.activeTurnId) activeCount += 1;
+    openInboundCount += Number(session.openInboundCount || 0);
+    openHumanInboundCount += Number(session.openHumanInboundCount || 0);
+    openSystemInboundCount += Number(session.openSystemInboundCount || 0);
+    backgroundJobCount += Number(session.backgroundJobCount || 0);
+    runningBackgroundJobCount += Number(session.runningBackgroundJobCount || 0);
+    failedBackgroundJobCount += Number(session.failedBackgroundJobCount || 0);
+  }
+
+  return {
+    sessionCount: sessions.length,
+    activeCount,
+    openInboundCount,
+    openHumanInboundCount,
+    openSystemInboundCount,
+    backgroundJobCount,
+    runningBackgroundJobCount,
+    failedBackgroundJobCount
+  };
+}
+
+function summarizeTraceFromEvents(events: readonly Record<string, unknown>[]): Record<string, unknown> {
+  const categories: Record<string, number> = {};
+  for (const event of events) {
+    const type = String(event.type || "");
+    if (type) {
+      categories[type] = (categories[type] || 0) + 1;
+    }
+  }
+  return {
+    source: "broker_db",
+    eventCount: events.length,
+    categories
+  };
+}
+
+function notifyTimelineListeners(sessionKey: string): void {
+  timelineListeners.get(sessionKey)?.forEach((listener) => listener());
+}
+
+function readRealtimeCursor(status: unknown): number {
+  if (!status || typeof status !== "object" || Array.isArray(status)) {
+    return 0;
+  }
+  const cursor = Number((status as Record<string, any>).realtime?.cursor || 0);
+  return Number.isFinite(cursor) ? cursor : 0;
 }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -1,6 +1,12 @@
-import React, { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
-import { getAdminStatusSnapshot, subscribeAdminStatus } from "./admin-status-store";
+import {
+  getAdminStatusSnapshot,
+  getTimelineSnapshot,
+  publishTimelinePayload,
+  subscribeAdminStatus,
+  subscribeTimeline
+} from "./admin-status-store";
 import { stableSessionOrder } from "./session-order";
 import { getTimelineEventDisplay, isTimelineEventVisible, statusLabel, type TimelineEvent } from "./timeline-display";
 
@@ -14,7 +20,6 @@ type UiState = {
 type SessionRecord = Record<string, any>;
 type TimelinePayload = { readonly events?: TimelineEvent[]; readonly trace?: Record<string, any> } | TimelineEvent[];
 
-const timelineCache = new Map<string, TimelinePayload>();
 const sessionFilters = ["ongoing", "all", "active", "inbound", "jobs", "issues", "usage"];
 
 export function AdminSessionsView(): React.JSX.Element {
@@ -114,7 +119,7 @@ export function AdminSessionsView(): React.JSX.Element {
         </div>
         <div id="session-detail-panel" className="panel-body">
           {selectedSession ? (
-            <SessionDetail key={selectedSession.key} session={selectedSession} refreshVersion={snapshot.version} />
+            <SessionDetail key={selectedSession.key} session={selectedSession} />
           ) : (
             <div className="empty-state">没有可检查的 session</div>
           )}
@@ -159,9 +164,8 @@ function SessionRow({ session, selected, onSelect }: {
   );
 }
 
-function SessionDetail({ session, refreshVersion }: {
+function SessionDetail({ session }: {
   readonly session: SessionRecord;
-  readonly refreshVersion: number;
 }): React.JSX.Element {
   const usage = session.usage || {};
   const state = sessionQueueState(session);
@@ -194,7 +198,7 @@ function SessionDetail({ session, refreshVersion }: {
           <div className="mini-panel trace-panel">
             <div className="mini-title">Agent 活动时间线</div>
             <div className="mini-body">
-              <SessionTimeline session={session} refreshVersion={refreshVersion} />
+              <SessionTimeline session={session} />
             </div>
           </div>
           <div className="mini-panel">
@@ -216,24 +220,25 @@ function SessionDetail({ session, refreshVersion }: {
   );
 }
 
-function SessionTimeline({ session, refreshVersion }: {
+function SessionTimeline({ session }: {
   readonly session: SessionRecord;
-  readonly refreshVersion: number;
 }): React.JSX.Element {
   const sessionKey = String(session.key || "");
-  const [payload, setPayload] = useState<TimelinePayload | null>(() => timelineCache.get(sessionKey) || null);
+  const timelineSnapshot = useSyncExternalStore(
+    (listener) => subscribeTimeline(sessionKey, listener),
+    () => getTimelineSnapshot(sessionKey),
+    () => getTimelineSnapshot(sessionKey)
+  );
+  const payload = timelineSnapshot.payload as TimelinePayload | null;
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    const cached = timelineCache.get(sessionKey) || null;
-    setPayload(cached);
     setError(null);
     void requestJson("/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/timeline")
       .then((nextPayload) => {
         if (cancelled) return;
-        timelineCache.set(sessionKey, nextPayload as TimelinePayload);
-        setPayload(nextPayload as TimelinePayload);
+        publishTimelinePayload(sessionKey, nextPayload as TimelinePayload);
       })
       .catch((nextError: unknown) => {
         if (!cancelled) setError(nextError instanceof Error ? nextError.message : String(nextError));
@@ -241,7 +246,7 @@ function SessionTimeline({ session, refreshVersion }: {
     return () => {
       cancelled = true;
     };
-  }, [sessionKey, refreshVersion]);
+  }, [sessionKey]);
 
   if (error) return <div className="summary-detail">{error}</div>;
   if (!payload) return <Timeline events={[{ at: session.createdAt, type: "session", title: "已创建" }]} />;
@@ -284,8 +289,29 @@ function TraceSummary({ trace }: { readonly trace: Record<string, any> }): React
 }
 
 function Timeline({ events }: { readonly events: readonly TimelineEvent[] }): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const shouldFollowRef = useRef(false);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || !shouldFollowRef.current) {
+      updateFollowState();
+      return;
+    }
+    container.scrollTop = container.scrollHeight;
+    updateFollowState();
+  }, [events.length]);
+
+  function updateFollowState(): void {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    shouldFollowRef.current = container.scrollHeight - container.scrollTop - container.clientHeight < 24;
+  }
+
   return (
-    <div className="timeline">
+    <div className="timeline" ref={containerRef} onScroll={updateFollowState} onMouseEnter={updateFollowState}>
       {events.map((event, index) => (
         <TimelineRow key={timelineEventKey(event, index)} event={event} />
       ))}

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -89,6 +89,11 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "GET" && url.pathname === "/admin/api/events") {
+    streamAdminEvents(request, response, options.adminService, url);
+    return true;
+  }
+
   if (method === "GET" && url.pathname === "/admin/api/status") {
     respondJson(response, 200, await options.adminService.getStatus());
     return true;
@@ -307,6 +312,79 @@ async function runAdminOperation(
       error: error instanceof Error ? error.message : String(error)
     });
   }
+}
+
+function streamAdminEvents(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  adminService: AdminService,
+  url: URL
+): void {
+  let cursor = readEventCursor(url, request);
+  let closed = false;
+  let draining = false;
+
+  response.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-store, no-transform",
+    connection: "keep-alive",
+    "x-accel-buffering": "no"
+  });
+  response.flushHeaders?.();
+
+  const interval = setInterval(() => {
+    void drain();
+  }, 500);
+
+  request.on("close", () => {
+    closed = true;
+    clearInterval(interval);
+  });
+
+  void drain();
+
+  async function drain(): Promise<void> {
+    if (closed || draining) {
+      return;
+    }
+    draining = true;
+    try {
+      const payload = await adminService.listRealtimeEvents({
+        afterSequence: cursor,
+        limit: 100
+      });
+      const events = Array.isArray(payload.events) ? payload.events as Array<Record<string, unknown>> : [];
+      for (const event of events) {
+        const sequence = Number(event.sequence);
+        if (!Number.isFinite(sequence)) {
+          continue;
+        }
+        cursor = Math.max(cursor, sequence);
+        response.write(`id: ${sequence}\n`);
+        response.write("event: admin-event\n");
+        response.write(`data: ${JSON.stringify({ ok: true, event })}\n\n`);
+      }
+    } catch (error) {
+      response.write("event: admin-error\n");
+      response.write(`data: ${JSON.stringify({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      })}\n\n`);
+    } finally {
+      draining = false;
+    }
+  }
+}
+
+function readEventCursor(url: URL, request: http.IncomingMessage): number {
+  const fromQuery = Number(url.searchParams.get("after") ?? "");
+  if (Number.isFinite(fromQuery) && fromQuery >= 0) {
+    return Math.floor(fromQuery);
+  }
+  const fromHeader = request.headers["last-event-id"];
+  const value = Array.isArray(fromHeader) ? fromHeader.at(-1) : fromHeader;
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0;
 }
 
 function isAuthorizedAdminRequest(request: http.IncomingMessage, config: AppConfig): boolean {

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -8,6 +8,7 @@ import type {
   AdminOperationKind,
   JsonLike,
   PersistedAdminAuditEvent,
+  PersistedAdminEvent,
   PersistedAdminOperation,
   PersistedAgentTraceEvent,
   PersistedBackgroundJob,
@@ -168,6 +169,7 @@ export class AdminService {
       account: runtime.account,
       rateLimits: runtime.rateLimits,
       deployment: runtime.deployment,
+      realtime: this.#realtimeInfo(),
       usage,
       operations: this.#listAdminOperations(10),
       auditEvents: this.#listAdminAuditEvents({ limit: 10 }),
@@ -193,6 +195,7 @@ export class AdminService {
       account: runtime.account,
       rateLimits: runtime.rateLimits,
       deployment: runtime.deployment,
+      realtime: this.#realtimeInfo(),
       usage,
       operations: this.#listAdminOperations(10),
       auditEvents: this.#listAdminAuditEvents({ limit: 10 }),
@@ -212,6 +215,7 @@ export class AdminService {
     const snapshot = await this.#readSessionSnapshot();
     return {
       ok: true,
+      realtime: this.#realtimeInfo(),
       sessions: snapshot.allSessions.slice(0, 500).map((session) =>
         this.#summarizeSession(session, {
           inbound: snapshot.inboundBySession.get(session.key) ?? [],
@@ -334,6 +338,21 @@ export class AdminService {
         operationId: options?.operationId,
         limit: 50
       })
+    };
+  }
+
+  async listRealtimeEvents(options: {
+    readonly afterSequence: number;
+    readonly limit?: number | undefined;
+  }): Promise<Record<string, unknown>> {
+    const events = this.options.sessions.listAdminEvents({
+      afterSequence: options.afterSequence,
+      limit: options.limit ?? 100
+    });
+    return {
+      ok: true,
+      cursor: events.at(-1)?.sequence ?? this.#latestRealtimeSequence(),
+      events: events.map((event) => this.#serializeRealtimeEvent(event))
     };
   }
 
@@ -588,6 +607,85 @@ export class AdminService {
         .map(summarizeUsageRecord),
       bySession: summarizeUsageBySession(records, 25)
     };
+  }
+
+  #realtimeInfo(): Record<string, unknown> {
+    return {
+      cursor: this.#latestRealtimeSequence()
+    };
+  }
+
+  #latestRealtimeSequence(): number {
+    const getLatest = (this.options.sessions as {
+      readonly getLatestAdminEventSequence?: (() => number) | undefined;
+    }).getLatestAdminEventSequence;
+    return typeof getLatest === "function" ? getLatest.call(this.options.sessions) : 0;
+  }
+
+  #serializeRealtimeEvent(event: PersistedAdminEvent): Record<string, unknown> {
+    const serialized: Record<string, unknown> = {
+      sequence: event.sequence,
+      kind: event.kind,
+      scope: event.scope,
+      sessionKey: event.sessionKey ?? null,
+      entityId: event.entityId ?? null,
+      payload: event.payload,
+      createdAt: event.createdAt
+    };
+
+    if (event.sessionKey) {
+      serialized.session = this.#summarizeSessionByKey(event.sessionKey) ?? null;
+    }
+
+    if (event.kind === "trace.append") {
+      const traceEvent = event.payload as unknown as PersistedAgentTraceEvent;
+      if (isVisibleTimelineTraceEvent(traceEvent)) {
+        serialized.timelineEvent = agentTraceEventToTimelineEvent(traceEvent);
+      }
+      if (event.sessionKey) {
+        const traceEvents = this.options.sessions
+          .listAgentTraceEvents(event.sessionKey, 1000)
+          .filter(isVisibleTimelineTraceEvent);
+        serialized.trace = summarizeAgentTrace(traceEvents);
+      }
+    }
+
+    if (event.kind === "operation.upsert") {
+      serialized.operation = event.payload;
+    }
+    if (event.kind === "audit.append") {
+      serialized.auditEvent = event.payload;
+    }
+
+    return serialized;
+  }
+
+  #summarizeSessionByKey(sessionKey: string): Record<string, unknown> | null {
+    const session = this.options.sessions.getSessionByKey(sessionKey);
+    if (!session) {
+      return null;
+    }
+
+    const inbound = this.options.sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs
+    });
+    const openInbound = this.options.sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      status: ["pending", "inflight"]
+    });
+    const jobs = this.options.sessions.listBackgroundJobs({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs
+    });
+
+    return this.#summarizeSession(session, {
+      inbound,
+      openInbound,
+      jobs,
+      usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key)
+    });
   }
 
   #serviceInfo(): Record<string, unknown> {

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type {
   JsonLike,
   PersistedAdminAuditEvent,
+  PersistedAdminEvent,
   PersistedAdminOperation,
   PersistedAgentTraceEvent,
   PersistedBackgroundJob,
@@ -400,6 +401,18 @@ export class SessionManager {
 
   async upsertAgentTraceEvent(record: PersistedAgentTraceEvent): Promise<void> {
     await this.#stateStore.upsertAgentTraceEvent(record);
+  }
+
+  listAdminEvents(options?: {
+    readonly afterSequence?: number | undefined;
+    readonly sessionKey?: string | undefined;
+    readonly limit?: number | undefined;
+  }): PersistedAdminEvent[] {
+    return this.#stateStore.listAdminEvents(options);
+  }
+
+  getLatestAdminEventSequence(): number {
+    return this.#stateStore.getLatestAdminEventSequence();
   }
 
   #requireSession(channelId: string, rootThreadTs: string): SlackSessionRecord {

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import type {
   PersistedAdminAuditEvent,
+  PersistedAdminEvent,
   PersistedAdminOperation,
   PersistedAgentTraceEvent,
   JsonLike,
@@ -18,7 +19,8 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 8;
+export const CURRENT_STATE_SCHEMA_VERSION = 9;
+const ADMIN_EVENT_RETENTION_LIMIT = 20_000;
 
 type SqlValue = string | number | bigint | null;
 type SqlRow = Record<string, unknown>;
@@ -266,8 +268,32 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
     up(database) {
       repairInboundMentionedUsersSchema(database);
     }
+  },
+  {
+    version: 9,
+    name: "admin_realtime_events",
+    up(database) {
+      createAdminEventsSchema(database);
+    }
   }
 ];
+
+function createAdminEventsSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS admin_events (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+      kind TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      session_key TEXT,
+      entity_id TEXT,
+      payload TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_admin_events_sequence ON admin_events(sequence);
+    CREATE INDEX IF NOT EXISTS idx_admin_events_session_sequence ON admin_events(session_key, sequence);
+  `);
+}
 
 function repairInboundMentionedUsersSchema(database: DatabaseSync): void {
   if (!tableExists(database, "inbound_messages")) {
@@ -395,6 +421,14 @@ export class StateStore {
     const normalized = this.#normalizeSession(record);
     this.#transaction(() => {
       this.#upsertSession(normalized);
+      this.#appendAdminEvent({
+        kind: "session.upsert",
+        scope: "session",
+        sessionKey: normalized.key,
+        entityId: normalized.key,
+        payload: normalized,
+        createdAt: normalized.updatedAt
+      });
     });
   }
 
@@ -408,6 +442,14 @@ export class StateStore {
       }
 
       this.#databaseRequired().prepare("DELETE FROM sessions WHERE key = ?").run(key);
+      this.#appendAdminEvent({
+        kind: "session.delete",
+        scope: "session",
+        sessionKey: key,
+        entityId: key,
+        payload: { key },
+        createdAt: new Date().toISOString()
+      });
       return true;
     });
   }
@@ -436,6 +478,14 @@ export class StateStore {
       });
 
       this.#upsertSession(updated);
+      this.#appendAdminEvent({
+        kind: "session.upsert",
+        scope: "session",
+        sessionKey: updated.key,
+        entityId: updated.key,
+        payload: updated,
+        createdAt: updated.updatedAt
+      });
       return updated;
     });
   }
@@ -564,6 +614,14 @@ export class StateStore {
     }
     this.#transaction(() => {
       this.#upsertInboundMessage(normalized);
+      this.#appendAdminEvent({
+        kind: "inbound.upsert",
+        scope: "session",
+        sessionKey: normalized.sessionKey,
+        entityId: normalized.key,
+        payload: normalized,
+        createdAt: normalized.updatedAt
+      });
     });
   }
 
@@ -588,6 +646,14 @@ export class StateStore {
         updatedAt: new Date().toISOString()
       };
       this.#upsertInboundMessage(updated);
+      this.#appendAdminEvent({
+        kind: "inbound.upsert",
+        scope: "session",
+        sessionKey: updated.sessionKey,
+        entityId: updated.key,
+        payload: updated,
+        createdAt: updated.updatedAt
+      });
       return updated;
     });
   }
@@ -616,6 +682,14 @@ export class StateStore {
           updatedAt
         };
         this.#upsertInboundMessage(nextMessage);
+        this.#appendAdminEvent({
+          kind: "inbound.upsert",
+          scope: "session",
+          sessionKey: nextMessage.sessionKey,
+          entityId: nextMessage.key,
+          payload: nextMessage,
+          createdAt: nextMessage.updatedAt
+        });
         updated.push(nextMessage);
       }
 
@@ -681,6 +755,14 @@ export class StateStore {
     }
     this.#transaction(() => {
       this.#upsertBackgroundJob(normalized);
+      this.#appendAdminEvent({
+        kind: "job.upsert",
+        scope: "session",
+        sessionKey: normalized.sessionKey,
+        entityId: normalized.id,
+        payload: normalized,
+        createdAt: normalized.updatedAt
+      });
     });
   }
 
@@ -706,6 +788,13 @@ export class StateStore {
     const normalized = this.#normalizeAdminOperation(record);
     this.#transaction(() => {
       this.#upsertAdminOperation(normalized);
+      this.#appendAdminEvent({
+        kind: "operation.upsert",
+        scope: "global",
+        entityId: normalized.id,
+        payload: normalized,
+        createdAt: normalized.updatedAt
+      });
     });
   }
 
@@ -750,6 +839,13 @@ export class StateStore {
         normalized.actor ?? null,
         normalized.createdAt
       );
+      this.#appendAdminEvent({
+        kind: "audit.append",
+        scope: "global",
+        entityId: normalized.id,
+        payload: normalized,
+        createdAt: normalized.createdAt
+      });
     });
   }
 
@@ -768,6 +864,14 @@ export class StateStore {
     const normalized = this.#normalizeAgentTurnUsage(record);
     this.#transaction(() => {
       this.#upsertAgentTurnUsage(normalized);
+      this.#appendAdminEvent({
+        kind: "usage.update",
+        scope: "session",
+        sessionKey: normalized.sessionKey,
+        entityId: normalized.turnId,
+        payload: normalized,
+        createdAt: normalized.updatedAt
+      });
     });
   }
 
@@ -787,7 +891,48 @@ export class StateStore {
     const normalized = this.#normalizeAgentTraceEvent(record);
     this.#transaction(() => {
       this.#upsertAgentTraceEvent(normalized);
+      this.#appendAdminEvent({
+        kind: "trace.append",
+        scope: "session",
+        sessionKey: normalized.sessionKey,
+        entityId: normalized.id,
+        payload: normalized,
+        createdAt: normalized.updatedAt
+      });
     });
+  }
+
+  listAdminEvents(options?: {
+    readonly afterSequence?: number | undefined;
+    readonly sessionKey?: string | undefined;
+    readonly limit?: number | undefined;
+  }): PersistedAdminEvent[] {
+    const afterSequence = Number(options?.afterSequence ?? 0);
+    const limit = Number(options?.limit ?? 100);
+    const where: string[] = ["sequence > ?"];
+    const params: SqlValue[] = [Number.isFinite(afterSequence) ? Math.max(0, Math.floor(afterSequence)) : 0];
+    if (options?.sessionKey) {
+      where.push("session_key = ?");
+      params.push(options.sessionKey);
+    }
+    params.push(Number.isFinite(limit) ? Math.max(1, Math.min(1000, Math.floor(limit))) : 100);
+
+    return this.#databaseRequired()
+      .prepare(`
+        SELECT * FROM admin_events
+        WHERE ${where.join(" AND ")}
+        ORDER BY sequence ASC
+        LIMIT ?
+      `)
+      .all(...params)
+      .map((row) => this.#rowToAdminEvent(row as SqlRow));
+  }
+
+  getLatestAdminEventSequence(): number {
+    const row = this.#databaseRequired()
+      .prepare("SELECT COALESCE(MAX(sequence), 0) AS sequence FROM admin_events")
+      .get() as { sequence?: number | bigint | null } | undefined;
+    return Number(row?.sequence ?? 0);
   }
 
   #openDatabase(): void {
@@ -1141,6 +1286,29 @@ export class StateStore {
     );
   }
 
+  #appendAdminEvent(event: Omit<PersistedAdminEvent, "sequence" | "payload"> & {
+    readonly payload: unknown;
+  }): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO admin_events (
+        kind, scope, session_key, entity_id, payload, created_at
+      ) VALUES (${placeholders(6)})
+    `).run(
+      event.kind,
+      event.scope,
+      event.sessionKey ?? null,
+      event.entityId ?? null,
+      JSON.stringify(event.payload),
+      event.createdAt
+    );
+    this.#databaseRequired().prepare(`
+      DELETE FROM admin_events
+      WHERE sequence NOT IN (
+        SELECT sequence FROM admin_events ORDER BY sequence DESC LIMIT ?
+      )
+    `).run(ADMIN_EVENT_RETENTION_LIMIT);
+  }
+
   #markProcessedEvent(eventId: string): void {
     this.#databaseRequired()
       .prepare("INSERT OR IGNORE INTO processed_events (event_id) VALUES (?)")
@@ -1288,6 +1456,18 @@ export class StateStore {
       actor: optionalStringColumn(row, "actor"),
       createdAt: stringColumn(row, "created_at")
     });
+  }
+
+  #rowToAdminEvent(row: SqlRow): PersistedAdminEvent {
+    return {
+      sequence: Number(row.sequence),
+      kind: stringColumn(row, "kind"),
+      scope: stringColumn(row, "scope") === "session" ? "session" : "global",
+      sessionKey: optionalStringColumn(row, "session_key"),
+      entityId: optionalStringColumn(row, "entity_id"),
+      payload: readJsonColumn<JsonLike>(row, "payload", {}),
+      createdAt: stringColumn(row, "created_at")
+    };
   }
 
   #rowToAgentTurnUsage(row: SqlRow): PersistedAgentTurnUsage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,16 @@ export interface PersistedAdminAuditEvent {
   readonly createdAt: string;
 }
 
+export interface PersistedAdminEvent {
+  readonly sequence: number;
+  readonly kind: string;
+  readonly scope: "global" | "session";
+  readonly sessionKey?: string | undefined;
+  readonly entityId?: string | undefined;
+  readonly payload: JsonLike;
+  readonly createdAt: string;
+}
+
 export type AgentTurnUsageSource = "exact" | "estimated" | "missing";
 export type PersistedAgentTurnStatus = "completed" | "interrupted" | "failed";
 

--- a/test/admin-events-store.test.ts
+++ b/test/admin-events-store.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { StateStore } from "../src/store/state-store.js";
+
+describe("admin realtime event store", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("persists ordered admin events alongside state mutations", async () => {
+    const { store } = await createStore();
+    await store.upsertSession({
+      key: "C123:111.222",
+      channelId: "C123",
+      channelName: "ops",
+      rootThreadTs: "111.222",
+      workspacePath: "/tmp/workspace",
+      createdAt: "2026-05-09T00:00:00.000Z",
+      updatedAt: "2026-05-09T00:00:00.000Z"
+    });
+    await store.upsertAgentTraceEvent({
+      id: "trace-1",
+      sessionKey: "C123:111.222",
+      source: "agent_runtime",
+      type: "agent_tool_call",
+      at: "2026-05-09T00:00:01.000Z",
+      sequence: 1,
+      title: "工具调用",
+      summary: "exec_command",
+      detail: "{\"cmd\":\"pnpm test\"}",
+      status: "running",
+      role: "assistant",
+      toolName: "exec_command",
+      callId: "call-1",
+      turnId: "turn-1",
+      createdAt: "2026-05-09T00:00:01.000Z",
+      updatedAt: "2026-05-09T00:00:01.000Z"
+    });
+
+    const events = store.listAdminEvents({ afterSequence: 0, limit: 10 });
+    expect(events.map((event) => event.kind)).toEqual([
+      "session.upsert",
+      "trace.append"
+    ]);
+    expect(events[0]).toMatchObject({
+      sequence: 1,
+      scope: "session",
+      sessionKey: "C123:111.222",
+      entityId: "C123:111.222",
+      payload: expect.objectContaining({
+        key: "C123:111.222",
+        channelName: "ops"
+      })
+    });
+    expect(events[1]).toMatchObject({
+      sequence: 2,
+      scope: "session",
+      sessionKey: "C123:111.222",
+      entityId: "trace-1",
+      payload: expect.objectContaining({
+        type: "agent_tool_call",
+        summary: "exec_command"
+      })
+    });
+    expect(store.getLatestAdminEventSequence()).toBe(2);
+    expect(store.listAdminEvents({ afterSequence: 1, limit: 10 }).map((event) => event.sequence)).toEqual([2]);
+  });
+
+  async function createStore(): Promise<{ readonly store: StateStore }> {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "admin-events-store-"));
+    cleanups.push(async () => {
+      await fs.rm(root, { force: true, recursive: true });
+    });
+    const store = new StateStore(path.join(root, "state"), path.join(root, "sessions"));
+    await store.load();
+    cleanups.push(async () => {
+      store.close();
+    });
+    return { store };
+  }
+});

--- a/test/admin-realtime-store.test.ts
+++ b/test/admin-realtime-store.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyAdminRealtimeEventToStatus,
+  applyTimelineRealtimeEvent,
+  type AdminRealtimeEvent
+} from "../src/admin-ui/admin-status-store.js";
+
+describe("admin realtime client store", () => {
+  it("upserts session summaries without reordering existing rows", () => {
+    const status = {
+      state: {
+        sessions: [
+          { key: "C1:1", updatedAt: "2026-05-09T00:00:01.000Z", activeTurnId: "turn-old" },
+          { key: "C2:2", updatedAt: "2026-05-09T00:00:02.000Z" }
+        ]
+      }
+    };
+
+    const updated = applyAdminRealtimeEventToStatus(status, {
+      sequence: 1,
+      kind: "session.upsert",
+      scope: "session",
+      sessionKey: "C2:2",
+      entityId: "C2:2",
+      createdAt: "2026-05-09T00:00:03.000Z",
+      payload: {},
+      session: { key: "C2:2", updatedAt: "2026-05-09T00:00:03.000Z", activeTurnId: "turn-new" }
+    } satisfies AdminRealtimeEvent);
+
+    expect((updated as Record<string, any>).state.sessions.map((session: Record<string, unknown>) => session.key)).toEqual(["C1:1", "C2:2"]);
+    expect((updated as Record<string, any>).state.sessions[1]).toMatchObject({
+      key: "C2:2",
+      activeTurnId: "turn-new"
+    });
+
+    const appended = applyAdminRealtimeEventToStatus(updated, {
+      sequence: 2,
+      kind: "session.upsert",
+      scope: "session",
+      sessionKey: "C3:3",
+      entityId: "C3:3",
+      createdAt: "2026-05-09T00:00:04.000Z",
+      payload: {},
+      session: { key: "C3:3", updatedAt: "2026-05-09T00:00:04.000Z" }
+    } satisfies AdminRealtimeEvent);
+
+    expect((appended as Record<string, any>).state.sessions.map((session: Record<string, unknown>) => session.key)).toEqual(["C1:1", "C2:2", "C3:3"]);
+  });
+
+  it("appends realtime timeline events and updates trace counts", () => {
+    const payload = {
+      ok: true,
+      trace: {
+        source: "broker_db",
+        eventCount: 1,
+        categories: {
+          agent_assistant_message: 1
+        }
+      },
+      events: [
+        { id: "message-1", type: "agent_assistant_message", at: "2026-05-09T00:00:01.000Z" }
+      ]
+    };
+
+    const updated = applyTimelineRealtimeEvent(payload, {
+      sequence: 2,
+      kind: "trace.append",
+      scope: "session",
+      sessionKey: "C1:1",
+      entityId: "trace-2",
+      createdAt: "2026-05-09T00:00:02.000Z",
+      payload: {},
+      timelineEvent: {
+        id: "tool-1",
+        type: "agent_tool_call",
+        at: "2026-05-09T00:00:02.000Z",
+        toolName: "exec_command"
+      },
+      trace: {
+        source: "broker_db",
+        eventCount: 2,
+        categories: {
+          agent_assistant_message: 1,
+          agent_tool_call: 1
+        }
+      }
+    } satisfies AdminRealtimeEvent);
+
+    expect((updated as Record<string, any>).events.map((event: Record<string, unknown>) => event.id)).toEqual([
+      "message-1",
+      "tool-1"
+    ]);
+    expect((updated as Record<string, any>).trace).toMatchObject({
+      eventCount: 2,
+      categories: {
+        agent_tool_call: 1
+      }
+    });
+  });
+});

--- a/test/admin-realtime.e2e.test.ts
+++ b/test/admin-realtime.e2e.test.ts
@@ -1,0 +1,277 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+import { createHttpHandler } from "../src/http/router.js";
+import { AdminService } from "../src/services/admin-service.js";
+import { SessionManager } from "../src/services/session-manager.js";
+import { StateStore } from "../src/store/state-store.js";
+import type { AppConfig } from "../src/config.js";
+
+describe("admin realtime e2e", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("streams durable events written by a separate state-store writer", async () => {
+    const fixture = await startAdminFixture();
+    const controller = new AbortController();
+    const eventPromise = readSseEvent(`${fixture.baseUrl}/admin/api/events?after=0`, controller.signal);
+
+    await delay(25);
+    const writerStore = new StateStore(fixture.config.stateDir, fixture.config.sessionsRoot);
+    await writerStore.load();
+    cleanups.push(async () => {
+      writerStore.close();
+    });
+    await writerStore.upsertSession({
+      key: "C123:111.222",
+      channelId: "C123",
+      channelName: "ops",
+      rootThreadTs: "111.222",
+      workspacePath: path.join(fixture.config.sessionsRoot, "C123-111-222", "workspace"),
+      createdAt: "2026-05-09T00:00:00.000Z",
+      updatedAt: "2026-05-09T00:00:01.000Z",
+      activeTurnId: "turn-1"
+    });
+
+    const message = await eventPromise;
+    controller.abort();
+    expect(message.event).toBe("admin-event");
+    expect(message.id).toBe("1");
+    expect(message.data).toMatchObject({
+      ok: true,
+      event: {
+        sequence: 1,
+        kind: "session.upsert",
+        sessionKey: "C123:111.222",
+        session: {
+          key: "C123:111.222",
+          channelLabel: "#ops",
+          activeTurnId: "turn-1"
+        }
+      }
+    });
+  });
+
+  it("replays missed events from the supplied cursor", async () => {
+    const fixture = await startAdminFixture();
+    await fixture.sessions.ensureSession("C123", "111.222", {
+      channelName: "ops"
+    });
+    await fixture.sessions.upsertAgentTraceEvent({
+      id: "trace-1",
+      sessionKey: "C123:111.222",
+      source: "agent_runtime",
+      type: "agent_tool_call",
+      at: "2026-05-09T00:00:01.000Z",
+      sequence: 1,
+      title: "工具调用",
+      summary: "exec_command",
+      detail: "{\"cmd\":\"pnpm test\"}",
+      status: "running",
+      role: "assistant",
+      toolName: "exec_command",
+      callId: "call-1",
+      turnId: "turn-1",
+      createdAt: "2026-05-09T00:00:01.000Z",
+      updatedAt: "2026-05-09T00:00:01.000Z"
+    });
+
+    const controller = new AbortController();
+    const message = await readSseEvent(`${fixture.baseUrl}/admin/api/events?after=1`, controller.signal);
+    controller.abort();
+    expect(message.id).toBe("2");
+    expect(message.data).toMatchObject({
+      ok: true,
+      event: {
+        sequence: 2,
+        kind: "trace.append",
+        sessionKey: "C123:111.222",
+        timelineEvent: {
+          type: "agent_tool_call",
+          toolName: "exec_command",
+          detail: "{\"cmd\":\"pnpm test\"}"
+        },
+        trace: {
+          categories: {
+            agent_tool_call: 1
+          }
+        }
+      }
+    });
+  });
+
+  async function startAdminFixture(): Promise<{
+    readonly baseUrl: string;
+    readonly config: AppConfig;
+    readonly sessions: SessionManager;
+  }> {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-realtime-"));
+    cleanups.push(async () => {
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    });
+
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot,
+      SERVICE_ROOT: dataRoot,
+      ADMIN_LAUNCHD_LABEL: "admin.test",
+      WORKER_LAUNCHD_LABEL: "worker.test",
+      ADMIN_PLIST_PATH: path.join(dataRoot, "admin.plist"),
+      WORKER_PLIST_PATH: path.join(dataRoot, "worker.plist")
+    } as NodeJS.ProcessEnv);
+    await fs.mkdir(config.codexHome, { recursive: true });
+    await fs.mkdir(config.logDir, { recursive: true });
+
+    const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot: config.sessionsRoot
+    });
+    await sessions.load();
+    cleanups.push(async () => {
+      stateStore.close();
+    });
+
+    const adminService = new AdminService({
+      config,
+      sessions,
+      startedAt: new Date("2026-05-09T00:00:00.000Z"),
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
+          activeProfile: null,
+          activeAuthPath: path.join(config.codexHome, "auth.json"),
+          profiles: []
+        }),
+        addProfile: async () => ({ name: "profile" }),
+        deleteProfile: async () => {},
+        activateProfile: async (name: string) => ({ name })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => [],
+        upsertManualMapping: async () => ({}),
+        deleteMapping: async () => {}
+      } as never,
+      runtime: {
+        restartRuntime: async () => {},
+        readAccountSummary: async () => ({
+          account: {
+            email: "admin@example.com",
+            type: "chatgpt",
+            planType: "team"
+          },
+          requiresOpenaiAuth: false
+        }),
+        readAccountRateLimits: async () => ({
+          rateLimits: null,
+          rateLimitsByLimitId: {}
+        })
+      } as never,
+      deployment: {
+        getStatus: async () => ({ ok: true }),
+        deploy: async () => ({ ok: true }),
+        rollback: async () => ({ ok: true }),
+        restartWorker: async () => {}
+      } as never
+    });
+
+    const server = http.createServer(
+      createHttpHandler({
+        adminService,
+        config
+      })
+    );
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start admin fixture");
+    }
+
+    return {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      config,
+      sessions
+    };
+  }
+});
+
+async function readSseEvent(url: string, signal: AbortSignal): Promise<{
+  readonly event: string;
+  readonly id: string;
+  readonly data: Record<string, unknown>;
+}> {
+  const response = await fetch(url, {
+    headers: {
+      accept: "text/event-stream"
+    },
+    signal
+  });
+  expect(response.ok).toBe(true);
+  expect(response.headers.get("content-type")).toContain("text/event-stream");
+  if (!response.body) {
+    throw new Error("missing response body");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 5_000) {
+      const result = await reader.read();
+      if (result.done) {
+        break;
+      }
+      buffer += decoder.decode(result.value, { stream: true });
+      const index = buffer.indexOf("\n\n");
+      if (index < 0) {
+        continue;
+      }
+      const block = buffer.slice(0, index);
+      const lines = block.split("\n");
+      const event = lines.find((line) => line.startsWith("event:"))?.slice("event:".length).trim() || "message";
+      const id = lines.find((line) => line.startsWith("id:"))?.slice("id:".length).trim() || "";
+      const data = lines
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice("data:".length).trimStart())
+        .join("\n");
+      if (!data) {
+        continue;
+      }
+      return {
+        event,
+        id,
+        data: JSON.parse(data) as Record<string, unknown>
+      };
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  throw new Error(`timed out waiting for SSE event from ${url}`);
+}

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -279,8 +279,12 @@ describe("StateStore", () => {
           name: "session_channel_metadata"
         },
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 8,
           name: "inbound_mentioned_users"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "admin_realtime_events"
         }
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- add a durable admin_events table with ordered cursor events for session, inbound, job, operation, audit, usage, and trace mutations
- expose /admin/api/events as an SSE stream that replays missed events by cursor and streams cross-process state changes from SQLite
- update the React admin session UI to consume realtime session summaries and append timeline events without refetching/replacing the selected timeline
- remove the 10-second automatic admin refresh label/loop and keep manual refresh as a fallback

## UX behavior
- existing session rows keep their current order while their content updates, so reading the list is not interrupted
- selected session timeline appends new trace events from SSE; token usage updates remain out of the visible timeline
- timeline only auto-follows when the user is already at the bottom

## Validation
- pnpm exec vitest run test/admin-events-store.test.ts test/admin-realtime.e2e.test.ts test/admin-realtime-store.test.ts
- pnpm exec vitest run test/admin-events-store.test.ts test/admin-realtime.e2e.test.ts test/admin-realtime-store.test.ts test/admin-control-plane.e2e.test.ts test/admin-session-view.test.ts test/state-store.test.ts
- pnpm build
- pnpm test
- local preview: seeded a separate StateStore and verified /admin/api/events replays session.upsert + trace.append and the session timeline contains agent_tool_call