### PR TITLE
[codex] Fix admin self-deploy restart

### DIFF
--- a/scripts/ops/macos-launchd-restart.mjs
+++ b/scripts/ops/macos-launchd-restart.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const options = {
+    delayMs: 250,
+    domain: undefined,
+    label: undefined,
+    logFile: undefined,
+    plist: undefined,
+    reason: "launchd restart"
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    switch (argument) {
+      case "--delay-ms":
+        options.delayMs = Number(argv[index + 1]);
+        index += 1;
+        break;
+      case "--domain":
+        options.domain = argv[index + 1];
+        index += 1;
+        break;
+      case "--label":
+        options.label = argv[index + 1];
+        index += 1;
+        break;
+      case "--log-file":
+        options.logFile = argv[index + 1];
+        index += 1;
+        break;
+      case "--plist":
+        options.plist = argv[index + 1];
+        index += 1;
+        break;
+      case "--reason":
+        options.reason = argv[index + 1];
+        index += 1;
+        break;
+      case "--help":
+      case "-h":
+        console.log("Usage: node scripts/ops/macos-launchd-restart.mjs --domain <domain> --plist <path> --label <label> [--delay-ms <ms>] [--log-file <path>] [--reason <text>]");
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!options.domain) {
+    throw new Error("Missing required argument: --domain");
+  }
+  if (!options.label) {
+    throw new Error("Missing required argument: --label");
+  }
+  if (!options.plist) {
+    throw new Error("Missing required argument: --plist");
+  }
+  if (!Number.isFinite(options.delayMs) || options.delayMs < 0) {
+    throw new Error("Invalid --delay-ms");
+  }
+
+  return options;
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function appendLog(logFile, message) {
+  if (!logFile) {
+    return;
+  }
+
+  try {
+    await fs.mkdir(path.dirname(logFile), { recursive: true });
+    await fs.appendFile(logFile, `${new Date().toISOString()} ${message}\n`, "utf8");
+  } catch {
+    // Logging must not decide whether launchd restart proceeds.
+  }
+}
+
+async function runCommand(command, args) {
+  return await new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({
+        code: -1,
+        stdout,
+        stderr: error instanceof Error ? error.message : String(error)
+      });
+    });
+    child.on("close", (code) => {
+      resolve({
+        code: code ?? -1,
+        stdout,
+        stderr
+      });
+    });
+  });
+}
+
+function summarize(result) {
+  return [result.stdout, result.stderr].join("\n").trim().replace(/\s+/g, " ").slice(0, 500);
+}
+
+const options = parseArgs(process.argv.slice(2));
+const serviceTarget = `${options.domain}/${options.label}`;
+
+await appendLog(options.logFile, `starting ${options.reason}: ${serviceTarget} via ${options.plist}`);
+await sleep(options.delayMs);
+
+const bootout = await runCommand("launchctl", ["bootout", options.domain, options.plist]);
+await appendLog(options.logFile, `bootout code=${bootout.code}${summarize(bootout) ? ` output=${summarize(bootout)}` : ""}`);
+await sleep(150);
+
+let loaded = false;
+let lastBootstrap = null;
+for (let attempt = 1; attempt <= 3; attempt += 1) {
+  const bootstrap = await runCommand("launchctl", ["bootstrap", options.domain, options.plist]);
+  lastBootstrap = bootstrap;
+  await appendLog(options.logFile, `bootstrap attempt=${attempt} code=${bootstrap.code}${summarize(bootstrap) ? ` output=${summarize(bootstrap)}` : ""}`);
+  if (bootstrap.code === 0) {
+    loaded = true;
+    break;
+  }
+
+  const printed = await runCommand("launchctl", ["print", serviceTarget]);
+  if (printed.code === 0) {
+    loaded = true;
+    await appendLog(options.logFile, "bootstrap failed but service is already loaded");
+    break;
+  }
+
+  await sleep(250 * attempt);
+}
+
+if (!loaded) {
+  await appendLog(options.logFile, `failed to bootstrap ${serviceTarget}${lastBootstrap ? `: ${summarize(lastBootstrap)}` : ""}`);
+  process.exit(1);
+}
+
+const kickstart = await runCommand("launchctl", ["kickstart", "-k", serviceTarget]);
+await appendLog(options.logFile, `kickstart code=${kickstart.code}${summarize(kickstart) ? ` output=${summarize(kickstart)}` : ""}`);
+process.exit(kickstart.code === 0 ? 0 : 1);

--- a/src/admin-index.ts
+++ b/src/admin-index.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 
 import { loadConfig } from "./config.js";
+import { deferUntilResponseFinished } from "./http/response-deferred-tasks.js";
 import { createHttpHandler } from "./http/router.js";
 import { logger } from "./logger.js";
 import { AdminService } from "./services/admin-service.js";
@@ -107,8 +108,24 @@ function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): 
     workerLaunchdLabel: config.workerLaunchdLabel,
     workerBaseUrl: config.workerBaseUrl,
     codexAppServerPort: config.codexAppServerPort,
-    releaseRepoUrl: config.releaseRepoUrl
+    releaseRepoUrl: config.releaseRepoUrl,
+    scheduleAdminRestart: scheduleAdminRestartAfterResponse
   });
+}
+
+function scheduleAdminRestartAfterResponse(restart: () => Promise<void>): void {
+  if (deferUntilResponseFinished(restart)) {
+    return;
+  }
+
+  const timer = setTimeout(() => {
+    void restart().catch((error: unknown) => {
+      logger.error("Scheduled admin restart failed", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    });
+  }, 250);
+  timer.unref?.();
 }
 
 startAdminService().catch((error: unknown) => {

--- a/src/http/response-deferred-tasks.ts
+++ b/src/http/response-deferred-tasks.ts
@@ -1,0 +1,89 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type http from "node:http";
+
+import { logger } from "../logger.js";
+
+type DeferredTask = () => Promise<void> | void;
+
+interface DeferredTaskContext {
+  readonly tasks: DeferredTask[];
+  responseDone: boolean;
+  flushScheduled: boolean;
+  flushing: boolean;
+}
+
+const storage = new AsyncLocalStorage<DeferredTaskContext>();
+
+export function runWithResponseDeferredTasks<T>(response: http.ServerResponse, callback: () => T): T {
+  const context: DeferredTaskContext = {
+    tasks: [],
+    responseDone: false,
+    flushScheduled: false,
+    flushing: false
+  };
+
+  const markResponseDone = () => {
+    context.responseDone = true;
+    scheduleFlush(context);
+  };
+
+  response.once("finish", markResponseDone);
+  response.once("close", markResponseDone);
+
+  return storage.run(context, callback);
+}
+
+export function deferUntilResponseFinished(task: DeferredTask): boolean {
+  const context = storage.getStore();
+  if (!context) {
+    return false;
+  }
+
+  context.tasks.push(task);
+  if (context.responseDone) {
+    scheduleFlush(context);
+  }
+  return true;
+}
+
+function scheduleFlush(context: DeferredTaskContext): void {
+  if (!context.responseDone || context.flushScheduled) {
+    return;
+  }
+
+  context.flushScheduled = true;
+  setImmediate(() => {
+    void flushTasks(context);
+  });
+}
+
+async function flushTasks(context: DeferredTaskContext): Promise<void> {
+  if (context.flushing) {
+    return;
+  }
+
+  context.flushScheduled = false;
+  context.flushing = true;
+  try {
+    while (context.tasks.length > 0) {
+      const task = context.tasks.shift();
+      if (!task) {
+        continue;
+      }
+
+      try {
+        await task();
+      } catch (error) {
+        logger.error("Deferred response task failed", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+  } finally {
+    context.flushing = false;
+  }
+
+  if (context.tasks.length > 0) {
+    scheduleFlush(context);
+  }
+}

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -9,6 +9,7 @@ import type { SlackAgentBridge } from "../services/slack/slack-agent-bridge.js";
 import { handleAdminRequest } from "./admin-routes.js";
 import { handleIntegrationRequest } from "./integration-routes.js";
 import { handleJobRequest } from "./job-routes.js";
+import { runWithResponseDeferredTasks } from "./response-deferred-tasks.js";
 import { handleSlackRequest } from "./slack-routes.js";
 
 export function createHttpHandler(options: {
@@ -19,7 +20,20 @@ export function createHttpHandler(options: {
   readonly config: AppConfig;
 }): (request: http.IncomingMessage, response: http.ServerResponse) => void {
   return (request, response) => {
-    void handleHttpRequest(request, response, options);
+    runWithResponseDeferredTasks(response, () => {
+      void handleHttpRequest(request, response, options).catch((error: unknown) => {
+        if (response.headersSent) {
+          response.destroy(error instanceof Error ? error : undefined);
+          return;
+        }
+
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          ok: false,
+          error: error instanceof Error ? error.message : String(error)
+        }));
+      });
+    });
   };
 }
 

--- a/src/services/deploy/release-deployment-service.ts
+++ b/src/services/deploy/release-deployment-service.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { logger } from "../../logger.js";
-import { execCommand } from "../../utils/exec.js";
+import { execCommand, spawnDetachedCommand } from "../../utils/exec.js";
 import { ensureDir, fileExists } from "../../utils/fs.js";
 
 const RELEASE_METADATA_FILENAME = ".broker-release.json";
@@ -85,6 +85,7 @@ export class ReleaseDeploymentService {
       readonly healthCheckIntervalMs?: number | undefined;
       readonly scheduleAdminRestart?: ((restart: () => Promise<void>) => void) | undefined;
       readonly exec?: typeof execCommand | undefined;
+      readonly spawnDetached?: typeof spawnDetachedCommand | undefined;
     }
   ) {}
 
@@ -314,13 +315,56 @@ export class ReleaseDeploymentService {
       return;
     }
 
-    await this.#restartLaunchdService({
-      reason,
-      plistPath: this.options.adminPlistPath,
-      launchdLabel: this.options.adminLaunchdLabel,
-      serviceName: "admin"
+    await this.#spawnDetachedAdminRestart(reason);
+  }
+
+  async #spawnDetachedAdminRestart(reason: string): Promise<void> {
+    if (!this.options.adminPlistPath || !this.options.adminLaunchdLabel) {
+      return;
+    }
+
+    if (!(await fileExists(this.options.adminPlistPath))) {
+      throw new Error(`Missing admin launchd plist: ${this.options.adminPlistPath}`);
+    }
+
+    const restartScriptPath = path.join(
+      this.options.currentReleasePath,
+      "scripts",
+      "ops",
+      "macos-launchd-restart.mjs"
+    );
+    if (!(await fileExists(restartScriptPath))) {
+      throw new Error(`Missing admin launchd restart helper: ${restartScriptPath}`);
+    }
+
+    const domain = `gui/${this.#uid}`;
+    const restartLogPath = path.join(this.options.serviceRoot, "logs", "admin-restart.log");
+    await ensureDir(path.dirname(restartLogPath));
+    this.#spawnDetached(process.execPath, [
+      restartScriptPath,
+      "--domain",
+      domain,
+      "--plist",
+      this.options.adminPlistPath,
+      "--label",
+      this.options.adminLaunchdLabel,
+      "--delay-ms",
+      "250",
+      "--log-file",
+      restartLogPath,
+      "--reason",
+      reason
+    ], {
+      cwd: this.options.serviceRoot
     });
-    await this.#assertAdminHealthy();
+
+    logger.info("Scheduled detached admin launchd restart", {
+      reason,
+      domain,
+      launchdLabel: this.options.adminLaunchdLabel,
+      plistPath: this.options.adminPlistPath,
+      helper: restartScriptPath
+    });
   }
 
   async #restartLaunchdService(options: {
@@ -604,5 +648,17 @@ export class ReleaseDeploymentService {
   ) {
     const exec = this.options.exec ?? execCommand;
     return await exec(command, args, options.cwd ? { cwd: options.cwd, env: process.env } : { env: process.env });
+  }
+
+  #spawnDetached(
+    command: string,
+    args: readonly string[],
+    options: {
+      readonly cwd?: string;
+      readonly env?: NodeJS.ProcessEnv;
+    } = {}
+  ): void {
+    const spawnDetached = this.options.spawnDetached ?? spawnDetachedCommand;
+    spawnDetached(command, args, options);
   }
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -42,3 +42,24 @@ export function execCommand(
     });
   });
 }
+
+export function spawnDetachedCommand(
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly cwd?: string;
+    readonly env?: NodeJS.ProcessEnv;
+  } = {}
+): void {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    detached: true,
+    stdio: "ignore"
+  });
+
+  child.on("error", () => {
+    // The caller cannot observe detached child failures; the child command should log its own errors.
+  });
+  child.unref();
+}

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "../src/config.js";
 import { renderAdminShellHtml } from "../src/admin-ui/admin-shell.js";
 import { stableSessionOrder } from "../src/admin-ui/session-order.js";
 import { renderAdminPage } from "../src/http/admin-page.js";
+import { deferUntilResponseFinished } from "../src/http/response-deferred-tasks.js";
 import { createHttpHandler } from "../src/http/router.js";
 
 describe("admin routes", () => {
@@ -78,6 +79,45 @@ describe("admin routes", () => {
       ok: true,
       status: "admin-ok"
     });
+  });
+
+  it("runs deploy restart callbacks only after the deploy response is finished", async () => {
+    const restartCalls: string[] = [];
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      deployRelease: async () => {
+        const deferred = deferUntilResponseFinished(async () => {
+          restartCalls.push("restart");
+        });
+        return {
+          ok: true,
+          deferred,
+          restartCount: restartCalls.length
+        };
+      }
+    });
+
+    const response = await fetch(`${baseUrl}/admin/api/deploy`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        ref: "main",
+        allow_active: true
+      })
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      deferred: true,
+      restartCount: 0
+    });
+
+    await waitFor(() => restartCalls.length === 1, "deferred restart callback");
   });
 
   it("renders auth profile management and session console sections in the admin page", async () => {
@@ -415,3 +455,14 @@ describe("admin routes", () => {
     ]);
   });
 });
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}

--- a/test/macos-launchd-restart.test.ts
+++ b/test/macos-launchd-restart.test.ts
@@ -1,0 +1,79 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("macOS launchd restart helper", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((directory) =>
+        fs.rm(directory, {
+          force: true,
+          recursive: true
+        })
+      )
+    );
+  });
+
+  it("runs bootout, bootstrap, then kickstart against the requested launchd service", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "launchd-restart-"));
+    tempDirs.push(tempRoot);
+
+    const fakeBin = path.join(tempRoot, "bin");
+    const commandLog = path.join(tempRoot, "commands.log");
+    const helperLog = path.join(tempRoot, "helper.log");
+    const plistPath = path.join(tempRoot, "admin.plist");
+    await fs.mkdir(fakeBin, { recursive: true });
+    await fs.writeFile(plistPath, "<plist/>", "utf8");
+    await fs.writeFile(
+      path.join(fakeBin, "launchctl"),
+      [
+        "#!/bin/sh",
+        "printf '%s\\n' \"$*\" >> \"$COMMAND_LOG\"",
+        "exit 0",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await fs.chmod(path.join(fakeBin, "launchctl"), 0o755);
+
+    const scriptPath = fileURLToPath(new URL("../scripts/ops/macos-launchd-restart.mjs", import.meta.url));
+    await execFileAsync(process.execPath, [
+      scriptPath,
+      "--domain",
+      "gui/501",
+      "--plist",
+      plistPath,
+      "--label",
+      "test.admin",
+      "--delay-ms",
+      "0",
+      "--log-file",
+      helperLog,
+      "--reason",
+      "test restart"
+    ], {
+      env: {
+        ...process.env,
+        COMMAND_LOG: commandLog,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`
+      }
+    });
+
+    await expect(fs.readFile(commandLog, "utf8")).resolves.toBe([
+      `bootout gui/501 ${plistPath}`,
+      `bootstrap gui/501 ${plistPath}`,
+      "kickstart -k gui/501/test.admin",
+      ""
+    ].join("\n"));
+    await expect(fs.readFile(helperLog, "utf8")).resolves.toContain("kickstart code=0");
+  });
+});

--- a/test/release-deployment-service.test.ts
+++ b/test/release-deployment-service.test.ts
@@ -325,8 +325,8 @@ describe("ReleaseDeploymentService", () => {
     await fs.writeFile(workerPlistPath, "<plist/>", "utf8");
 
     let workerLoaded = false;
-    let adminLoaded = false;
     const scheduledAdminRestarts: Array<() => Promise<void>> = [];
+    const detachedCommands: string[] = [];
     const commands: string[] = [];
 
     vi.stubGlobal("fetch", vi.fn(async () => ({
@@ -375,7 +375,9 @@ describe("ReleaseDeploymentService", () => {
         const releaseRoot = String(args[5]);
         const revision = String(args[6]);
         await fs.mkdir(path.join(releaseRoot, ".git"), { recursive: true });
+        await fs.mkdir(path.join(releaseRoot, "scripts", "ops"), { recursive: true });
         await fs.writeFile(path.join(releaseRoot, ".revision"), `${revision}\n`, "utf8");
+        await fs.writeFile(path.join(releaseRoot, "scripts", "ops", "macos-launchd-restart.mjs"), "", "utf8");
         return { stdout: "", stderr: "" };
       }
       if (command === "corepack") {
@@ -385,17 +387,11 @@ describe("ReleaseDeploymentService", () => {
         if (args[2] === workerPlistPath) {
           workerLoaded = false;
         }
-        if (args[2] === adminPlistPath) {
-          adminLoaded = false;
-        }
         return { stdout: "", stderr: "" };
       }
       if (command === "launchctl" && args[0] === "bootstrap") {
         if (args[2] === workerPlistPath) {
           workerLoaded = true;
-        }
-        if (args[2] === adminPlistPath) {
-          adminLoaded = true;
         }
         return { stdout: "", stderr: "" };
       }
@@ -405,9 +401,6 @@ describe("ReleaseDeploymentService", () => {
       if (command === "launchctl" && args[0] === "print") {
         const domain = String(args[1]);
         if (domain.endsWith("/test.worker") && workerLoaded) {
-          return { stdout: "loaded\n", stderr: "" };
-        }
-        if (domain.endsWith("/test.admin") && adminLoaded) {
           return { stdout: "loaded\n", stderr: "" };
         }
         throw new Error("not loaded");
@@ -433,6 +426,9 @@ describe("ReleaseDeploymentService", () => {
       scheduleAdminRestart: (restart) => {
         scheduledAdminRestarts.push(restart);
       },
+      spawnDetached: (command, args) => {
+        detachedCommands.push(`${command} ${args.join(" ")}`);
+      },
       exec
     });
 
@@ -443,11 +439,11 @@ describe("ReleaseDeploymentService", () => {
     expect(commands.some((command) => command.includes(`${currentReleasePath}`))).toBe(false);
 
     await scheduledAdminRestarts[0]!();
-    expect(adminLoaded).toBe(true);
-    expect(commands).toEqual(expect.arrayContaining([
-      expect.stringContaining(`launchctl bootstrap gui/`),
-      expect.stringContaining(adminPlistPath),
-      expect.stringContaining("test.admin")
-    ]));
+    expect(commands.some((command) => command.includes(adminPlistPath))).toBe(false);
+    expect(detachedCommands).toHaveLength(1);
+    expect(detachedCommands[0]).toContain("macos-launchd-restart.mjs");
+    expect(detachedCommands[0]).toContain("--plist " + adminPlistPath);
+    expect(detachedCommands[0]).toContain("--label test.admin");
+    expect(detachedCommands[0]).toContain("--domain gui/");
   });
 });


### PR DESCRIPTION
## Summary\n- defer deploy-triggered admin restarts until the HTTP response finishes\n- restart admin through a detached launchd helper so bootout cannot kill the process before bootstrap\n- add regression coverage for response-deferred restarts, detached admin restart spawning, and the helper command order\n\n## Tests\n- pnpm exec vitest run test/admin-routes.test.ts test/release-deployment-service.test.ts test/macos-launchd-restart.test.ts\n- pnpm build\n- pnpm test