### PR TITLE
[codex] Improve admin tool timeline summaries

### DIFF
--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -113,9 +113,9 @@
     .timeline-event:last-child { border-bottom: 0; }
     .timeline-main { min-width: 0; }
     .timeline-event strong { color: var(--text); font-size: 11px; }
-    .timeline-title { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 6px; align-items: baseline; min-width: 0; }
-    .timeline-title strong { white-space: nowrap; }
-    .timeline-title span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .timeline-title { display: flex; gap: 6px; align-items: baseline; min-width: 0; }
+    .timeline-title strong { min-width: 0; max-width: min(54ch, 58%); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .timeline-title span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .trace-meta { color: var(--muted); font-size: 9px; }
     .trace-details summary { cursor: pointer; color: var(--cyan); font-size: 9px; }
     .trace-details pre { margin: 4px 0 0; padding: 4px 6px; max-height: 160px; overflow: auto; white-space: pre-wrap; border: 1px solid var(--line); background: #030508; font: 10px/1.4 var(--mono); }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -322,10 +322,11 @@ function Timeline({ events }: { readonly events: readonly TimelineEvent[] }): Re
 function TimelineRow({ event }: { readonly event: TimelineEvent }): React.JSX.Element {
   const display = getTimelineEventDisplay(event);
   const badgeTone = statusTone(event.status === "failed" || event.status === "error" ? event.status : event.type);
+  const isCommandEvent = event.toolName === "exec_command";
   const meta = [
     event.status ? ("状态 " + statusLabel(event.status)) : "",
-    event.role ? ("角色 " + event.role) : "",
-    event.toolName ? ("工具 " + event.toolName) : "",
+    !isCommandEvent && event.role ? ("角色 " + event.role) : "",
+    !isCommandEvent && event.toolName ? ("工具 " + event.toolName) : "",
     event.detailTruncated ? "内容已截断" : ""
   ].filter(Boolean).join(" · ");
   return (
@@ -333,7 +334,7 @@ function TimelineRow({ event }: { readonly event: TimelineEvent }): React.JSX.El
       <span>{fmtTime(event.at)}</span>
       <Badge label={display.badgeLabel} tone={badgeTone} />
       <div className="timeline-main">
-        <div className="timeline-title"><strong>{display.title}</strong><span>{display.summary}</span></div>
+        <div className="timeline-title"><strong title={display.title}>{display.title}</strong><span title={display.summary}>{display.summary}</span></div>
         {meta ? <div className="trace-meta">{meta}</div> : null}
         {event.detail ? (
           <details className="trace-details">

--- a/src/admin-ui/timeline-display.ts
+++ b/src/admin-ui/timeline-display.ts
@@ -1,3 +1,9 @@
+import {
+  mergeToolTracePayloads,
+  parseToolTraceDetail,
+  summarizeToolTraceDisplay
+} from "../tool-trace-summary.js";
+
 export type TimelineEvent = Record<string, any>;
 
 export type TimelineEventDisplay = {
@@ -26,6 +32,22 @@ export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisp
       break;
     case "agent_tool_call":
     case "agent_tool_result": {
+      const toolDisplay = summarizeToolTraceDisplay({
+        eventType: type,
+        toolName: nonEmptyString(event.toolName),
+        status: nonEmptyString(event.status),
+        payload: mergeToolTracePayloads(event.metadata, parseToolTraceDetail(event.detail)),
+        fallbackTitle: rawTitle,
+        fallbackSummary: rawSummary
+      });
+      if (toolDisplay) {
+        return {
+          badgeLabel: toolDisplay.badgeLabel || badgeLabel,
+          title: toolDisplay.title,
+          summary: toolDisplay.summary
+        };
+      }
+
       const title = nonEmptyString(event.toolName) || rawSummary || rawTitle;
       const summary = title === rawSummary ? "" : (rawSummary || "");
       return { badgeLabel, title, summary };
@@ -42,6 +64,10 @@ export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisp
 }
 
 function timelineCategoryLabel(type: string, event: TimelineEvent): string {
+  if ((type === "agent_tool_call" || type === "agent_tool_result") && event.toolName === "exec_command") {
+    return "命令";
+  }
+
   const labels: Record<string, string> = {
     agent_input_received: "输入",
     agent_input_delivered: "输入",

--- a/src/services/agent-runtime/agent-trace-recorder.ts
+++ b/src/services/agent-runtime/agent-trace-recorder.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { logger } from "../../logger.js";
+import { summarizeToolTraceDisplay } from "../../tool-trace-summary.js";
 import type {
   AgentRuntimeEvent
 } from "./types.js";
@@ -151,29 +152,37 @@ export class AgentTraceRecorder {
           }
         }, now)];
       case "agent.tool.started":
-        return [this.#trace(session, event, {
-          type: "agent_tool_call",
-          title: "工具调用",
-          summary: event.name,
-          detail: stableJson(event.input),
-          status: "running",
-          role: "assistant",
-          toolName: event.name,
-          callId: event.callId,
-          turnId: event.turnId
-        }, now)];
+        {
+          const toolSummary = summarizeToolTrace(event.name, "agent_tool_call", "running", event.input);
+          return [this.#trace(session, event, {
+            type: "agent_tool_call",
+            title: toolSummary?.title ?? "工具调用",
+            summary: toolSummary?.summary ?? event.name,
+            detail: stableJson(event.input),
+            status: "running",
+            role: "assistant",
+            toolName: event.name,
+            callId: event.callId,
+            turnId: event.turnId,
+            metadata: toolSummary?.metadata
+          }, now)];
+        }
       case "agent.tool.completed":
-        return [this.#trace(session, event, {
-          type: "agent_tool_result",
-          title: "工具结果",
-          summary: event.name ?? event.callId,
-          detail: stableJson(event.output),
-          status: event.status,
-          role: "tool",
-          toolName: event.name,
-          callId: event.callId,
-          turnId: event.turnId
-        }, now)];
+        {
+          const toolSummary = summarizeToolTrace(event.name, "agent_tool_result", event.status, event.output);
+          return [this.#trace(session, event, {
+            type: "agent_tool_result",
+            title: toolSummary?.title ?? "工具结果",
+            summary: toolSummary?.summary ?? event.name ?? event.callId,
+            detail: stableJson(event.output),
+            status: event.status,
+            role: "tool",
+            toolName: event.name,
+            callId: event.callId,
+            turnId: event.turnId,
+            metadata: toolSummary?.metadata
+          }, now)];
+        }
       case "agent.usage.updated":
         return [this.#trace(session, event, {
           type: "agent_token_count",
@@ -316,6 +325,25 @@ function traceSequence(at: string): number {
 
 function summarizeTraceText(text: string): string {
   return text.replace(/\s+/g, " ").trim().slice(0, 220);
+}
+
+function summarizeToolTrace(
+  toolName: string | undefined,
+  eventType: "agent_tool_call" | "agent_tool_result",
+  status: string,
+  payload: unknown
+): {
+  readonly title: string;
+  readonly summary: string;
+  readonly metadata: JsonLike;
+} | undefined {
+  return summarizeToolTraceDisplay({
+    eventType,
+    toolName,
+    status,
+    payload,
+    fallbackSummary: toolName
+  });
 }
 
 function truncateTraceDetail(text: string): {

--- a/src/tool-trace-summary.ts
+++ b/src/tool-trace-summary.ts
@@ -1,0 +1,300 @@
+export interface ToolTraceDisplaySummary {
+  readonly badgeLabel?: string | undefined;
+  readonly title: string;
+  readonly summary: string;
+  readonly metadata: Record<string, string | number | boolean | null>;
+}
+
+export function summarizeToolTraceDisplay(options: {
+  readonly eventType: string;
+  readonly toolName?: string | undefined;
+  readonly status?: string | undefined;
+  readonly payload?: unknown;
+  readonly fallbackTitle?: string | undefined;
+  readonly fallbackSummary?: string | undefined;
+}): ToolTraceDisplaySummary | undefined {
+  const toolName = normalizeString(options.toolName ?? options.fallbackSummary ?? options.fallbackTitle);
+  if (toolName !== "exec_command") {
+    return undefined;
+  }
+
+  return summarizeExecCommandTrace({
+    eventType: options.eventType,
+    status: options.status,
+    payload: asRecord(options.payload),
+    fallbackTitle: toolName,
+    fallbackSummary: options.fallbackSummary
+  });
+}
+
+export function parseToolTraceDetail(detail: unknown): Record<string, unknown> | undefined {
+  if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+    return detail as Record<string, unknown>;
+  }
+
+  const text = normalizeString(detail);
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return asRecord(parsed);
+  } catch {
+    const command = extractJsonStringField(text, "command");
+    const cwd = extractJsonStringField(text, "cwd");
+    const aggregatedOutput = extractJsonStringField(text, "aggregatedOutput");
+    const error = extractJsonStringField(text, "error");
+    const exitCode = extractJsonNumberField(text, "exitCode");
+    const durationMs = extractJsonNumberField(text, "durationMs");
+    const status = extractJsonStringField(text, "status");
+    const compact = compactRecord({
+      command,
+      cwd,
+      aggregatedOutput,
+      error,
+      exitCode,
+      durationMs,
+      status
+    });
+    return Object.keys(compact).length ? compact : undefined;
+  }
+}
+
+export function mergeToolTracePayloads(...payloads: readonly unknown[]): Record<string, unknown> | undefined {
+  const merged: Record<string, unknown> = {};
+  for (const payload of payloads) {
+    const record = asRecord(payload);
+    if (!record) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(record)) {
+      if (value !== undefined && value !== null && merged[key] === undefined) {
+        merged[key] = value;
+      }
+    }
+  }
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function summarizeExecCommandTrace(options: {
+  readonly eventType: string;
+  readonly status?: string | undefined;
+  readonly payload?: Record<string, unknown> | undefined;
+  readonly fallbackTitle: string;
+  readonly fallbackSummary?: string | undefined;
+}): ToolTraceDisplaySummary {
+  const payload = options.payload ?? {};
+  const rawCommand = normalizeString(payload.command);
+  const command = rawCommand ? simplifyShellCommand(rawCommand) : "";
+  const title = compactText(command || options.fallbackTitle, 160);
+  const cwdLabel = summarizeCwd(
+    (rawCommand ? extractShellCdPath(rawCommand) : "") ||
+      normalizeString(payload.cwd)
+  );
+  const actionSummary = summarizeCommandActions(payload.commandActions);
+  const exitCode = normalizeNumber(payload.exitCode);
+  const durationMs = normalizeNumber(payload.durationMs);
+  const outputPreview = summarizeOutput(payload.aggregatedOutput ?? payload.output ?? payload.error);
+  const status = normalizeString(options.status ?? payload.status);
+  const isResult = options.eventType === "agent_tool_result";
+  const summaryParts = isResult
+    ? [
+        exitCode !== undefined ? `exit ${exitCode}` : statusLabel(status),
+        durationMs !== undefined ? formatDuration(durationMs) : "",
+        outputPreview ? `输出 ${outputPreview}` : "",
+        outputPreview ? "" : actionSummary,
+        outputPreview || actionSummary ? "" : cwdLabel
+      ]
+    : [
+        actionSummary,
+        cwdLabel ? `cwd ${cwdLabel}` : "",
+        statusLabel(status)
+      ];
+  const summary = compactText(summaryParts.filter(Boolean).join(" · ") || options.fallbackSummary || "", 220);
+
+  return {
+    badgeLabel: "命令",
+    title,
+    summary,
+    metadata: compactMetadataRecord({
+      command: rawCommand,
+      commandPreview: title,
+      cwd: normalizeString(payload.cwd),
+      cwdLabel,
+      actionSummary,
+      exitCode,
+      durationMs,
+      outputPreview
+    })
+  };
+}
+
+function simplifyShellCommand(command: string): string {
+  const shell = command.match(/^\/(?:bin|usr\/bin|opt\/homebrew\/bin)\/(?:zsh|bash|sh)\s+-lc\s+"([\s\S]*)"$/);
+  const body = shell ? unescapeShellQuotedArgument(shell[1] ?? "") : command;
+  const cdPath = extractShellCdPath(body);
+  const cdPrefix = cdPath ? body.match(/^cd\s+.+?\s+&&\s+/)?.[0] : undefined;
+  return (cdPrefix ? body.slice(cdPrefix.length) : body).trim();
+}
+
+function extractShellCdPath(command: string): string {
+  return command.match(/^\/(?:bin|usr\/bin|opt\/homebrew\/bin)\/(?:zsh|bash|sh)\s+-lc\s+"([\s\S]*)"$/)
+    ? extractShellCdPath(unescapeShellQuotedArgument(command.match(/^\/(?:bin|usr\/bin|opt\/homebrew\/bin)\/(?:zsh|bash|sh)\s+-lc\s+"([\s\S]*)"$/)?.[1] ?? ""))
+    : (command.match(/^cd\s+(.+?)\s+&&\s+/)?.[1] ?? "").trim();
+}
+
+function unescapeShellQuotedArgument(value: string): string {
+  return value.replace(/\\"/g, "\"").replace(/\\\\/g, "\\");
+}
+
+function summarizeCwd(cwd: string): string {
+  if (!cwd) {
+    return "";
+  }
+  const workspaceIndex = cwd.indexOf("/workspace/");
+  if (workspaceIndex >= 0) {
+    return compactText(cwd.slice(workspaceIndex + "/workspace/".length), 80);
+  }
+  if (cwd.endsWith("/workspace")) {
+    return "workspace";
+  }
+  return compactText(cwd.split("/").filter(Boolean).slice(-2).join("/"), 80);
+}
+
+function summarizeCommandActions(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) {
+    return "";
+  }
+
+  const firstType = normalizeString(asRecord(value[0])?.type);
+  const label = actionTypeLabel(firstType);
+  const names = value
+    .map((entry) => normalizeString(asRecord(entry)?.name) || summarizePath(normalizeString(asRecord(entry)?.path)))
+    .filter(Boolean)
+    .slice(0, 3);
+  const suffix = value.length > names.length ? ` +${value.length - names.length}` : "";
+  return compactText([label, names.join(", ") + suffix].filter(Boolean).join(" "), 120);
+}
+
+function actionTypeLabel(type: string): string {
+  const labels: Record<string, string> = {
+    read: "读取",
+    search: "搜索",
+    edit: "编辑",
+    write: "写入",
+    execute: "执行",
+    test: "测试"
+  };
+  return labels[type] || (type ? `${type}` : "操作");
+}
+
+function summarizePath(value: string): string {
+  if (!value) {
+    return "";
+  }
+  return value.split("/").filter(Boolean).slice(-1)[0] ?? "";
+}
+
+function summarizeOutput(value: unknown): string {
+  const text = normalizeString(value);
+  if (!text) {
+    return "";
+  }
+  const lines = text
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return compactText(lines[0] ?? text.trim(), 160);
+}
+
+function statusLabel(value: string): string {
+  const labels: Record<string, string> = {
+    completed: "完成",
+    done: "完成",
+    failed: "失败",
+    error: "失败",
+    running: "运行中",
+    inprogress: "运行中",
+    inflight: "运行中",
+    started: "已开始"
+  };
+  const normalized = value.toLowerCase().replace(/[^a-z]/g, "");
+  return labels[normalized] || "";
+}
+
+function formatDuration(value: number): string {
+  if (value < 1000) {
+    return `${Math.round(value)}ms`;
+  }
+  return `${(value / 1000).toFixed(value < 10_000 ? 1 : 0).replace(/\.0$/, "")}s`;
+}
+
+function compactText(value: string, maxLength: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(1, maxLength - 1)).trim()}…`;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function compactRecord(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined && value !== null && value !== "")
+  );
+}
+
+function compactMetadataRecord(record: Record<string, unknown>): Record<string, string | number | boolean | null> {
+  const compacted: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      if (value !== "") {
+        compacted[key] = value;
+      }
+    }
+  }
+  return compacted;
+}
+
+function extractJsonStringField(text: string, key: string): string {
+  const match = text.match(new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`));
+  if (!match) {
+    return "";
+  }
+
+  try {
+    return JSON.parse(`"${match[1]}"`) as string;
+  } catch {
+    return match[1] ?? "";
+  }
+}
+
+function extractJsonNumberField(text: string, key: string): number | undefined {
+  const match = text.match(new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*(-?\\d+(?:\\.\\d+)?)`));
+  return match ? normalizeNumber(match[1]) : undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -40,11 +40,66 @@ describe("admin session timeline display", () => {
       type: "agent_tool_call",
       title: "工具调用",
       summary: "exec_command",
-      toolName: "exec_command"
+      status: "running",
+      toolName: "exec_command",
+      detail: JSON.stringify({
+        command: "/bin/zsh -lc \"cd /tmp/workspace/cueboard && pnpm test\"",
+        cwd: "/tmp/workspace",
+        commandActions: [
+          {
+            type: "test",
+            name: "unit"
+          }
+        ]
+      })
     })).toEqual({
-      badgeLabel: "工具",
-      title: "exec_command",
-      summary: ""
+      badgeLabel: "命令",
+      title: "pnpm test",
+      summary: "测试 unit · cwd cueboard · 运行中"
+    });
+  });
+
+  it("shows command result output instead of repeating exec_command", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_tool_result",
+      title: "工具结果",
+      summary: "exec_command",
+      status: "completed",
+      toolName: "exec_command",
+      detail: JSON.stringify({
+        command: "/bin/zsh -lc \"cd /tmp/workspace/cueboard && rg -n \\\"bridge\\\" src | sed -n '1,20p'\"",
+        cwd: "/tmp/workspace",
+        exitCode: 0,
+        durationMs: 1240,
+        aggregatedOutput: "src/index.ts:12: bridge config\nsrc/app.ts:5: bridge app"
+      })
+    })).toEqual({
+      badgeLabel: "命令",
+      title: "rg -n \"bridge\" src | sed -n '1,20p'",
+      summary: "exit 0 · 1.2s · 输出 src/index.ts:12: bridge config"
+    });
+  });
+
+  it("can recover command summaries from truncated detail text", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_tool_result",
+      title: "工具结果",
+      summary: "exec_command",
+      status: "completed",
+      toolName: "exec_command",
+      detailTruncated: true,
+      detail: [
+        "{",
+        "  \"command\": \"/bin/zsh -lc \\\"cd /tmp/workspace/cueboard && pnpm build\\\"\",",
+        "  \"cwd\": \"/tmp/workspace\",",
+        "  \"exitCode\": 0,",
+        "  \"durationMs\": 980,",
+        "  \"aggregatedOutput\": \"dist/admin-ui/assets/admin-ui.js 250 kB\""
+      ].join("\n")
+    })).toEqual({
+      badgeLabel: "命令",
+      title: "pnpm build",
+      summary: "exit 0 · 980ms · 输出 dist/admin-ui/assets/admin-ui.js 250 kB"
     });
   });
 

--- a/test/agent-trace-recorder.test.ts
+++ b/test/agent-trace-recorder.test.ts
@@ -51,4 +51,88 @@ describe("AgentTraceRecorder", () => {
       recursive: true
     });
   });
+
+  it("records exec_command trace events with command and result summaries", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-recorder-tool-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const stateStore = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot
+    });
+
+    await sessions.load();
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "thread-1");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-1");
+
+    const recorder = new AgentTraceRecorder({
+      sessions
+    });
+    await recorder.record({
+      type: "agent.tool.started",
+      agentSessionId: "thread-1",
+      brokerSessionKey: session.key,
+      turnId: "turn-1",
+      callId: "call-1",
+      name: "exec_command",
+      input: {
+        command: "/bin/zsh -lc \"cd /tmp/workspace/app && pnpm test\"",
+        cwd: "/tmp/workspace",
+        commandActions: [
+          {
+            type: "test",
+            name: "unit"
+          }
+        ]
+      },
+      at: "2026-03-19T00:00:03.000Z"
+    });
+    await recorder.record({
+      type: "agent.tool.completed",
+      agentSessionId: "thread-1",
+      brokerSessionKey: session.key,
+      turnId: "turn-1",
+      callId: "call-1",
+      name: "exec_command",
+      output: {
+        command: "/bin/zsh -lc \"cd /tmp/workspace/app && pnpm test\"",
+        cwd: "/tmp/workspace",
+        exitCode: 0,
+        durationMs: 1200,
+        aggregatedOutput: "PASS unit tests"
+      },
+      status: "completed",
+      at: "2026-03-19T00:00:04.000Z"
+    });
+
+    expect(sessions.listAgentTraceEvents(session.key)).toEqual([
+      expect.objectContaining({
+        type: "agent_tool_call",
+        title: "pnpm test",
+        summary: "测试 unit · cwd app · 运行中",
+        metadata: expect.objectContaining({
+          commandPreview: "pnpm test",
+          cwdLabel: "app",
+          actionSummary: "测试 unit"
+        })
+      }),
+      expect.objectContaining({
+        type: "agent_tool_result",
+        title: "pnpm test",
+        summary: "exit 0 · 1.2s · 输出 PASS unit tests",
+        metadata: expect.objectContaining({
+          exitCode: 0,
+          durationMs: 1200,
+          outputPreview: "PASS unit tests"
+        })
+      })
+    ]);
+
+    stateStore.close();
+    await fs.rm(stateDir, {
+      force: true,
+      recursive: true
+    });
+  });
 });


### PR DESCRIPTION
## Summary\n- show exec_command timeline rows as actual command activity instead of repeating the tool name\n- parse existing trace detail JSON so old command events display command, cwd, exit code, duration, and output preview\n- persist richer tool trace titles/summaries for new runtime events\n- constrain timeline title overflow so long commands do not break layout\n\n## Tests\n- pnpm exec vitest run test/admin-session-view.test.ts test/agent-trace-recorder.test.ts test/admin-control-plane.e2e.test.ts test/admin-realtime.e2e.test.ts\n- pnpm build\n- pnpm test\n\n## Manual check\n- Ran the display formatter against a real live exec_command trace row; it rendered badge=命令, title=curl..., summary=exit 0 · 242ms · 输出 {"ok":true}.