### PR TITLE
[codex] Improve admin input timeline summaries

### DIFF
--- a/src/admin-ui/timeline-display.ts
+++ b/src/admin-ui/timeline-display.ts
@@ -1,3 +1,4 @@
+import { summarizeInputTraceDisplay } from "../input-trace-summary.js";
 import {
   mergeToolTracePayloads,
   parseToolTraceDetail,
@@ -13,7 +14,14 @@ export type TimelineEventDisplay = {
 };
 
 export function isTimelineEventVisible(event: TimelineEvent): boolean {
-  return String(event.type || "").toLowerCase() !== "agent_token_count";
+  const type = String(event.type || "").toLowerCase();
+  if (type === "agent_token_count") {
+    return false;
+  }
+  if (type === "agent_input_delivered" && String(event.status || "").toLowerCase() === "joined_active_turn") {
+    return false;
+  }
+  return true;
 }
 
 export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisplay {
@@ -23,6 +31,22 @@ export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisp
   const badgeLabel = timelineCategoryLabel(type, event);
 
   switch (type) {
+    case "agent_input_received": {
+      const inputDisplay = summarizeInputTraceDisplay({
+        source: nonEmptyString(event.metadata?.source) || nonEmptyString(event.source),
+        text: event.detail,
+        fallbackTitle: rawTitle,
+        fallbackSummary: rawSummary
+      });
+      if (inputDisplay) {
+        return {
+          badgeLabel: inputDisplay.badgeLabel || badgeLabel,
+          title: inputDisplay.title,
+          summary: inputDisplay.summary
+        };
+      }
+      break;
+    }
     case "agent_input_delivered":
     case "agent_turn_started":
     case "agent_turn_completed":

--- a/src/input-trace-summary.ts
+++ b/src/input-trace-summary.ts
@@ -1,0 +1,284 @@
+export interface InputTraceDisplaySummary {
+  readonly badgeLabel?: string | undefined;
+  readonly title: string;
+  readonly summary: string;
+  readonly metadata: Record<string, string | number | boolean | null>;
+}
+
+export function summarizeInputTraceDisplay(options: {
+  readonly source?: string | undefined;
+  readonly text?: unknown;
+  readonly fallbackTitle?: string | undefined;
+  readonly fallbackSummary?: string | undefined;
+}): InputTraceDisplaySummary | undefined {
+  const source = normalizeString(options.source);
+  const text = normalizeString(options.text);
+  const extracted = extractInputPayload(text);
+
+  if (extracted) {
+    return summarizePayload(extracted.payload, source, extracted.kind);
+  }
+
+  const fallbackSummary = normalizeString(options.fallbackSummary);
+  if (looksLikeBrokerWrapper(fallbackSummary)) {
+    return {
+      badgeLabel: "输入",
+      title: normalizeString(options.fallbackTitle) || "输入",
+      summary: "Broker 内部输入包装；未解析出 Slack 消息",
+      metadata: {
+        source
+      }
+    };
+  }
+
+  return undefined;
+}
+
+function summarizePayload(
+  payload: Record<string, unknown>,
+  source: string,
+  kind: InputPayloadKind
+): InputTraceDisplaySummary {
+  if (kind === "recovered_message_batch" || Array.isArray(payload.messages)) {
+    const messagePayloads = Array.isArray(payload.messages) ? payload.messages : [];
+    const messages = messagePayloads
+      .map((entry) => asRecord(entry))
+      .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+    const first = messages[0];
+    const firstText = compactText(extractSlackText(first), 180);
+    return {
+      badgeLabel: "恢复",
+      title: firstText || `恢复 ${messages.length} 条 Slack 消息`,
+      summary: `批量恢复 ${messages.length} 条消息`,
+      metadata: {
+        source,
+        batchMessageCount: messages.length
+      }
+    };
+  }
+
+  if (kind === "background_job_event" || payload.job) {
+    return summarizeBackgroundJobPayload(payload, source);
+  }
+
+  if (kind === "unexpected_turn_stop" || payload.previous_turn) {
+    return summarizeUnexpectedTurnStopPayload(payload, source);
+  }
+
+  const slackText = compactText(extractSlackText(payload), 220);
+  const sender = summarizeSender(asRecord(payload.sender));
+  const imageCount = Array.isArray(payload.images) ? payload.images.length : 0;
+  const summary = [
+    sender,
+    sourceLabel(normalizeString(payload.source) || source),
+    imageCount > 0 ? `${imageCount} 张图` : ""
+  ].filter(Boolean).join(" · ");
+
+  return {
+    badgeLabel: "Slack",
+    title: slackText || "[无文本消息]",
+    summary,
+    metadata: compactMetadataRecord({
+      source: normalizeString(payload.source) || source,
+      messageTs: normalizeString(payload.message_ts),
+      sender,
+      imageCount
+    })
+  };
+}
+
+type InputPayloadKind =
+  | "structured_message"
+  | "recovered_message_batch"
+  | "background_job_event"
+  | "unexpected_turn_stop";
+
+interface ExtractedInputPayload {
+  readonly kind: InputPayloadKind;
+  readonly payload: Record<string, unknown>;
+}
+
+function summarizeBackgroundJobPayload(payload: Record<string, unknown>, source: string): InputTraceDisplaySummary {
+  const job = asRecord(payload.job);
+  const jobKind = normalizeString(job?.job_kind);
+  const eventKind = normalizeString(job?.event_kind);
+  const jobId = normalizeString(job?.job_id);
+  return {
+    badgeLabel: "后台任务",
+    title: compactText(
+      normalizeString(payload.summary) ||
+        normalizeString(payload.details_text) ||
+        "后台任务事件",
+      220
+    ),
+    summary: [
+      jobKind,
+      eventKind,
+      jobId ? `Job ${jobId}` : ""
+    ].filter(Boolean).join(" · "),
+    metadata: compactMetadataRecord({
+      source: normalizeString(payload.source) || source,
+      messageTs: normalizeString(payload.message_ts),
+      jobKind,
+      eventKind,
+      jobId
+    })
+  };
+}
+
+function summarizeUnexpectedTurnStopPayload(payload: Record<string, unknown>, source: string): InputTraceDisplaySummary {
+  const previousTurn = asRecord(payload.previous_turn);
+  const reason = normalizeString(payload.reason);
+  return {
+    badgeLabel: "提醒",
+    title: "回合异常停止",
+    summary: compactText(reason || "前一个回合没有明确结束状态", 220),
+    metadata: compactMetadataRecord({
+      source: normalizeString(payload.source) || source,
+      messageTs: normalizeString(payload.message_ts),
+      previousTurnId: normalizeString(previousTurn?.turn_id)
+    })
+  };
+}
+
+function extractInputPayload(text: string): ExtractedInputPayload | undefined {
+  if (!text) {
+    return undefined;
+  }
+
+  const namedPayload =
+    extractNamedJsonPayload(text, "recovered_message_batch_json", "recovered_message_batch") ??
+    extractNamedJsonPayload(text, "background_job_event_json", "background_job_event") ??
+    extractNamedJsonPayload(text, "unexpected_turn_stop_json", "unexpected_turn_stop");
+  if (namedPayload) {
+    return namedPayload;
+  }
+
+  const blocks = extractJsonBlocks(text)
+    .map((block) => parseJsonObject(block))
+    .filter((payload): payload is Record<string, unknown> => Boolean(payload));
+  const currentMessage = [...blocks].reverse().find((payload) =>
+    normalizeString(payload.source) !== "thread_history" &&
+      (payload.text !== undefined || payload.text_with_resolved_mentions !== undefined || payload.images !== undefined)
+  );
+  const payload = currentMessage ?? blocks[blocks.length - 1];
+  return payload ? {
+    kind: "structured_message",
+    payload
+  } : undefined;
+}
+
+function extractNamedJsonPayload(
+  text: string,
+  label: string,
+  kind: InputPayloadKind
+): ExtractedInputPayload | undefined {
+  const index = text.indexOf(label);
+  if (index < 0) {
+    return undefined;
+  }
+
+  const afterLabel = text.slice(index + label.length);
+  const block = extractJsonBlocks(afterLabel)[0];
+  const payload = block ? parseJsonObject(block) : undefined;
+  return payload ? {
+    kind,
+    payload
+  } : undefined;
+}
+
+function extractJsonBlocks(text: string): string[] {
+  const blocks: string[] = [];
+  const regex = /```json\s*([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    if (match[1]?.trim()) {
+      blocks.push(match[1].trim());
+    }
+  }
+  return blocks;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | undefined {
+  try {
+    return asRecord(JSON.parse(text));
+  } catch {
+    return undefined;
+  }
+}
+
+function extractSlackText(payload: Record<string, unknown> | undefined): string {
+  if (!payload) {
+    return "";
+  }
+  const text = normalizeString(payload.text_with_resolved_mentions) ||
+    normalizeString(payload.text) ||
+    normalizeString(payload.summary);
+  return text === "[no text body]" ? "" : text;
+}
+
+function summarizeSender(sender: Record<string, unknown> | undefined): string {
+  if (!sender) {
+    return "";
+  }
+  return normalizeString(sender.display_name) ||
+    normalizeString(sender.real_name) ||
+    normalizeString(sender.username) ||
+    normalizeString(sender.mention) ||
+    normalizeString(sender.user_id) ||
+    normalizeString(sender.sender_id);
+}
+
+function sourceLabel(source: string): string {
+  const labels: Record<string, string> = {
+    app_mention: "提及",
+    direct_message: "私信",
+    thread_reply: "线程回复",
+    slack_user: "Slack",
+    broker_recovery: "恢复",
+    background_job: "后台任务",
+    background_job_event: "后台任务"
+  };
+  return labels[source] || source;
+}
+
+function looksLikeBrokerWrapper(value: string): boolean {
+  return value.startsWith("A newer Slack message arrived") ||
+    value.startsWith("The broker detected Slack thread messages") ||
+    value.startsWith("The broker server restarted or reconnected");
+}
+
+function compactText(value: string, maxLength: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(1, maxLength - 1)).trim()}…`;
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function compactMetadataRecord(record: Record<string, unknown>): Record<string, string | number | boolean | null> {
+  const compacted: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      if (value !== "" && value !== 0) {
+        compacted[key] = value;
+      }
+    }
+  }
+  return compacted;
+}

--- a/src/services/agent-runtime/agent-trace-recorder.ts
+++ b/src/services/agent-runtime/agent-trace-recorder.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { summarizeInputTraceDisplay } from "../../input-trace-summary.js";
 import { logger } from "../../logger.js";
 import { summarizeToolTraceDisplay } from "../../tool-trace-summary.js";
 import type {
@@ -97,18 +98,27 @@ export class AgentTraceRecorder {
           status: "completed"
         }, now)];
       case "agent.input.received":
-        return [this.#trace(session, event, {
-          type: "agent_input_received",
-          title: inputTitle(event.source),
-          summary: event.textPreview,
-          detail: event.text,
-          status: "received",
-          role: event.source === "runtime_reminder" ? "system" : "user",
-          metadata: {
-            inputId: event.inputId,
-            source: event.source
-          }
-        }, now)];
+        {
+          const inputSummary = summarizeInputTraceDisplay({
+            source: event.source,
+            text: event.text,
+            fallbackTitle: inputTitle(event.source),
+            fallbackSummary: event.textPreview
+          });
+          return [this.#trace(session, event, {
+            type: "agent_input_received",
+            title: inputSummary?.title ?? inputTitle(event.source),
+            summary: inputSummary?.summary ?? event.textPreview,
+            detail: event.text,
+            status: "received",
+            role: event.source === "runtime_reminder" ? "system" : "user",
+            metadata: {
+              inputId: event.inputId,
+              source: event.source,
+              ...(inputSummary?.metadata ?? {})
+            }
+          }, now)];
+        }
       case "agent.input.delivered":
         return [this.#trace(session, event, {
           type: "agent_input_delivered",

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -59,6 +59,120 @@ describe("admin session timeline display", () => {
     });
   });
 
+  it("shows the Slack payload instead of the broker input wrapper", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_input_received",
+      title: "用户消息",
+      summary: "A newer Slack message arrived while the current turn is still active. Treat it as the latest instruction...",
+      metadata: {
+        source: "slack_user"
+      },
+      detail: [
+        "A newer Slack message arrived while the current turn is still active.",
+        "Treat it as the latest instruction and adjust the ongoing work accordingly.",
+        "",
+        "Current Slack message requiring a response:",
+        "A new message arrived in the active Slack thread. Carefully judge whether it requires a reply or action from you.",
+        "structured_message_json:",
+        "```json",
+        JSON.stringify({
+          source: "app_mention",
+          message_ts: "1778316208.809479",
+          sender: {
+            kind: "user",
+            user_id: "U123",
+            mention: "<@U123>",
+            display_name: "Jc"
+          },
+          text: "<@U0ALY77RMJL> 结合 willow repo，分析图中问题",
+          text_with_resolved_mentions: "@codex-3720 结合 willow repo，分析图中问题",
+          images: []
+        }, null, 2),
+        "```"
+      ].join("\n")
+    })).toEqual({
+      badgeLabel: "Slack",
+      title: "@codex-3720 结合 willow repo，分析图中问题",
+      summary: "Jc · 提及"
+    });
+  });
+
+  it("hides joined-active-turn input delivery rows because they duplicate the input row", () => {
+    expect(isTimelineEventVisible({
+      type: "agent_input_delivered",
+      status: "joined_active_turn",
+      title: "输入已送达",
+      summary: "进入当前回合"
+    })).toBe(false);
+
+    expect(isTimelineEventVisible({
+      type: "agent_input_delivered",
+      status: "started_turn",
+      title: "输入已送达",
+      summary: "启动新回合"
+    })).toBe(true);
+  });
+
+  it("summarizes broker-managed background job input events", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_input_received",
+      title: "后台任务事件",
+      summary: "A broker-managed background job reported a new asynchronous event for this session.",
+      metadata: {
+        source: "background_job"
+      },
+      detail: [
+        "A broker-managed background job reported a new asynchronous event for this session.",
+        "background_job_event_json:",
+        "```json",
+        JSON.stringify({
+          source: "background_job_event",
+          message_ts: "1778316208.809479",
+          job: {
+            job_id: "job-1",
+            job_kind: "watch_ci",
+            event_kind: "state_changed"
+          },
+          summary: "CI turned green."
+        }, null, 2),
+        "```"
+      ].join("\n")
+    })).toEqual({
+      badgeLabel: "后台任务",
+      title: "CI turned green.",
+      summary: "watch_ci · state_changed · Job job-1"
+    });
+  });
+
+  it("summarizes unexpected turn stop reminders instead of broker instructions", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_input_received",
+      title: "Runtime 提醒",
+      summary: "The previous run for this Slack thread appears to have stopped unexpectedly.",
+      metadata: {
+        source: "runtime_reminder"
+      },
+      detail: [
+        "The previous run for this Slack thread appears to have stopped unexpectedly.",
+        "unexpected_turn_stop_json:",
+        "```json",
+        JSON.stringify({
+          source: "unexpected_turn_stop",
+          message_ts: "1778316208.809479",
+          previous_turn: {
+            turn_id: "turn-1"
+          },
+          reason: "The previous run ended without an explicit final, block, or wait state."
+        }, null, 2),
+        "```"
+      ].join("\n")
+    })).toEqual({
+      badgeLabel: "提醒",
+      title: "回合异常停止",
+      summary: "The previous run ended without an explicit final, block, or wait state."
+    });
+  });
+
   it("shows command result output instead of repeating exec_command", () => {
     expect(getTimelineEventDisplay({
       type: "agent_tool_result",

--- a/test/agent-trace-recorder.test.ts
+++ b/test/agent-trace-recorder.test.ts
@@ -135,4 +135,74 @@ describe("AgentTraceRecorder", () => {
       recursive: true
     });
   });
+
+  it("records Slack input trace events with the user message instead of the broker wrapper", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-recorder-input-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const stateStore = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot
+    });
+
+    await sessions.load();
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "thread-1");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-1");
+
+    const recorder = new AgentTraceRecorder({
+      sessions
+    });
+    await recorder.record({
+      type: "agent.input.received",
+      inputId: "input-1",
+      agentSessionId: "thread-1",
+      brokerSessionKey: session.key,
+      source: "slack_user",
+      textPreview: "A newer Slack message arrived while the current turn is still active. Treat it as the latest instruction...",
+      text: [
+        "A newer Slack message arrived while the current turn is still active.",
+        "Treat it as the latest instruction and adjust the ongoing work accordingly.",
+        "",
+        "A new message arrived in the active Slack thread. Carefully judge whether it requires a reply or action from you.",
+        "structured_message_json:",
+        "```json",
+        JSON.stringify({
+          source: "app_mention",
+          message_ts: "1778316208.809479",
+          sender: {
+            kind: "user",
+            user_id: "U123",
+            mention: "<@U123>",
+            display_name: "Jc"
+          },
+          text: "<@U0ALY77RMJL> 结合 willow repo，分析图中问题",
+          text_with_resolved_mentions: "@codex-3720 结合 willow repo，分析图中问题",
+          images: []
+        }, null, 2),
+        "```"
+      ].join("\n"),
+      at: "2026-03-19T00:00:03.000Z"
+    });
+
+    expect(sessions.listAgentTraceEvents(session.key)).toEqual([
+      expect.objectContaining({
+        type: "agent_input_received",
+        title: "@codex-3720 结合 willow repo，分析图中问题",
+        summary: "Jc · 提及",
+        metadata: expect.objectContaining({
+          inputId: "input-1",
+          source: "app_mention",
+          sender: "Jc",
+          messageTs: "1778316208.809479"
+        })
+      })
+    ]);
+
+    stateStore.close();
+    await fs.rm(stateDir, {
+      force: true,
+      recursive: true
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- parse broker input wrappers so admin timeline shows the actual Slack message payload instead of internal delivery instructions
- hide duplicate `joined_active_turn` input delivery rows from the timeline
- summarize background-job and unexpected-turn input events with structured labels
- persist richer input trace summaries for newly recorded events

## Validation
- `pnpm exec vitest run test/admin-session-view.test.ts test/agent-trace-recorder.test.ts test/e2e-broker.test.ts`
- `pnpm build`
- `pnpm test`
- checked a live old `agent_input_received` DB row through the built formatter: `Slack / 这边也暂停 / Haowen Sun · 线程回复`