### PR TITLE
Add admin session permalink pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ SLACK_PROGRESS_REMINDER_REPEAT_MS=120000
 # Service storage
 PORT=3000
 SERVICE_NAME=slack-codex-broker
+# Optional admin origin used in Slack session trace links.
+# ADMIN_BASE_URL=https://admin.example.com
 # Optional: protects /admin/api/* when set.
 # BROKER_ADMIN_TOKEN=change-me
 DATA_ROOT=/app/.data

--- a/src/admin-session-url.ts
+++ b/src/admin-session-url.ts
@@ -1,0 +1,22 @@
+export function buildAdminSessionUrl(adminBaseUrl: string, sessionKey: string): string {
+  const base = normalizeAdminBaseUrl(adminBaseUrl);
+  const path = `/admin/sessions/${encodeURIComponent(sessionKey)}`;
+  return `${base}${path}`;
+}
+
+function normalizeAdminBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "http://127.0.0.1:3000";
+  }
+
+  try {
+    const url = new URL(trimmed);
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -65,6 +65,8 @@
     .session-master-detail { height: 100%; min-height: 0; display: grid; grid-template-columns: minmax(320px, 420px) minmax(0, 1fr); gap: 1px; align-items: stretch; background: var(--line); }
     .session-master-detail > .panel { display: flex; flex-direction: column; }
     .session-master-detail > * { background: var(--panel); }
+    .session-permalink-layout { height: 100%; min-height: 0; display: flex; }
+    .session-permalink-panel { flex: 1; display: flex; flex-direction: column; }
     .session-list { flex: 1; min-height: 0; overflow: auto; }
     .session-row-button { position: relative; display: block; width: 100%; padding: 0; border: 0; border-bottom: 1px solid var(--line); background: transparent; color: var(--text); text-align: left; cursor: pointer; }
     .session-row-button::before { content: ""; position: absolute; top: 0; bottom: 0; left: 0; width: 2px; background: transparent; }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -18,11 +18,20 @@ type UiState = {
 };
 
 type SessionRecord = Record<string, any>;
-type TimelinePayload = { readonly events?: TimelineEvent[]; readonly trace?: Record<string, any> } | TimelineEvent[];
+type TimelinePayload = {
+  readonly events?: TimelineEvent[];
+  readonly trace?: Record<string, any>;
+  readonly session?: SessionRecord;
+} | TimelineEvent[];
 
 const sessionFilters = ["ongoing", "all", "active", "inbound", "jobs", "issues", "usage"];
 
 export function AdminSessionsView(): React.JSX.Element {
+  const permalinkSessionKey = readPermalinkSessionKey();
+  if (permalinkSessionKey) {
+    return <SessionPermalinkView sessionKey={permalinkSessionKey} />;
+  }
+
   const snapshot = useSyncExternalStore(subscribeAdminStatus, getAdminStatusSnapshot, getAdminStatusSnapshot);
   const status = (snapshot.status || {}) as Record<string, any>;
   const sessions = (status.state?.sessions || []) as SessionRecord[];
@@ -129,6 +138,61 @@ export function AdminSessionsView(): React.JSX.Element {
   );
 }
 
+function SessionPermalinkView({ sessionKey }: { readonly sessionKey: string }): React.JSX.Element {
+  const snapshot = useSyncExternalStore(subscribeAdminStatus, getAdminStatusSnapshot, getAdminStatusSnapshot);
+  const sessions = ((snapshot.status || {}) as Record<string, any>).state?.sessions || [];
+  const realtimeSession = (sessions as SessionRecord[]).find((session) => session.key === sessionKey) || null;
+  const timelineSnapshot = useSyncExternalStore(
+    (listener) => subscribeTimeline(sessionKey, listener),
+    () => getTimelineSnapshot(sessionKey),
+    () => getTimelineSnapshot(sessionKey)
+  );
+  const timelinePayload = timelineSnapshot.payload as TimelinePayload | null;
+  const [fetchedSession, setFetchedSession] = useState<SessionRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const session = realtimeSession || fetchedSession || (Array.isArray(timelinePayload) ? null : timelinePayload?.session) || null;
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    void requestJson(sessionTimelineApiPath(sessionKey))
+      .then((nextPayload) => {
+        if (cancelled) return;
+        const payload = nextPayload as TimelinePayload;
+        publishTimelinePayload(sessionKey, payload);
+        if (!Array.isArray(payload) && payload.session) {
+          setFetchedSession(payload.session);
+        }
+      })
+      .catch((nextError: unknown) => {
+        if (!cancelled) setError(nextError instanceof Error ? nextError.message : String(nextError));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionKey]);
+
+  return (
+    <div className="session-permalink-layout">
+      <section className="panel session-detail-panel session-permalink-panel">
+        <div className="panel-head">
+          <div className="panel-title">会话活动</div>
+          <a className="link-button" href="/admin">返回会话索引</a>
+        </div>
+        <div className="panel-body">
+          {error ? (
+            <div className="empty-state">{error}</div>
+          ) : session ? (
+            <SessionDetail key={session.key} session={session} />
+          ) : (
+            <div className="empty-state">正在加载会话</div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
 function SessionRow({ session, selected, onSelect }: {
   readonly session: SessionRecord;
   readonly selected: boolean;
@@ -181,6 +245,7 @@ function SessionDetail({ session }: {
         </div>
         <div className="session-detail-actions">
           <Badge label={state.label} tone={state.tone} />
+          <a className="link-button" href={adminSessionPath(String(session.key || ""))}>打开 Session 页面</a>
           {session.threadUrl ? (
             <a className="link-button" href={session.threadUrl} target="_blank" rel="noreferrer">打开 Slack Thread</a>
           ) : null}
@@ -235,7 +300,7 @@ function SessionTimeline({ session }: {
   useEffect(() => {
     let cancelled = false;
     setError(null);
-    void requestJson("/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/timeline")
+    void requestJson(sessionTimelineApiPath(sessionKey))
       .then((nextPayload) => {
         if (cancelled) return;
         publishTimelinePayload(sessionKey, nextPayload as TimelinePayload);
@@ -550,6 +615,30 @@ async function requestJson(path: string): Promise<unknown> {
   const payload = await response.json().catch(() => ({})) as Record<string, any>;
   if (!response.ok || payload.ok === false) throw new Error(payload.error || response.statusText || "请求失败");
   return payload;
+}
+
+function sessionTimelineApiPath(sessionKey: string): string {
+  return "/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/timeline";
+}
+
+function adminSessionPath(sessionKey: string): string {
+  return "/admin/sessions/" + encodeURIComponent(sessionKey);
+}
+
+function readPermalinkSessionKey(): string | null {
+  const prefix = "/admin/sessions/";
+  if (!window.location.pathname.startsWith(prefix)) {
+    return null;
+  }
+  const encoded = window.location.pathname.slice(prefix.length).split("/")[0] || "";
+  if (!encoded) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
 }
 
 function loadUiState(): UiState {

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -18,7 +18,7 @@ export async function handleAdminRequest(
     readonly config: AppConfig;
   }
 ): Promise<boolean> {
-  if (method === "GET" && url.pathname === "/admin") {
+  if (method === "GET" && (url.pathname === "/admin" || url.pathname.startsWith("/admin/sessions/"))) {
     response.writeHead(200, { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" });
     response.end(renderAdminPage({
       serviceName: options.config.serviceName

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -1025,6 +1025,7 @@ export class AdminService {
       lastTurnSignalReason: session.lastTurnSignalReason ?? null,
       lastTurnSignalAt: session.lastTurnSignalAt ?? null,
       lastSlackReplyAt: session.lastSlackReplyAt ?? null,
+      sessionPageLinkPostedAt: session.sessionPageLinkPostedAt ?? null,
       lastObservedMessageTs: session.lastObservedMessageTs ?? null,
       lastDeliveredMessageTs: session.lastDeliveredMessageTs ?? null,
       openInboundCount: related.openInbound.length,

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -191,6 +191,16 @@ export class SessionManager {
     });
   }
 
+  async setSessionPageLinkPostedAt(
+    channelId: string,
+    rootThreadTs: string,
+    sessionPageLinkPostedAt: string
+  ): Promise<SlackSessionRecord> {
+    return await this.#patchSession(channelId, rootThreadTs, {
+      sessionPageLinkPostedAt
+    });
+  }
+
   async recordTurnSignal(
     channelId: string,
     rootThreadTs: string,

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { buildAdminSessionUrl } from "../../admin-session-url.js";
 import type { AppConfig } from "../../config.js";
 import { logger } from "../../logger.js";
 import { SessionManager } from "../session-manager.js";
@@ -737,6 +738,34 @@ export class SlackConversationService {
     return ts;
   }
 
+  async #postSessionPageLinkIfNeeded(session: SlackSessionRecord): Promise<SlackSessionRecord> {
+    if (session.sessionPageLinkPostedAt) {
+      return session;
+    }
+
+    const url = buildAdminSessionUrl(this.#config.adminBaseUrl, session.key);
+    try {
+      await this.#postBotThreadMessage(
+        session.channelId,
+        session.rootThreadTs,
+        `已开始处理。<${url}|查看 Bot 行为时间线>`,
+        { alreadyFormatted: true }
+      );
+      return await this.#sessions.setSessionPageLinkPostedAt(
+        session.channelId,
+        session.rootThreadTs,
+        new Date().toISOString()
+      );
+    } catch (error) {
+      logger.warn("Failed to post admin session link into Slack thread", {
+        sessionKey: session.key,
+        adminSessionUrl: url,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return session;
+    }
+  }
+
   async #recordStopSignal(
     session: SlackSessionRecord,
     signal: {
@@ -773,6 +802,7 @@ export class SlackConversationService {
       return;
     }
 
+    latestSession = await this.#postSessionPageLinkIfNeeded(latestSession);
     this.#setAssistantThinking(latestSession);
     if (latestSession.activeTurnId) {
       try {
@@ -1062,6 +1092,7 @@ export class SlackConversationService {
           continue;
         }
 
+        session = await this.#postSessionPageLinkIfNeeded(session);
         const dispatchMessages = next.recoveryKind ? pendingMessages : [pendingMessages[0]!];
         const slackInput = next.recoveryKind
           ? await this.#inboundStore.createRecoveredBatchInput(session, dispatchMessages, next.recoveryKind)

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -19,7 +19,7 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 9;
+export const CURRENT_STATE_SCHEMA_VERSION = 10;
 const ADMIN_EVENT_RETENTION_LIMIT = 20_000;
 
 type SqlValue = string | number | bigint | null;
@@ -52,6 +52,7 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
           last_observed_message_ts TEXT,
           last_delivered_message_ts TEXT,
           last_slack_reply_at TEXT,
+          session_page_link_posted_at TEXT,
           last_turn_signal_turn_id TEXT,
           last_turn_signal_kind TEXT,
           last_turn_signal_reason TEXT,
@@ -275,6 +276,13 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
     up(database) {
       createAdminEventsSchema(database);
     }
+  },
+  {
+    version: 10,
+    name: "session_page_link_announcement",
+    up(database) {
+      repairSessionPageLinkAnnouncementSchema(database);
+    }
   }
 ];
 
@@ -317,6 +325,17 @@ function repairSessionChannelMetadataSchema(database: DatabaseSync): void {
   }
   if (!columns.has("channel_type")) {
     database.exec("ALTER TABLE sessions ADD COLUMN channel_type TEXT");
+  }
+}
+
+function repairSessionPageLinkAnnouncementSchema(database: DatabaseSync): void {
+  if (!tableExists(database, "sessions")) {
+    return;
+  }
+
+  const columns = tableColumns(database, "sessions");
+  if (!columns.has("session_page_link_posted_at")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN session_page_link_posted_at TEXT");
   }
 }
 
@@ -979,12 +998,12 @@ export class StateStore {
       INSERT INTO sessions (
         key, channel_id, channel_name, channel_type, root_thread_ts, workspace_path, created_at, updated_at,
         agent_session_id, active_turn_id, active_turn_started_at,
-        last_observed_message_ts, last_delivered_message_ts, last_slack_reply_at,
+        last_observed_message_ts, last_delivered_message_ts, last_slack_reply_at, session_page_link_posted_at,
         last_turn_signal_turn_id, last_turn_signal_kind, last_turn_signal_reason, last_turn_signal_at,
         co_author_candidate_user_ids, co_author_candidate_revision,
         co_author_confirmed_user_ids, co_author_confirmed_revision,
         co_author_ignore_missing_revision, co_author_prompt_revision, co_author_prompted_at
-      ) VALUES (${placeholders(25)})
+      ) VALUES (${placeholders(26)})
       ON CONFLICT(key) DO UPDATE SET
         channel_id = excluded.channel_id,
         channel_name = excluded.channel_name,
@@ -999,6 +1018,7 @@ export class StateStore {
         last_observed_message_ts = excluded.last_observed_message_ts,
         last_delivered_message_ts = excluded.last_delivered_message_ts,
         last_slack_reply_at = excluded.last_slack_reply_at,
+        session_page_link_posted_at = excluded.session_page_link_posted_at,
         last_turn_signal_turn_id = excluded.last_turn_signal_turn_id,
         last_turn_signal_kind = excluded.last_turn_signal_kind,
         last_turn_signal_reason = excluded.last_turn_signal_reason,
@@ -1025,6 +1045,7 @@ export class StateStore {
       record.lastObservedMessageTs ?? null,
       record.lastDeliveredMessageTs ?? null,
       record.lastSlackReplyAt ?? null,
+      record.sessionPageLinkPostedAt ?? null,
       record.lastTurnSignalTurnId ?? null,
       record.lastTurnSignalKind ?? null,
       record.lastTurnSignalReason ?? null,
@@ -1350,6 +1371,7 @@ export class StateStore {
       lastObservedMessageTs: optionalStringColumn(row, "last_observed_message_ts"),
       lastDeliveredMessageTs: optionalStringColumn(row, "last_delivered_message_ts"),
       lastSlackReplyAt: optionalStringColumn(row, "last_slack_reply_at"),
+      sessionPageLinkPostedAt: optionalStringColumn(row, "session_page_link_posted_at"),
       lastTurnSignalTurnId: optionalStringColumn(row, "last_turn_signal_turn_id"),
       lastTurnSignalKind: optionalStringColumn(row, "last_turn_signal_kind") as SlackSessionRecord["lastTurnSignalKind"],
       lastTurnSignalReason: optionalStringColumn(row, "last_turn_signal_reason"),
@@ -1541,6 +1563,7 @@ export class StateStore {
       lastObservedMessageTs: session.lastObservedMessageTs,
       lastDeliveredMessageTs: session.lastDeliveredMessageTs,
       lastSlackReplyAt: session.lastSlackReplyAt,
+      sessionPageLinkPostedAt: session.sessionPageLinkPostedAt,
       lastTurnSignalTurnId: session.lastTurnSignalTurnId,
       lastTurnSignalKind: session.lastTurnSignalKind,
       lastTurnSignalReason: session.lastTurnSignalReason,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface SlackSessionRecord {
   readonly lastObservedMessageTs?: string | undefined;
   readonly lastDeliveredMessageTs?: string | undefined;
   readonly lastSlackReplyAt?: string | undefined;
+  readonly sessionPageLinkPostedAt?: string | undefined;
   readonly lastTurnSignalTurnId?: string | undefined;
   readonly lastTurnSignalKind?: SlackTurnSignalKind | undefined;
   readonly lastTurnSignalReason?: string | undefined;

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -180,6 +180,33 @@ describe("admin routes", () => {
     expect(shell).not.toContain("/admin/api/runtime-files");
   });
 
+  it("serves a deep-linkable admin session page", async () => {
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      getStatus: async () => ({ ok: true, status: "admin-ok" }),
+      addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      activateAuthProfile: async () => ({ ok: true }),
+      deployRelease: async () => ({ ok: true }),
+      rollbackRelease: async () => ({ ok: true })
+    });
+
+    const page = await fetch(`${baseUrl}/admin/sessions/${encodeURIComponent("C123:111.222")}`);
+    expect(page.status).toBe(200);
+    const html = await page.text();
+    const sessionViewSource = await fs.readFile(new URL("../src/admin-ui/session-view.tsx", import.meta.url), "utf8");
+
+    expect(html).toContain('id="admin-root"');
+    expect(html).toContain('/admin/assets/admin-ui.js');
+    expect(sessionViewSource).toContain("readPermalinkSessionKey");
+    expect(sessionViewSource).toContain("SessionPermalinkView");
+    expect(sessionViewSource).toContain("/admin/api/sessions/\" + encodeURIComponent(sessionKey) + \"/timeline");
+  });
+
   it("persists session ui state in the admin page script", async () => {
     const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -45,6 +45,7 @@ describe("loadConfig", () => {
     expect(config.isolatedMcpServers).toEqual(["linear", "notion"]);
     expect(config.codexDisabledMcpServers).toEqual(["*", "linear", "notion"]);
     expect(config.tempadLinkServiceUrl).toBeUndefined();
+    expect(config.adminBaseUrl).toBe("http://127.0.0.1:3000");
   });
 
   it("rejects invalid numeric values", () => {

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -123,6 +123,65 @@ describe.sequential("slack-codex-broker e2e", () => {
     );
   }, 90_000);
 
+  it("posts a session permalink when the bot starts processing a Slack thread", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
+    cleanups.push(async () => {
+      await removeTempRoot(tempRoot);
+    });
+
+    const brokerPort = await getFreePort();
+    const mockSlack = new MockSlackServer("UBOT", {
+      botId: "BBOT",
+      appId: "AAPP"
+    });
+    const mockCodex = new MockCodexAppServer();
+    const slackPort = await mockSlack.start();
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+      await mockSlack.stop();
+    });
+
+    const broker = await startBrokerProcess({
+      port: brokerPort,
+      slackPort,
+      codexUrl,
+      tempRoot,
+      extraEnv: {
+        ADMIN_BASE_URL: "https://admin.example.test"
+      }
+    });
+    cleanups.push(() => broker.stop());
+
+    await mockSlack.sendEvent("evt-session-link", {
+      type: "app_mention",
+      user: "U123",
+      channel: "C123",
+      thread_ts: "991.220",
+      ts: "991.221",
+      text: "<@UBOT> trace link"
+    });
+
+    await waitFor(() => mockCodex.turnsStarted.length >= 1, "first turn start");
+    await waitFor(
+      () => mockSlack.postedMessages.some((message) =>
+        message.threadTs === "991.220" &&
+          message.text.includes("查看 Bot 行为时间线") &&
+          message.text.includes("https://admin.example.test/admin/sessions/C123%3A991.220")
+      ),
+      "session permalink startup message"
+    );
+    await waitForSessionIdle(tempRoot, "C123:991.220");
+
+    const postedLinks = mockSlack.postedMessages.filter((message) =>
+      message.threadTs === "991.220" && message.text.includes("/admin/sessions/C123%3A991.220")
+    );
+    expect(postedLinks).toHaveLength(1);
+    await expect(readSessionRecord(tempRoot, "C123:991.220")).resolves.toMatchObject({
+      sessionPageLinkPostedAt: expect.any(String)
+    });
+  }, 60_000);
+
   it("falls back to an eyes reaction when Slack assistant status is unavailable", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
     cleanups.push(async () => {

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -283,8 +283,12 @@ describe("StateStore", () => {
           name: "inbound_mentioned_users"
         },
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 9,
           name: "admin_realtime_events"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "session_page_link_announcement"
         }
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- add deep-linkable `/admin/sessions/:sessionKey` pages that render a single session timeline
- post the session timeline link into the Slack thread when bot processing starts
- persist `sessionPageLinkPostedAt` in SQLite to avoid duplicate startup link messages

## Tests
- pnpm exec vitest run test/config.test.ts test/admin-routes.test.ts test/e2e-broker.test.ts test/state-store.test.ts
- pnpm build
- pnpm test
- git diff --check