### PR TITLE
[codex] Improve admin session timeline readability

### DIFF
--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -118,6 +118,7 @@
     .timeline-title { display: flex; gap: 6px; align-items: baseline; min-width: 0; }
     .timeline-title strong { min-width: 0; max-width: min(54ch, 58%); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .timeline-title span { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .timeline-title.timeline-title-single strong { max-width: 100%; }
     .trace-meta { color: var(--muted); font-size: 9px; }
     .trace-details summary { cursor: pointer; color: var(--cyan); font-size: 9px; }
     .trace-details pre { margin: 4px 0 0; padding: 4px 6px; max-height: 160px; overflow: auto; white-space: pre-wrap; border: 1px solid var(--line); background: #030508; font: 10px/1.4 var(--mono); }
@@ -184,11 +185,67 @@
       .admin-nav { overflow-x: auto; }
       .nav-item { white-space: nowrap; }
       .view-grid { grid-template-columns: 1fr; }
-      .session-master-detail { grid-template-columns: 1fr; }
+      .session-master-detail { grid-template-columns: 1fr; grid-template-rows: minmax(180px, 32vh) minmax(0, 1fr); }
       .session-list { max-height: 32vh; min-height: 0; }
       .session-line { grid-template-columns: minmax(0, 1fr) auto; }
       .session-time { grid-column: 1 / -1; }
       .session-detail-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .session-inspector { grid-template-columns: 1fr; }
       .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+    @media (max-width: 720px) {
+      body { font-size: 11px; }
+      .shell { padding: 6px; }
+      .topbar { align-items: flex-start; flex-wrap: wrap; gap: 6px; padding: 4px 0 6px; }
+      .admin-nav { max-width: 100%; }
+      .topbar-center { order: 3; flex-basis: 100%; width: 100%; gap: 4px; overflow-x: auto; padding-bottom: 2px; }
+      .top-actions { margin-left: auto; max-width: 100%; overflow-x: auto; padding-bottom: 2px; }
+      .quota-account { max-width: 100%; }
+      .nav-item { padding: 6px 12px; }
+      .admin-content { padding-top: 6px; }
+      .panel-head { align-items: flex-start; flex-wrap: wrap; gap: 6px; padding: 5px 6px; }
+      .toolbar { gap: 4px; padding: 4px 6px; }
+      .toolbar input { min-width: 0; }
+      .toolbar select { flex: 0 0 126px; }
+      .selected-session-head { grid-template-columns: 1fr; align-items: start; gap: 6px; padding: 6px; }
+      .session-detail-actions { width: 100%; min-width: 0; overflow-x: auto; padding-bottom: 2px; }
+      .session-detail-title, .session-detail-subtitle { white-space: normal; overflow-wrap: anywhere; }
+      .session-body { padding: 6px; }
+      .session-detail-summary { margin-bottom: 4px; }
+      .mini-body { padding: 4px; }
+      .trace-summary { overflow-x: auto; flex-wrap: nowrap; padding-bottom: 2px; }
+      .timeline { max-height: none; height: min(60dvh, 540px); }
+      .session-permalink-panel .timeline { height: min(64dvh, 640px); }
+      .timeline-event { grid-template-columns: 54px 78px minmax(0, 1fr); gap: 4px; padding: 6px 4px; }
+      .timeline-title { display: block; }
+      .timeline-title strong,
+      .timeline-title span {
+        display: block;
+        max-width: 100%;
+        overflow: visible;
+        text-overflow: clip;
+        white-space: normal;
+        overflow-wrap: anywhere;
+      }
+      .timeline-title span { margin-top: 2px; }
+      .trace-details pre { max-height: 220px; }
+      .operation-row { grid-template-columns: 1fr; }
+      .deploy-actions { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 520px) {
+      .topbar { display: grid; grid-template-columns: 1fr; }
+      .top-actions { width: 100%; margin-left: 0; }
+      .topbar-center { order: initial; }
+      .session-master-detail { grid-template-rows: minmax(190px, 38dvh) minmax(0, 1fr); }
+      .session-list { max-height: 38dvh; }
+      .session-summary { padding: 7px 6px 7px 8px; }
+      .session-line { gap: 4px; }
+      .session-meta-line { gap: 3px; }
+      .session-detail-actions { flex-wrap: wrap; overflow-x: visible; }
+      .session-detail-summary { grid-template-columns: 1fr; }
+      .timeline-event { grid-template-columns: 48px minmax(0, 1fr); }
+      .timeline-event > .badge { justify-self: start; }
+      .timeline-main { grid-column: 1 / -1; }
+      .metric-grid { grid-template-columns: 1fr; }
+      .risk-strip { grid-template-columns: 1fr 1fr; }
     }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -399,7 +399,10 @@ function TimelineRow({ event }: { readonly event: TimelineEvent }): React.JSX.El
       <span>{fmtTime(event.at)}</span>
       <Badge label={display.badgeLabel} tone={badgeTone} />
       <div className="timeline-main">
-        <div className="timeline-title"><strong title={display.title}>{display.title}</strong><span title={display.summary}>{display.summary}</span></div>
+        <div className={"timeline-title" + (display.summary ? "" : " timeline-title-single")}>
+          <strong title={display.title}>{display.title}</strong>
+          {display.summary ? <span title={display.summary}>{display.summary}</span> : null}
+        </div>
         {meta ? <div className="trace-meta">{meta}</div> : null}
         {event.detail ? (
           <details className="trace-details">

--- a/src/admin-ui/timeline-display.ts
+++ b/src/admin-ui/timeline-display.ts
@@ -47,6 +47,13 @@ export function getTimelineEventDisplay(event: TimelineEvent): TimelineEventDisp
       }
       break;
     }
+    case "agent_assistant_message": {
+      const content = assistantMessageContent(event, rawSummary);
+      if (content) {
+        return { badgeLabel, title: content, summary: "" };
+      }
+      return { badgeLabel, title: rawTitle, summary: isGenericAssistantSummary(rawSummary) ? "" : rawSummary };
+    }
     case "agent_input_delivered":
     case "agent_turn_started":
     case "agent_turn_completed":
@@ -136,6 +143,33 @@ function normalizeTimelineText(value: unknown): string {
 
 function nonEmptyString(value: unknown): string {
   return String(value || "").trim();
+}
+
+function assistantMessageContent(event: TimelineEvent, rawSummary: string): string {
+  const detail = nonEmptyString(event.detail);
+  if (detail && !isGenericAssistantSummary(detail)) {
+    return compactTimelineText(detail, 320);
+  }
+  if (rawSummary && !isGenericAssistantSummary(rawSummary)) {
+    return compactTimelineText(rawSummary, 320);
+  }
+  return "";
+}
+
+function isGenericAssistantSummary(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized === "replied in slack." ||
+    normalized === "replied in slack" ||
+    normalized === "sent a slack reply." ||
+    normalized === "sent a slack reply";
+}
+
+function compactTimelineText(value: string, maxLength: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(1, maxLength - 1)).trim()}…`;
 }
 
 export function statusLabel(value: unknown): string {

--- a/src/input-trace-summary.ts
+++ b/src/input-trace-summary.ts
@@ -24,7 +24,7 @@ export function summarizeInputTraceDisplay(options: {
     return {
       badgeLabel: "输入",
       title: normalizeString(options.fallbackTitle) || "输入",
-      summary: "Broker 内部输入包装；未解析出 Slack 消息",
+      summary: "",
       metadata: {
         source
       }

--- a/src/services/agent-runtime/agent-trace-recorder.ts
+++ b/src/services/agent-runtime/agent-trace-recorder.ts
@@ -149,11 +149,16 @@ export class AgentTraceRecorder {
           turnId: event.turnId
         }, now)];
       case "agent.message.completed":
+        {
+          const text = event.text.trim();
+          if (!text) {
+            return [];
+          }
         return [this.#trace(session, event, {
           type: event.role === "assistant" ? "agent_assistant_message" : "agent_user_message",
           title: event.role === "assistant" ? "Assistant 消息" : "用户消息",
-          summary: summarizeTraceText(event.text),
-          detail: event.text,
+          summary: summarizeTraceText(text),
+          detail: text,
           status: "completed",
           role: event.role,
           turnId: event.turnId,
@@ -161,6 +166,7 @@ export class AgentTraceRecorder {
             messageId: event.messageId
           }
         }, now)];
+        }
       case "agent.tool.started":
         {
           const toolSummary = summarizeToolTrace(event.name, "agent_tool_call", "running", event.input);

--- a/src/services/agent-runtime/codex-app-server-runtime.ts
+++ b/src/services/agent-runtime/codex-app-server-runtime.ts
@@ -412,7 +412,7 @@ function rawCodexEventToAgentEvents(
   if (rawType === "response_item" && payloadType === "message" && turnId) {
     const role = normalizeNonEmptyString(payload.role);
     const text = extractContentText(payload.content);
-    if (role === "assistant") {
+    if (role === "assistant" && text.trim()) {
       return [{
         type: "agent.message.completed",
         agentSessionId,

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -97,6 +97,31 @@ describe("admin session timeline display", () => {
     });
   });
 
+  it("shows assistant reply content instead of generic Slack delivery text", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_assistant_message",
+      title: "Assistant 消息",
+      summary: "Replied in Slack.",
+      detail: "已经合并并部署，线上健康检查正常。"
+    })).toEqual({
+      badgeLabel: "Assistant",
+      title: "已经合并并部署，线上健康检查正常。",
+      summary: ""
+    });
+  });
+
+  it("does not surface broker English wrappers when no structured payload can be extracted", () => {
+    expect(getTimelineEventDisplay({
+      type: "agent_input_received",
+      title: "用户消息",
+      summary: "A newer Slack message arrived while the current turn is still active. Treat it as the latest instruction..."
+    })).toEqual({
+      badgeLabel: "输入",
+      title: "用户消息",
+      summary: ""
+    });
+  });
+
   it("hides joined-active-turn input delivery rows because they duplicate the input row", () => {
     expect(isTimelineEventVisible({
       type: "agent_input_delivered",

--- a/test/agent-trace-recorder.test.ts
+++ b/test/agent-trace-recorder.test.ts
@@ -40,10 +40,47 @@ describe("AgentTraceRecorder", () => {
       expect.objectContaining({
         type: "agent_assistant_message",
         title: "Assistant 消息",
+        summary: "我会先检查状态。",
         detail: "我会先检查状态。",
         turnId: "turn-1"
       })
     ]);
+
+    stateStore.close();
+    await fs.rm(stateDir, {
+      force: true,
+      recursive: true
+    });
+  });
+
+  it("does not record empty assistant message trace events", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-recorder-empty-message-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const stateStore = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot
+    });
+
+    await sessions.load();
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "thread-1");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-1");
+
+    const recorder = new AgentTraceRecorder({
+      sessions
+    });
+    await recorder.record({
+      type: "agent.message.completed",
+      agentSessionId: "thread-1",
+      turnId: "turn-1",
+      messageId: "message-empty",
+      role: "assistant",
+      text: "   \n  ",
+      at: "2026-03-19T00:00:03.000Z"
+    });
+
+    expect(sessions.listAgentTraceEvents(session.key)).toEqual([]);
 
     stateStore.close();
     await fs.rm(stateDir, {

--- a/test/codex-app-server-runtime.test.ts
+++ b/test/codex-app-server-runtime.test.ts
@@ -127,6 +127,62 @@ describe("CodexAppServerRuntime", () => {
       })
     ]);
   });
+
+  it("emits assistant message content from response_item notifications", () => {
+    const { codex, events } = createRuntimeFixture();
+
+    codex.emit("notification", "codex/event", {
+      thread_id: "thread-1",
+      turn_id: "turn-1",
+      msg: {
+        type: "response_item",
+        payload: {
+          type: "message",
+          id: "message-1",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "我已经修好移动端布局。"
+            }
+          ]
+        },
+        timestamp: "2026-05-09T00:00:01.000Z"
+      }
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "agent.message.completed",
+        agentSessionId: "thread-1",
+        brokerSessionKey: TEST_SESSION.key,
+        turnId: "turn-1",
+        messageId: "message-1",
+        role: "assistant",
+        text: "我已经修好移动端布局。"
+      })
+    ]);
+  });
+
+  it("ignores empty assistant response_item notifications", () => {
+    const { codex, events } = createRuntimeFixture();
+
+    codex.emit("notification", "codex/event", {
+      thread_id: "thread-1",
+      turn_id: "turn-1",
+      msg: {
+        type: "response_item",
+        payload: {
+          type: "message",
+          id: "message-empty",
+          role: "assistant",
+          content: []
+        }
+      }
+    });
+
+    expect(events).toEqual([]);
+  });
 });
 
 function createRuntimeFixture(): {

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -1894,13 +1894,23 @@ async function waitForHttpReady(url: string, logs: readonly string[], timeoutMs 
 async function waitFor(predicate: () => boolean | Promise<boolean>, label: string, timeoutMs = DEFAULT_E2E_TIMEOUT_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await predicate()) {
-      return;
+    try {
+      if (await predicate()) {
+        return;
+      }
+    } catch (error) {
+      if (!isTransientSqliteLock(error)) {
+        throw error;
+      }
     }
     await delay(100);
   }
 
   throw new Error(`Timed out waiting for ${label}`);
+}
+
+function isTransientSqliteLock(error: unknown): boolean {
+  return error instanceof Error && /database is locked/i.test(error.message);
 }
 
 async function waitForSessionIdle(


### PR DESCRIPTION
## What changed
- Show assistant timeline rows with the actual bot reply text instead of generic delivery summaries like `Replied in Slack.`.
- Suppress empty assistant response items before they reach admin trace storage.
- Keep broker English input wrapper text out of the visible admin timeline when no Slack payload can be extracted.
- Tighten mobile admin/session layouts so the page stays full-height and timeline content wraps instead of disappearing behind ellipsis.
- Make the e2e wait helper tolerate transient SQLite write locks while polling a live broker process.

## Why
The session timeline was showing internal wrappers and empty/generic rows instead of the information a thread user needs: what the bot actually received, did, and replied. On small screens the same problem was amplified by fixed-width timeline columns and single-line truncation.

## Validation
- `pnpm exec vitest run test/admin-session-view.test.ts test/agent-trace-recorder.test.ts test/codex-app-server-runtime.test.ts`
- `pnpm build`
- `pnpm exec vitest run test/e2e-broker.test.ts -t "backfills Slack channel names"`
- `pnpm exec vitest run test/macos-bootstrap.test.ts`
- `pnpm test`
