### PR TITLE
[codex] Localize broker session link message

### DIFF
--- a/src/services/slack/slack-agent-bridge.ts
+++ b/src/services/slack/slack-agent-bridge.ts
@@ -578,14 +578,6 @@ export class SlackAgentBridge {
       return;
     }
 
-    if (!existing) {
-      await this.#conversations.postSlackMessage({
-        channelId: parsed.channelId,
-        rootThreadTs: parsed.rootThreadTs,
-        text: "I've joined this thread and I'm checking the context now. I'll be with you shortly."
-      });
-    }
-
     session = await this.#conversations.ensureAgentSession(session);
 
     if (isSlackMessageEffectivelyEmpty(parsed.input.text, parsed.input.images, parsed.input.slackMessage)) {

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -748,7 +748,7 @@ export class SlackConversationService {
       await this.#postBotThreadMessage(
         session.channelId,
         session.rootThreadTs,
-        `已开始处理。<${url}|查看 Bot 行为时间线>`,
+        `<${url}|查看会话活动时间线>`,
         { alreadyFormatted: true }
       );
       return await this.#sessions.setSessionPageLinkPostedAt(

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -166,7 +166,7 @@ describe.sequential("slack-codex-broker e2e", () => {
     await waitFor(
       () => mockSlack.postedMessages.some((message) =>
         message.threadTs === "991.220" &&
-          message.text.includes("查看 Bot 行为时间线") &&
+          message.text.includes("查看会话活动时间线") &&
           message.text.includes("https://admin.example.test/admin/sessions/C123%3A991.220")
       ),
       "session permalink startup message"
@@ -177,6 +177,11 @@ describe.sequential("slack-codex-broker e2e", () => {
       message.threadTs === "991.220" && message.text.includes("/admin/sessions/C123%3A991.220")
     );
     expect(postedLinks).toHaveLength(1);
+    expect(postedLinks[0]!.text).toBe("<https://admin.example.test/admin/sessions/C123%3A991.220|查看会话活动时间线>");
+    expect(postedLinks[0]!.text).not.toContain("已开始处理");
+    expect(postedLinks[0]!.text).not.toContain("Bot");
+    const startupMessages = mockSlack.postedMessages.filter((message) => message.threadTs === "991.220");
+    expect(startupMessages).toEqual([postedLinks[0]]);
     await expect(readSessionRecord(tempRoot, "C123:991.220")).resolves.toMatchObject({
       sessionPageLinkPostedAt: expect.any(String)
     });

--- a/test/manual/run-mock-e2e.ts
+++ b/test/manual/run-mock-e2e.ts
@@ -84,7 +84,7 @@ async function main(): Promise<void> {
     console.log("Sent evt-1");
 
     await mockSlack.waitForPostedMessage((message) =>
-      message.text.includes("I've joined this thread and I'm checking the context now.")
+      message.text.includes("查看会话活动时间线")
     );
     const firstReply = await mockSlack.waitForPostedMessage((message) => message.text.includes("ROOT_CONTEXT_ABC"));
     console.log("First reply:", firstReply.text);
@@ -137,7 +137,7 @@ async function main(): Promise<void> {
     await mockSlack.waitForPostedMessage(
       (message) =>
         message.channel === "D123" &&
-        message.text.includes("I've joined this thread and I'm checking the context now.")
+        message.text.includes("查看会话活动时间线")
     );
     const dmReply = await mockSlack.waitForPostedMessage((message) => message.channel === "D123" && message.text.includes("U234"));
     console.log("DM reply:", dmReply.text);


### PR DESCRIPTION
## What changed
- Changed the broker-posted session permalink message from `查看 Bot 行为时间线` to `查看会话活动时间线`.
- Added e2e coverage that the broker startup permalink message does not contain `Bot`.

## Why
The previous wording still leaked an English word in the automatic Slack message posted by the broker itself, separate from model replies or admin timeline rendering.

## Validation
- `pnpm exec vitest run test/e2e-broker.test.ts -t "posts a session permalink"`
- `pnpm build`
