### PR TITLE
Add session auth profile binding

### DIFF
--- a/docs/session-auth-profile-routing.md
+++ b/docs/session-auth-profile-routing.md
@@ -1,0 +1,83 @@
+# Session auth profile routing
+
+## Goal
+
+Each Slack session must bind to one managed Codex auth profile.
+
+New sessions automatically select the usable profile with the most remaining Codex quota. After a session is bound, the broker must keep using that profile. If the bound profile becomes unavailable, the broker must not automatically switch to another profile. It must stop dispatch for that session, preserve pending Slack input, post one Slack message with the session page link, and wait for a human to switch the session profile from the session page.
+
+## Current State
+
+The broker already manages auth profiles under `.data/auth-profiles/docker/profiles`. `AuthProfileService` can list profiles, probe account and quota state, and change the global active profile.
+
+The agent runtime is currently global. A worker process creates one Codex app-server runtime with one `CODEX_HOME/auth.json`. Admin profile activation changes the global active auth and restarts the worker runtime. That is not session binding. It is unsafe for concurrent sessions because one session can change the auth identity used by another.
+
+## Target Model
+
+The worker owns an auth-profile runtime pool:
+
+- one Codex runtime per auth profile,
+- one isolated `CODEX_HOME` per runtime,
+- one `auth.json` per runtime copied from the bound profile,
+- one app-server port per runtime,
+- one `AppServerClient` per runtime.
+
+The session row stores:
+
+- `auth_profile_name`,
+- `auth_profile_bound_at`,
+- `auth_blocked_at`,
+- `auth_block_reason`,
+- `auth_blocked_notice_posted_at`.
+
+The broker routes every agent operation through the runtime selected by `session.authProfileName`.
+
+## Profile Selection
+
+New session selection uses probed profile snapshots:
+
+- exclude profiles whose account or rate limit probe failed,
+- exclude profiles whose primary or secondary Codex limit is exhausted,
+- rank by effective remaining quota,
+- use deterministic tie breaking.
+
+Effective remaining quota is the conservative minimum of known primary and secondary remaining percentages. Missing windows are treated as 100 percent remaining for that window because some account types may omit one window.
+
+## Bound Session Failure
+
+Before dispatching a pending Slack input into Codex, the worker checks the bound profile. If the profile is unavailable:
+
+- do not start or steer a Codex turn,
+- leave inbound messages in `pending`,
+- clear `active_turn_id`,
+- set auth blocked fields on the session,
+- record an agent trace event,
+- post one Slack notice with the session link.
+
+The notice is idempotent for one blocked state. Repeated Slack messages while the session remains blocked must not spam the thread.
+
+## Manual Recovery
+
+The session page exposes the current auth binding and available profile list. A user can choose a usable profile and click `切换并继续处理`.
+
+The admin action must:
+
+- validate the selected profile exists and is usable,
+- update the session auth binding,
+- clear auth blocked fields,
+- reset `agent_session_id` because the old app-server thread belongs to a different profile runtime,
+- record an agent trace event,
+- ask the worker to resume pending dispatch for that session.
+
+Admin is a separate process in deployment, so resuming work cannot be an in-process call. The admin process calls a local worker HTTP endpoint after updating the shared state database.
+
+## Acceptance Criteria
+
+- A new session automatically binds to the usable profile with the most effective remaining quota.
+- Existing sessions keep their bound profile even when another profile later has more quota.
+- If the bound profile is unavailable, the broker does not auto-switch.
+- The pending Slack input remains pending while auth is blocked.
+- Slack receives exactly one blocked notice per blocked state, with the session page link.
+- The session page shows the current binding, blocked reason, profile candidates, and a `切换并继续处理` action.
+- Manual switch clears the blocked state, resets stale agent runtime state, and resumes pending dispatch through the newly selected profile runtime.
+- Slack behavior is unchanged for healthy sessions.

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -109,6 +109,12 @@
     .mini-panel { border: 1px solid var(--line); }
     .mini-title { padding: 3px 6px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 9px; text-transform: uppercase; }
     .mini-body { padding: 4px 6px; }
+    .auth-profile-panel { display: grid; gap: 6px; min-width: 0; }
+    .auth-profile-current { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 6px; align-items: center; color: var(--muted); font-size: 10px; }
+    .auth-profile-current strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); }
+    .auth-profile-blocked { display: flex; gap: 6px; align-items: center; min-width: 0; color: var(--red); font-size: 10px; }
+    .auth-profile-blocked span:last-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .auth-profile-switcher { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px; align-items: center; }
 
     .timeline { display: grid; gap: 0; max-height: min(420px, 52vh); overflow: auto; border: 1px solid var(--line); }
     .timeline-event { display: grid; grid-template-columns: 72px 90px minmax(0, 1fr); gap: 6px; align-items: start; padding: 4px 6px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 10px; }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -231,6 +231,8 @@ function SessionRow({ session, selected, onSelect }: {
 function SessionDetail({ session }: {
   readonly session: SessionRecord;
 }): React.JSX.Element {
+  const snapshot = useSyncExternalStore(subscribeAdminStatus, getAdminStatusSnapshot, getAdminStatusSnapshot);
+  const authProfiles = (((snapshot.status || {}) as Record<string, any>).authProfiles?.profiles || []) as SessionRecord[];
   const usage = session.usage || {};
   const state = sessionQueueState(session);
   const activityAt = sessionActivityAt(session);
@@ -260,6 +262,12 @@ function SessionDetail({ session }: {
           <Kpi label="Token / 轮次" value={fmtTokens(usage.totalTokens || 0) + " / " + (usage.turnCount || 0)} />
         </div>
         <div className="session-inspector">
+          <div className="mini-panel">
+            <div className="mini-title">Auth Profile</div>
+            <div className="mini-body">
+              <AuthProfilePanel session={session} profiles={authProfiles} />
+            </div>
+          </div>
           <div className="mini-panel trace-panel">
             <div className="mini-title">Agent 活动时间线</div>
             <div className="mini-body">
@@ -316,6 +324,80 @@ function SessionTimeline({ session }: {
   if (error) return <div className="summary-detail">{error}</div>;
   if (!payload) return <Timeline events={[{ at: session.createdAt, type: "session", title: "已创建" }]} />;
   return <TimelinePayloadView payload={payload} />;
+}
+
+function AuthProfilePanel({ session, profiles }: {
+  readonly session: SessionRecord;
+  readonly profiles: readonly SessionRecord[];
+}): React.JSX.Element {
+  const [selected, setSelected] = useState(String(session.authProfileName || ""));
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const currentProfile = profiles.find((profile) => profile.name === session.authProfileName);
+  const blocked = Boolean(session.authBlockedAt);
+
+  useEffect(() => {
+    setSelected(String(session.authProfileName || ""));
+    setMessage(null);
+  }, [session.key, session.authProfileName, session.authBlockedAt]);
+
+  async function switchProfile(): Promise<void> {
+    if (!selected || selected === session.authProfileName) {
+      return;
+    }
+
+    setBusy(true);
+    setMessage(null);
+    try {
+      await requestJson("/admin/api/sessions/" + encodeURIComponent(String(session.key || "")) + "/auth-profile", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: selected })
+      });
+      const timelinePayload = await requestJson(sessionTimelineApiPath(String(session.key || "")));
+      publishTimelinePayload(String(session.key || ""), timelinePayload as TimelinePayload);
+      setMessage("已切换，正在恢复待处理消息");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="auth-profile-panel">
+      <div className="auth-profile-current">
+        <span>当前</span>
+        <strong>{session.authProfileName || "未绑定"}</strong>
+        {currentProfile ? <span>{profileQuotaLabel(currentProfile)}</span> : null}
+      </div>
+      {blocked ? (
+        <div className="auth-profile-blocked">
+          <Badge label="等待手动切换" tone="danger" />
+          <span>{session.authBlockReasonLabel || session.authBlockReason || "账号不可用"}</span>
+        </div>
+      ) : null}
+      <div className="auth-profile-switcher">
+        <select value={selected} onChange={(event) => setSelected(event.target.value)}>
+          <option value="">选择账号</option>
+          {profiles.map((profile) => (
+            <option key={profile.name} value={profile.name}>
+              {profile.name} · {profileQuotaLabel(profile)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="link-button"
+          disabled={busy || !selected || selected === session.authProfileName}
+          onClick={() => { void switchProfile(); }}
+        >
+          切换并继续处理
+        </button>
+      </div>
+      {message ? <div className="summary-detail">{message}</div> : null}
+    </div>
+  );
 }
 
 function TimelinePayloadView({ payload }: { readonly payload: TimelinePayload }): React.JSX.Element {
@@ -500,7 +582,7 @@ function sessionMatchesFilter(session: SessionRecord, mode: string, query: strin
   if (mode === "active" && !session.activeTurnId) return false;
   if (mode === "inbound" && !session.openInboundCount) return false;
   if (mode === "jobs" && !session.runningBackgroundJobCount) return false;
-  if (mode === "issues" && !session.failedBackgroundJobCount) return false;
+  if (mode === "issues" && !session.failedBackgroundJobCount && !session.authBlockedAt) return false;
   if (mode === "usage" && !session.usage?.turnCount) return false;
   if (!query) return true;
   return [session.key, session.channelId, session.channelLabel, session.workspacePath, sessionPrimaryText(session), sessionFirstText(session)]
@@ -519,6 +601,8 @@ function renderSessionMeta(session: SessionRecord): Array<{ key: string; label: 
     : "";
   return [
     { key: "channel", label: session.channelLabel || session.channelId || "未知频道", tone: "info", title: session.key },
+    session.authBlockedAt ? { key: "auth-blocked", label: "账号待切换", tone: "danger", title: session.authBlockReasonLabel || session.authBlockReason } : null,
+    session.authProfileName ? { key: "auth-profile", label: "Auth " + session.authProfileName, tone: "info" } : null,
     pendingDetail ? { key: "pending", label: pendingDetail, tone: Number(session.openHumanInboundCount || 0) ? "warn" : "" } : null,
     { key: "jobs", label: "Jobs " + (session.backgroundJobCount || 0), tone: Number(session.failedBackgroundJobCount || 0) ? "danger" : (Number(session.runningBackgroundJobCount || 0) ? "good" : "") },
     Number(session.failedBackgroundJobCount || 0) ? { key: "failed", label: "失败 " + session.failedBackgroundJobCount, tone: "danger" } : null,
@@ -558,6 +642,9 @@ function summarizeSessionLead(session: SessionRecord): string {
 }
 
 function sessionQueueState(session: SessionRecord): { label: string; tone: string; rank: number; detail: string } {
+  if (session.authBlockedAt) {
+    return { label: "账号待切换", tone: "danger", rank: 70, detail: session.authBlockReasonLabel || session.authBlockReason || "账号不可用" };
+  }
   if (Number(session.failedBackgroundJobCount || 0) > 0) {
     return { label: "异常", tone: "danger", rank: 60, detail: session.failedBackgroundJobCount + " 个失败任务" };
   }
@@ -577,6 +664,29 @@ function sessionQueueState(session: SessionRecord): { label: string; tone: strin
     return { label: "有记录", tone: "info", rank: 10, detail: fmtTokens(session.usage?.totalTokens || 0) };
   }
   return { label: "空闲", tone: "", rank: 0, detail: "" };
+}
+
+function profileQuotaLabel(profile: SessionRecord): string {
+  const rateLimits = profile.rateLimits || {};
+  if (rateLimits.ok === false) {
+    return "不可用";
+  }
+
+  const limits = rateLimits.rateLimits || {};
+  const primary = remainingPercent(limits.primary?.usedPercent);
+  const secondary = remainingPercent(limits.secondary?.usedPercent);
+  const parts = [];
+  if (primary !== null) parts.push("短窗 " + Math.round(primary) + "%");
+  if (secondary !== null) parts.push("周 " + Math.round(secondary) + "%");
+  return parts.length ? parts.join(" / ") : "额度未知";
+}
+
+function remainingPercent(usedPercent: unknown): number | null {
+  const used = Number(usedPercent);
+  if (!Number.isFinite(used)) {
+    return null;
+  }
+  return Math.max(0, Math.min(100, 100 - used));
 }
 
 function compareSessionsForMode(mode: string, left: SessionRecord, right: SessionRecord): number {
@@ -613,8 +723,8 @@ function sessionActivityMs(session: SessionRecord): number {
   return timestampMs(sessionActivityAt(session));
 }
 
-async function requestJson(path: string): Promise<unknown> {
-  const response = await fetch(path);
+async function requestJson(path: string, init?: RequestInit): Promise<unknown> {
+  const response = await fetch(path, init);
   const payload = await response.json().catch(() => ({})) as Record<string, any>;
   if (!response.ok || payload.ok === false) throw new Error(payload.error || response.statusText || "请求失败");
   return payload;
@@ -685,7 +795,7 @@ function statusTone(status: unknown): string {
   const value = String(status || "").toLowerCase();
   if (["succeeded", "running", "active", "ok", "completed", "done"].includes(value)) return "good";
   if (["pending", "inflight", "registered", "starting", "idle", "started", "wait"].includes(value)) return "warn";
-  if (["failed", "error", "stopped", "cancelled"].includes(value)) return "danger";
+  if (["failed", "error", "stopped", "cancelled", "blocked"].includes(value)) return "danger";
   if (["agent_system_prompt", "agent_memory", "agent_runtime_instruction"].includes(value)) return "purple";
   if (["agent_user_message", "agent_assistant_message", "agent_tool_result", "agent_token_count"].includes(value)) return "good";
   if (["agent_runtime_reminder", "agent_tool_call", "agent_turn_started"].includes(value)) return "warn";

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -65,6 +65,39 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "POST" && url.pathname.startsWith("/admin/api/sessions/") && url.pathname.endsWith("/auth-profile")) {
+    const sessionKey = decodeURIComponent(url.pathname.slice(
+      "/admin/api/sessions/".length,
+      -"/auth-profile".length
+    ));
+    if (!sessionKey || sessionKey.includes("/")) {
+      return false;
+    }
+
+    const body = await readAdminBody(request, response);
+    if (!body) {
+      return true;
+    }
+
+    const name = readString(body.name);
+    if (!name) {
+      respondJson(response, 400, {
+        ok: false,
+        error: "missing_required_body",
+        required: ["name"]
+      });
+      return true;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.switchSessionAuthProfile({
+        sessionKey,
+        name
+      })
+    );
+    return true;
+  }
+
   if (method === "GET" && url.pathname === "/admin/api/preflight") {
     respondJson(response, 200, await options.adminService.getOperationPreflight({
       operation: readString(url.searchParams.get("operation")) ?? "unknown"

--- a/src/http/slack-routes.ts
+++ b/src/http/slack-routes.ts
@@ -32,6 +32,12 @@ export async function handleSlackRequest(
     return true;
   }
 
+  const matchedResumeSession = matchResumeSessionPath(url.pathname);
+  if (method === "POST" && matchedResumeSession) {
+    await handleSlackResumePendingSessionRequest(response, options, matchedResumeSession.sessionKey);
+    return true;
+  }
+
   if (method === "POST" && url.pathname === "/slack/post-message") {
     await handleSlackPostMessageRequest(request, response, options);
     return true;
@@ -63,6 +69,28 @@ export async function handleSlackRequest(
   }
 
   return false;
+}
+
+async function handleSlackResumePendingSessionRequest(
+  response: http.ServerResponse,
+  options: {
+    readonly bridge: SlackAgentBridge;
+  },
+  sessionKey: string
+): Promise<void> {
+  try {
+    const resumedCount = await options.bridge.resumePendingSession(sessionKey);
+    respondJson(response, 200, {
+      ok: true,
+      sessionKey,
+      resumedCount
+    });
+  } catch (error) {
+    respondJson(response, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
 }
 
 async function handleSlackThreadHistoryRequest(
@@ -543,6 +571,23 @@ function normalizeStringArray(value: unknown): string[] | undefined {
     .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
     .filter(Boolean);
   return normalized.length > 0 ? normalized : undefined;
+}
+
+function matchResumeSessionPath(pathname: string): { readonly sessionKey: string } | null {
+  const prefix = "/slack/sessions/";
+  const suffix = "/resume-pending";
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) {
+    return null;
+  }
+
+  const encodedKey = pathname.slice(prefix.length, -suffix.length);
+  if (!encodedKey) {
+    return null;
+  }
+
+  return {
+    sessionKey: decodeURIComponent(encodedKey)
+  };
 }
 
 function normalizeMappings(value: unknown):

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,15 @@ export async function startService(): Promise<{
   configureServiceLogger(config);
   const { sessions: sessionManager } = createSessionServices(config);
   const githubAuthorMappings = await createGitHubAuthorMappings(config);
+  const authProfiles = new AuthProfileService({
+    config
+  });
   const codexBroker = createCodexBroker(config);
   const agentRuntime = createAgentRuntime({
+    config,
     codex: codexBroker,
-    sessions: sessionManager
+    sessions: sessionManager,
+    authProfiles
   });
   const bridge = createSlackBridge({
     config,
@@ -47,9 +52,6 @@ export async function startService(): Promise<{
     config,
     sessions: sessionManager,
     jobManager
-  });
-  const authProfiles = new AuthProfileService({
-    config
   });
   const adminService = new AdminService({
     config,

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -20,6 +20,11 @@ import type { SessionManager } from "./session-manager.js";
 import type { AuthProfileService } from "./auth-profile-service.js";
 import type { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
 import type { RuntimeControl } from "./runtime-control.js";
+import {
+  authProfileReasonLabel,
+  evaluateAuthProfile,
+  findAuthProfile
+} from "./session-auth-profile-selector.js";
 import type {
   DeployReleaseOptions,
   RollbackReleaseOptions,
@@ -411,6 +416,46 @@ export class AdminService {
         return {
           ok: true,
           activatedProfile: activated.name
+        };
+      }
+    );
+  }
+
+  async switchSessionAuthProfile(options: {
+    readonly sessionKey: string;
+    readonly name: string;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "session_auth_profile_switch",
+      {
+        sessionKey: options.sessionKey,
+        name: options.name
+      },
+      async () => {
+        const session = this.options.sessions.getSessionByKey(options.sessionKey);
+        if (!session) {
+          throw new Error(`Session not found: ${options.sessionKey}`);
+        }
+
+        const status = await this.options.authProfiles.listProfilesStatus();
+        const profile = findAuthProfile(status, options.name);
+        if (!profile) {
+          throw new Error(`Auth profile not found: ${options.name}`);
+        }
+
+        const evaluation = evaluateAuthProfile(profile);
+        if (!evaluation.usable) {
+          throw new Error(`Auth profile is not usable: ${authProfileReasonLabel(evaluation.reason)}`);
+        }
+
+        await this.options.sessions.resetInflightMessages(session.channelId, session.rootThreadTs);
+        const switched = await this.options.sessions.switchSessionAuthProfileAndClearBlock(session.key, profile.name);
+        await this.#appendSessionAuthProfileSwitchTrace(switched, profile.name);
+        const workerResume = await this.#resumeWorkerPendingSession(switched.key);
+        return {
+          ok: true,
+          session: this.#summarizeSessionByKey(switched.key),
+          workerResume
         };
       }
     );
@@ -1026,6 +1071,12 @@ export class AdminService {
       lastTurnSignalAt: session.lastTurnSignalAt ?? null,
       lastSlackReplyAt: session.lastSlackReplyAt ?? null,
       sessionPageLinkPostedAt: session.sessionPageLinkPostedAt ?? null,
+      authProfileName: session.authProfileName ?? null,
+      authProfileBoundAt: session.authProfileBoundAt ?? null,
+      authBlockedAt: session.authBlockedAt ?? null,
+      authBlockReason: session.authBlockReason ?? null,
+      authBlockReasonLabel: authProfileReasonLabel(session.authBlockReason),
+      authBlockedNoticePostedAt: session.authBlockedNoticePostedAt ?? null,
       lastObservedMessageTs: session.lastObservedMessageTs ?? null,
       lastDeliveredMessageTs: session.lastDeliveredMessageTs ?? null,
       openInboundCount: related.openInbound.length,
@@ -1038,6 +1089,46 @@ export class AdminService {
       backgroundJobs: related.jobs.slice(0, 5).map((job) => this.#summarizeJob(job)),
       usage: related.usage ?? emptySessionUsageSummary(session)
     };
+  }
+
+  async #appendSessionAuthProfileSwitchTrace(
+    session: SlackSessionRecord,
+    profileName: string
+  ): Promise<void> {
+    const now = new Date().toISOString();
+    const sequence = this.options.sessions.listAgentTraceEvents(session.key, 10_000).length + 1;
+    await this.options.sessions.upsertAgentTraceEvent({
+      id: randomUUID(),
+      sessionKey: session.key,
+      source: "broker",
+      type: "agent_runtime_instruction",
+      at: now,
+      sequence,
+      title: "Auth Profile 已切换",
+      summary: `人工切换到 ${profileName}，继续处理待处理消息`,
+      detail: JSON.stringify({ profileName }, null, 2),
+      status: "completed",
+      metadata: {
+        profileName
+      },
+      createdAt: now,
+      updatedAt: now
+    });
+  }
+
+  async #resumeWorkerPendingSession(sessionKey: string): Promise<Record<string, unknown>> {
+    const url = new URL(
+      `/slack/sessions/${encodeURIComponent(sessionKey)}/resume-pending`,
+      this.options.config.workerBaseUrl
+    );
+    const response = await fetch(url, {
+      method: "POST"
+    });
+    const payload = await response.json().catch(() => ({})) as Record<string, unknown>;
+    if (!response.ok || payload.ok === false) {
+      throw new Error(String(payload.error || response.statusText || "worker_resume_failed"));
+    }
+    return payload;
   }
 }
 

--- a/src/services/agent-runtime/session-auth-profile-runtime.ts
+++ b/src/services/agent-runtime/session-auth-profile-runtime.ts
@@ -1,0 +1,294 @@
+import { EventEmitter } from "node:events";
+import path from "node:path";
+
+import type { AppConfig } from "../../config.js";
+import type { AuthProfileService, AuthProfileSummary } from "../auth-profile-service.js";
+import { CodexBroker } from "../codex/codex-broker.js";
+import { SessionManager } from "../session-manager.js";
+import {
+  authProfileReasonLabel,
+  evaluateAuthProfile,
+  findAuthProfile,
+  selectBestAuthProfile,
+  type AuthProfileUnavailableReason
+} from "../session-auth-profile-selector.js";
+import { CodexAppServerRuntime } from "./codex-app-server-runtime.js";
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentRuntimeEvent,
+  AgentSession,
+  AgentSessionSnapshot,
+  AgentSubmitInputResult,
+  AgentTurnSnapshot,
+  ReadAgentTurnOptions,
+  SubmitAgentInput
+} from "./types.js";
+import type { SlackSessionRecord, SlackUserIdentity } from "../../types.js";
+
+interface ProfileRuntimeEntry {
+  readonly runtime: AgentRuntime;
+  readonly eventHandler: (event: AgentRuntimeEvent) => void;
+}
+
+export class AuthProfileUnavailableError extends Error {
+  readonly code = "auth_profile_unavailable";
+  readonly sessionKey: string;
+  readonly profileName?: string | undefined;
+  readonly reason: AuthProfileUnavailableReason;
+
+  constructor(options: {
+    readonly sessionKey: string;
+    readonly profileName?: string | undefined;
+    readonly reason: AuthProfileUnavailableReason;
+  }) {
+    super(`Auth profile unavailable for ${options.sessionKey}: ${options.profileName ?? "none"} (${options.reason})`);
+    this.name = "AuthProfileUnavailableError";
+    this.sessionKey = options.sessionKey;
+    this.profileName = options.profileName;
+    this.reason = options.reason;
+  }
+
+  get userMessage(): string {
+    return authProfileReasonLabel(this.reason);
+  }
+}
+
+export function isAuthProfileUnavailableError(error: unknown): error is AuthProfileUnavailableError {
+  return error instanceof AuthProfileUnavailableError ||
+    Boolean(error && typeof error === "object" && (error as { code?: unknown }).code === "auth_profile_unavailable");
+}
+
+export class SessionAuthProfileRuntime extends EventEmitter implements AgentRuntime {
+  readonly #config: AppConfig;
+  readonly #sessions: SessionManager;
+  readonly #authProfiles: AuthProfileService;
+  readonly #createProfileRuntime: (options: {
+    readonly profile: AuthProfileSummary;
+    readonly codexHome: string;
+    readonly port: number;
+  }) => AgentRuntime;
+  readonly #legacyRuntime?: AgentRuntime | undefined;
+  readonly #profileRuntimes = new Map<string, ProfileRuntimeEntry>();
+  readonly #profilePorts = new Map<string, number>();
+  #nextPortOffset = 0;
+  #slackBotIdentity: SlackUserIdentity | null = null;
+
+  constructor(options: {
+    readonly config: AppConfig;
+    readonly sessions: SessionManager;
+    readonly authProfiles: AuthProfileService;
+    readonly legacyRuntime?: AgentRuntime | undefined;
+    readonly createProfileRuntime?: ((options: {
+      readonly profile: AuthProfileSummary;
+      readonly codexHome: string;
+      readonly port: number;
+    }) => AgentRuntime) | undefined;
+  }) {
+    super();
+    this.#config = options.config;
+    this.#sessions = options.sessions;
+    this.#authProfiles = options.authProfiles;
+    this.#legacyRuntime = options.legacyRuntime;
+    this.#nextPortOffset = options.legacyRuntime ? 1 : 0;
+    this.#createProfileRuntime = options.createProfileRuntime ?? ((runtimeOptions) =>
+      createDefaultProfileRuntime({
+        config: this.#config,
+        sessions: this.#sessions,
+        ...runtimeOptions
+      })
+    );
+    if (this.#legacyRuntime) {
+      this.#legacyRuntime.on("event", (event) => this.emit("event", event));
+    }
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return {
+      submitWhileActive: true,
+      interrupt: true,
+      readTurn: true,
+      readSession: true,
+      rawEvents: true,
+      tokenUsage: "exact",
+      toolCalls: true,
+      systemPromptEcho: true
+    };
+  }
+
+  async start(): Promise<void> {
+    await this.#legacyRuntime?.start();
+  }
+
+  async stop(): Promise<void> {
+    const entries = [...this.#profileRuntimes.values()];
+    this.#profileRuntimes.clear();
+    await Promise.all(entries.map(async (entry) => {
+      entry.runtime.off("event", entry.eventHandler);
+      await entry.runtime.stop();
+    }));
+    await this.#legacyRuntime?.stop();
+  }
+
+  setSlackBotIdentity(identity: SlackUserIdentity | null): void {
+    this.#slackBotIdentity = identity;
+    this.#legacyRuntime?.setSlackBotIdentity(identity);
+    for (const entry of this.#profileRuntimes.values()) {
+      entry.runtime.setSlackBotIdentity(identity);
+    }
+  }
+
+  async ensureSession(session: SlackSessionRecord): Promise<AgentSession> {
+    const resolved = await this.#resolveRuntime(session);
+    return await resolved.runtime.ensureSession(resolved.session);
+  }
+
+  async submitInput(input: SubmitAgentInput): Promise<AgentSubmitInputResult> {
+    const resolved = await this.#resolveRuntime(input.session);
+    return await resolved.runtime.submitInput({
+      ...input,
+      session: resolved.session
+    });
+  }
+
+  async interrupt(session: SlackSessionRecord): Promise<void> {
+    const resolved = await this.#resolveRuntime(session);
+    await resolved.runtime.interrupt(resolved.session);
+  }
+
+  async readSession(session: SlackSessionRecord): Promise<AgentSessionSnapshot | null> {
+    const resolved = await this.#resolveRuntime(session);
+    return await resolved.runtime.readSession(resolved.session);
+  }
+
+  async readTurn(
+    session: SlackSessionRecord,
+    turnId: string,
+    options?: ReadAgentTurnOptions
+  ): Promise<AgentTurnSnapshot | null> {
+    const resolved = await this.#resolveRuntime(session);
+    return await resolved.runtime.readTurn(resolved.session, turnId, options);
+  }
+
+  async #resolveRuntime(session: SlackSessionRecord): Promise<{
+    readonly session: SlackSessionRecord;
+    readonly runtime: AgentRuntime;
+  }> {
+    const status = await this.#authProfiles.listProfilesStatus();
+    if (status.profiles.length === 0 && this.#legacyRuntime) {
+      return {
+        session,
+        runtime: this.#legacyRuntime
+      };
+    }
+
+    if (session.authProfileName) {
+      const profile = findAuthProfile(status, session.authProfileName);
+      if (!profile) {
+        throw new AuthProfileUnavailableError({
+          sessionKey: session.key,
+          profileName: session.authProfileName,
+          reason: "profile_not_found"
+        });
+      }
+
+      const evaluation = evaluateAuthProfile(profile);
+      if (!evaluation.usable) {
+        throw new AuthProfileUnavailableError({
+          sessionKey: session.key,
+          profileName: profile.name,
+          reason: evaluation.reason ?? "rate_limits_probe_failed"
+        });
+      }
+
+      return {
+        session,
+        runtime: this.#runtimeForProfile(profile)
+      };
+    }
+
+    const selected = selectBestAuthProfile(status);
+    if (!selected) {
+      throw new AuthProfileUnavailableError({
+        sessionKey: session.key,
+        reason: "no_usable_auth_profiles"
+      });
+    }
+
+    const boundSession = await this.#sessions.setSessionAuthProfile(session.key, selected.name);
+    return {
+      session: boundSession,
+      runtime: this.#runtimeForProfile(selected)
+    };
+  }
+
+  #runtimeForProfile(profile: AuthProfileSummary): AgentRuntime {
+    const existing = this.#profileRuntimes.get(profile.name);
+    if (existing) {
+      return existing.runtime;
+    }
+
+    const runtime = this.#createProfileRuntime({
+      profile,
+      codexHome: path.join(this.#profileRuntimeRoot(profile.name), "codex-home"),
+      port: this.#portForProfile(profile.name)
+    });
+    runtime.setSlackBotIdentity(this.#slackBotIdentity);
+    const eventHandler = (event: AgentRuntimeEvent) => this.emit("event", event);
+    runtime.on("event", eventHandler);
+    this.#profileRuntimes.set(profile.name, {
+      runtime,
+      eventHandler
+    });
+    return runtime;
+  }
+
+  #profileRuntimeRoot(profileName: string): string {
+    return path.join(path.dirname(this.#config.stateDir), "auth-profile-runtimes", safePathSegment(profileName));
+  }
+
+  #portForProfile(profileName: string): number {
+    const existing = this.#profilePorts.get(profileName);
+    if (existing) {
+      return existing;
+    }
+
+    const port = this.#config.codexAppServerPort + this.#nextPortOffset;
+    this.#nextPortOffset += 1;
+    this.#profilePorts.set(profileName, port);
+    return port;
+  }
+}
+
+function createDefaultProfileRuntime(options: {
+  readonly config: AppConfig;
+  readonly sessions: SessionManager;
+  readonly profile: AuthProfileSummary;
+  readonly codexHome: string;
+  readonly port: number;
+}): AgentRuntime {
+  const codex = new CodexBroker({
+    serviceName: `${options.config.serviceName}:${options.profile.name}`,
+    brokerHttpBaseUrl: options.config.brokerHttpBaseUrl,
+    codexHome: options.codexHome,
+    reposRoot: options.config.reposRoot,
+    hostCodexHomePath: options.config.codexHostHomePath,
+    hostGeminiHomePath: options.config.geminiHostHomePath,
+    codexAppServerPort: options.port,
+    codexAuthJsonPath: options.profile.path,
+    codexDisabledMcpServers: options.config.codexDisabledMcpServers,
+    tempadLinkServiceUrl: options.config.tempadLinkServiceUrl,
+    geminiHttpProxy: options.config.geminiHttpProxy,
+    geminiHttpsProxy: options.config.geminiHttpsProxy,
+    geminiAllProxy: options.config.geminiAllProxy,
+    openAiApiKey: options.config.codexOpenAiApiKey
+  });
+  return new CodexAppServerRuntime({
+    codex,
+    sessions: options.sessions
+  });
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "_") || "profile";
+}

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -185,12 +185,16 @@ export class AppServerProcess {
   async #bootstrapAuth(): Promise<void> {
     const authTarget = path.join(this.#codexHome, "auth.json");
 
+    if (this.#authJsonPath && await fileExists(this.#authJsonPath)) {
+      await pointSymlink(authTarget, this.#authJsonPath);
+      return;
+    }
+
     if (await fileExists(authTarget)) {
       return;
     }
 
     const candidatePaths = [
-      this.#authJsonPath,
       path.join(os.homedir(), ".codex", "auth.json")
     ].filter((value): value is string => Boolean(value));
 
@@ -504,6 +508,25 @@ async function waitForAppServerListen(
 function formatStartupDetails(stdoutTail: string, stderrTail: string): string {
   const details = (stderrTail || stdoutTail).trim();
   return details ? `: ${details}` : "";
+}
+
+async function pointSymlink(linkPath: string, targetPath: string): Promise<void> {
+  const desiredTarget = path.relative(path.dirname(linkPath), targetPath);
+  try {
+    const currentTarget = await fs.readlink(linkPath);
+    const resolvedCurrent = path.resolve(path.dirname(linkPath), currentTarget);
+    if (path.resolve(resolvedCurrent) === path.resolve(targetPath)) {
+      return;
+    }
+  } catch (error) {
+    if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT") &&
+        !(error && typeof error === "object" && "code" in error && error.code === "EINVAL")) {
+      throw error;
+    }
+  }
+
+  await fs.rm(linkPath, { force: true });
+  await fs.symlink(desiredTarget, linkPath);
 }
 
 function isAddressInUseStartupError(error: unknown): boolean {

--- a/src/services/service-components.ts
+++ b/src/services/service-components.ts
@@ -3,6 +3,8 @@ import { configureLogger } from "../logger.js";
 import { StateStore } from "../store/state-store.js";
 import type { AgentRuntime } from "./agent-runtime/types.js";
 import { CodexAppServerRuntime } from "./agent-runtime/codex-app-server-runtime.js";
+import { SessionAuthProfileRuntime } from "./agent-runtime/session-auth-profile-runtime.js";
+import type { AuthProfileService } from "./auth-profile-service.js";
 import { CodexBroker } from "./codex/codex-broker.js";
 import { IsolatedMcpService } from "./codex/isolated-mcp-service.js";
 import { DiskPressureCleanupService } from "./disk-pressure-cleanup-service.js";
@@ -67,12 +69,22 @@ export function createCodexBroker(config: AppConfig): CodexBroker {
 }
 
 export function createAgentRuntime(options: {
+  readonly config: AppConfig;
   readonly codex: CodexBroker;
   readonly sessions: SessionManager;
+  readonly authProfiles: AuthProfileService;
 }): AgentRuntime {
-  return new CodexAppServerRuntime({
-    codex: options.codex,
-    sessions: options.sessions
+  const legacyRuntime = options.config.codexAppServerUrl
+    ? new CodexAppServerRuntime({
+        codex: options.codex,
+        sessions: options.sessions
+      })
+    : undefined;
+  return new SessionAuthProfileRuntime({
+    config: options.config,
+    sessions: options.sessions,
+    authProfiles: options.authProfiles,
+    legacyRuntime
   });
 }
 

--- a/src/services/session-auth-profile-selector.ts
+++ b/src/services/session-auth-profile-selector.ts
@@ -1,0 +1,147 @@
+import type { AuthProfileSummary, AuthProfilesStatus } from "./auth-profile-service.js";
+
+export type AuthProfileUnavailableReason =
+  | "profile_not_found"
+  | "account_probe_failed"
+  | "rate_limits_probe_failed"
+  | "primary_quota_exhausted"
+  | "secondary_quota_exhausted"
+  | "credits_exhausted"
+  | "no_usable_auth_profiles";
+
+export interface AuthProfileEvaluation {
+  readonly profileName: string;
+  readonly usable: boolean;
+  readonly reason?: AuthProfileUnavailableReason | undefined;
+  readonly effectiveRemainingPercent: number;
+  readonly primaryRemainingPercent?: number | undefined;
+  readonly secondaryRemainingPercent?: number | undefined;
+}
+
+export function selectBestAuthProfile(status: AuthProfilesStatus): AuthProfileSummary | null {
+  const candidates = status.profiles
+    .map((profile) => ({
+      profile,
+      evaluation: evaluateAuthProfile(profile)
+    }))
+    .filter((candidate) => candidate.evaluation.usable)
+    .sort((left, right) => {
+      const remainingDelta = right.evaluation.effectiveRemainingPercent - left.evaluation.effectiveRemainingPercent;
+      if (remainingDelta) {
+        return remainingDelta;
+      }
+
+      const secondaryDelta =
+        (right.evaluation.secondaryRemainingPercent ?? 100) -
+        (left.evaluation.secondaryRemainingPercent ?? 100);
+      if (secondaryDelta) {
+        return secondaryDelta;
+      }
+
+      const primaryDelta =
+        (right.evaluation.primaryRemainingPercent ?? 100) -
+        (left.evaluation.primaryRemainingPercent ?? 100);
+      if (primaryDelta) {
+        return primaryDelta;
+      }
+
+      return left.profile.name.localeCompare(right.profile.name);
+    });
+
+  return candidates[0]?.profile ?? null;
+}
+
+export function findAuthProfile(status: AuthProfilesStatus, profileName: string): AuthProfileSummary | null {
+  return status.profiles.find((profile) => profile.name === profileName) ?? null;
+}
+
+export function evaluateAuthProfile(profile: AuthProfileSummary): AuthProfileEvaluation {
+  if (!profile.account.ok) {
+    return unavailable(profile.name, "account_probe_failed");
+  }
+
+  if (!profile.rateLimits.ok) {
+    return unavailable(profile.name, "rate_limits_probe_failed");
+  }
+
+  const limits = profile.rateLimits.rateLimits;
+  const primaryRemaining = remainingPercent(limits?.primary?.usedPercent);
+  const secondaryRemaining = remainingPercent(limits?.secondary?.usedPercent);
+  const credits = limits?.credits;
+
+  if (primaryRemaining !== undefined && primaryRemaining <= 0) {
+    return unavailable(profile.name, "primary_quota_exhausted", {
+      primaryRemainingPercent: primaryRemaining,
+      secondaryRemainingPercent: secondaryRemaining
+    });
+  }
+
+  if (secondaryRemaining !== undefined && secondaryRemaining <= 0) {
+    return unavailable(profile.name, "secondary_quota_exhausted", {
+      primaryRemainingPercent: primaryRemaining,
+      secondaryRemainingPercent: secondaryRemaining
+    });
+  }
+
+  if (credits && !credits.unlimited && credits.hasCredits === false) {
+    return unavailable(profile.name, "credits_exhausted", {
+      primaryRemainingPercent: primaryRemaining,
+      secondaryRemainingPercent: secondaryRemaining
+    });
+  }
+
+  return {
+    profileName: profile.name,
+    usable: true,
+    effectiveRemainingPercent: Math.min(primaryRemaining ?? 100, secondaryRemaining ?? 100),
+    primaryRemainingPercent: primaryRemaining,
+    secondaryRemainingPercent: secondaryRemaining
+  };
+}
+
+export function authProfileReasonLabel(reason: string | undefined): string {
+  switch (reason) {
+    case "profile_not_found":
+      return "绑定的账号不存在";
+    case "account_probe_failed":
+      return "账号状态读取失败";
+    case "rate_limits_probe_failed":
+      return "额度状态读取失败";
+    case "primary_quota_exhausted":
+      return "短窗口额度已耗尽";
+    case "secondary_quota_exhausted":
+      return "周额度已耗尽";
+    case "credits_exhausted":
+      return "账号 credits 不可用";
+    case "no_usable_auth_profiles":
+      return "没有可用账号";
+    default:
+      return reason || "账号不可用";
+  }
+}
+
+function remainingPercent(usedPercent: number | undefined): number | undefined {
+  if (!Number.isFinite(usedPercent)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.min(100, 100 - Number(usedPercent)));
+}
+
+function unavailable(
+  profileName: string,
+  reason: AuthProfileUnavailableReason,
+  partial?: {
+    readonly primaryRemainingPercent?: number | undefined;
+    readonly secondaryRemainingPercent?: number | undefined;
+  }
+): AuthProfileEvaluation {
+  return {
+    profileName,
+    usable: false,
+    reason,
+    effectiveRemainingPercent: 0,
+    primaryRemainingPercent: partial?.primaryRemainingPercent,
+    secondaryRemainingPercent: partial?.secondaryRemainingPercent
+  };
+}

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -201,6 +201,60 @@ export class SessionManager {
     });
   }
 
+  async setSessionAuthProfile(
+    sessionKey: string,
+    profileName: string,
+    options?: {
+      readonly boundAt?: string | undefined;
+    }
+  ): Promise<SlackSessionRecord> {
+    return await this.#stateStore.patchSession(sessionKey, {
+      authProfileName: profileName,
+      authProfileBoundAt: options?.boundAt ?? new Date().toISOString()
+    });
+  }
+
+  async markSessionAuthBlocked(
+    sessionKey: string,
+    options: {
+      readonly reason: string;
+      readonly blockedAt?: string | undefined;
+    }
+  ): Promise<SlackSessionRecord> {
+    return await this.#stateStore.patchSession(sessionKey, {
+      authBlockedAt: options.blockedAt ?? new Date().toISOString(),
+      authBlockReason: options.reason
+    });
+  }
+
+  async setSessionAuthBlockedNoticePostedAt(
+    sessionKey: string,
+    postedAt: string
+  ): Promise<SlackSessionRecord> {
+    return await this.#stateStore.patchSession(sessionKey, {
+      authBlockedNoticePostedAt: postedAt
+    });
+  }
+
+  async switchSessionAuthProfileAndClearBlock(
+    sessionKey: string,
+    profileName: string,
+    options?: {
+      readonly boundAt?: string | undefined;
+    }
+  ): Promise<SlackSessionRecord> {
+    return await this.#stateStore.patchSession(sessionKey, {
+      authProfileName: profileName,
+      authProfileBoundAt: options?.boundAt ?? new Date().toISOString(),
+      authBlockedAt: undefined,
+      authBlockReason: undefined,
+      authBlockedNoticePostedAt: undefined,
+      agentSessionId: undefined,
+      activeTurnId: undefined,
+      activeTurnStartedAt: undefined
+    });
+  }
+
   async recordTurnSignal(
     channelId: string,
     rootThreadTs: string,

--- a/src/services/slack/slack-agent-bridge.ts
+++ b/src/services/slack/slack-agent-bridge.ts
@@ -133,6 +133,10 @@ export class SlackAgentBridge {
     return await this.#conversations.replayThreadMessage(options);
   }
 
+  async resumePendingSession(sessionKey: string): Promise<number> {
+    return await this.#conversations.resumePendingSession(sessionKey);
+  }
+
   async acceptBackgroundJobEvent(options: {
     readonly channelId: string;
     readonly rootThreadTs: string;

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -15,6 +16,10 @@ import type {
   SlackTurnSignalKind
 } from "../../types.js";
 import type { AgentRuntime, AgentRuntimeEvent } from "../agent-runtime/types.js";
+import {
+  isAuthProfileUnavailableError,
+  type AuthProfileUnavailableError
+} from "../agent-runtime/session-auth-profile-runtime.js";
 import { AgentTraceRecorder } from "../agent-runtime/agent-trace-recorder.js";
 import {
   SlackApi,
@@ -262,6 +267,17 @@ export class SlackConversationService {
 
     await this.acceptInboundMessage(session, input);
     return input;
+  }
+
+  async resumePendingSession(sessionKey: string): Promise<number> {
+    const session = this.#findSessionByKey(sessionKey);
+    if (session.authBlockedAt) {
+      throw new Error(`Session auth is still blocked: ${sessionKey}`);
+    }
+
+    return await this.#resumePendingDispatch(sessionKey, {
+      forceReset: true
+    });
   }
 
   async acceptBackgroundJobEvent(options: {
@@ -1132,6 +1148,11 @@ export class SlackConversationService {
           return;
         }
 
+        if (isAuthProfileUnavailableError(error)) {
+          await this.#handleAuthProfileUnavailable(session, error, runtime);
+          break;
+        }
+
         logger.error("Slack conversation turn dispatch failed", {
           sessionKey,
           channelId: session.channelId,
@@ -1310,6 +1331,9 @@ export class SlackConversationService {
       if (refreshedSession.activeTurnId) {
         continue;
       }
+      if (refreshedSession.authBlockedAt) {
+        continue;
+      }
 
       const resumedCount = await this.#resumePendingDispatch(refreshedSession.key);
 
@@ -1375,6 +1399,9 @@ export class SlackConversationService {
       if (runtime.processing) {
         continue;
       }
+      if (session.authBlockedAt) {
+        continue;
+      }
 
       const reconciled = await this.#inboundStore.reconcileOrphanedInflightMessages(session);
       if (reconciled.markedDoneCount > 0 || reconciled.resetToPendingCount > 0) {
@@ -1399,6 +1426,9 @@ export class SlackConversationService {
       .sort((left, right) => compareIsoTimestamp(right.updatedAt, left.updatedAt));
 
     for (const session of sessions) {
+      if (session.authBlockedAt) {
+        continue;
+      }
       const pendingSyntheticMessages = this.#sessions.listInboundMessages({
         channelId: session.channelId,
         rootThreadTs: session.rootThreadTs,
@@ -1503,5 +1533,86 @@ export class SlackConversationService {
       default:
         return;
     }
+  }
+
+  async #handleAuthProfileUnavailable(
+    session: SlackSessionRecord,
+    error: AuthProfileUnavailableError,
+    runtime: RuntimeSessionState
+  ): Promise<void> {
+    logger.warn("Pausing Slack session until a human switches auth profile", {
+      sessionKey: session.key,
+      profileName: error.profileName ?? null,
+      reason: error.reason
+    });
+
+    runtime.blockedUntilMs = Number.MAX_SAFE_INTEGER;
+    runtime.blockedFailureFingerprint = `auth:${error.profileName ?? "none"}:${error.reason}`;
+    const alreadyBlocked = Boolean(session.authBlockedAt);
+    const blockedAt = new Date().toISOString();
+    let blockedSession = await this.#sessions.markSessionAuthBlocked(session.key, {
+      reason: error.reason,
+      blockedAt
+    });
+    blockedSession = await this.#sessions.setActiveTurnId(
+      blockedSession.channelId,
+      blockedSession.rootThreadTs,
+      undefined
+    );
+    if (!alreadyBlocked) {
+      await this.#recordAuthBlockedTrace(blockedSession, error, blockedAt);
+    }
+
+    if (!blockedSession.authBlockedNoticePostedAt) {
+      const url = buildAdminSessionUrl(this.#config.adminBaseUrl, blockedSession.key);
+      const postedAt = new Date().toISOString();
+      await this.#postBotThreadMessage(
+        blockedSession.channelId,
+        blockedSession.rootThreadTs,
+        [
+          `当前会话绑定的账号额度不可用：${error.userMessage}`,
+          `<${url}|打开 Session 页面手动切换账号并继续处理>`
+        ].join("\n"),
+        {
+          alreadyFormatted: true,
+          turnSignal: {
+            kind: "block",
+            reason: error.reason
+          }
+        }
+      );
+      await this.#sessions.setSessionAuthBlockedNoticePostedAt(blockedSession.key, postedAt);
+    }
+
+    this.#clearAssistantStatus(blockedSession.channelId, blockedSession.rootThreadTs);
+  }
+
+  async #recordAuthBlockedTrace(
+    session: SlackSessionRecord,
+    error: AuthProfileUnavailableError,
+    at: string
+  ): Promise<void> {
+    const existingCount = this.#sessions.listAgentTraceEvents(session.key, 10_000).length;
+    await this.#sessions.upsertAgentTraceEvent({
+      id: randomUUID(),
+      sessionKey: session.key,
+      source: "broker",
+      type: "agent_runtime_error",
+      at,
+      sequence: existingCount + 1,
+      title: "Auth 不可用",
+      summary: `等待人工切换账号：${error.userMessage}`,
+      detail: JSON.stringify({
+        profileName: error.profileName ?? null,
+        reason: error.reason
+      }, null, 2),
+      status: "blocked",
+      metadata: {
+        profileName: error.profileName ?? null,
+        reason: error.reason
+      },
+      createdAt: at,
+      updatedAt: at
+    });
   }
 }

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -19,7 +19,7 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 10;
+export const CURRENT_STATE_SCHEMA_VERSION = 11;
 const ADMIN_EVENT_RETENTION_LIMIT = 20_000;
 
 type SqlValue = string | number | bigint | null;
@@ -53,6 +53,11 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
           last_delivered_message_ts TEXT,
           last_slack_reply_at TEXT,
           session_page_link_posted_at TEXT,
+          auth_profile_name TEXT,
+          auth_profile_bound_at TEXT,
+          auth_blocked_at TEXT,
+          auth_block_reason TEXT,
+          auth_blocked_notice_posted_at TEXT,
           last_turn_signal_turn_id TEXT,
           last_turn_signal_kind TEXT,
           last_turn_signal_reason TEXT,
@@ -283,6 +288,13 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
     up(database) {
       repairSessionPageLinkAnnouncementSchema(database);
     }
+  },
+  {
+    version: 11,
+    name: "session_auth_profile_binding",
+    up(database) {
+      repairSessionAuthProfileSchema(database);
+    }
   }
 ];
 
@@ -336,6 +348,29 @@ function repairSessionPageLinkAnnouncementSchema(database: DatabaseSync): void {
   const columns = tableColumns(database, "sessions");
   if (!columns.has("session_page_link_posted_at")) {
     database.exec("ALTER TABLE sessions ADD COLUMN session_page_link_posted_at TEXT");
+  }
+}
+
+function repairSessionAuthProfileSchema(database: DatabaseSync): void {
+  if (!tableExists(database, "sessions")) {
+    return;
+  }
+
+  const columns = tableColumns(database, "sessions");
+  if (!columns.has("auth_profile_name")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN auth_profile_name TEXT");
+  }
+  if (!columns.has("auth_profile_bound_at")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN auth_profile_bound_at TEXT");
+  }
+  if (!columns.has("auth_blocked_at")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN auth_blocked_at TEXT");
+  }
+  if (!columns.has("auth_block_reason")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN auth_block_reason TEXT");
+  }
+  if (!columns.has("auth_blocked_notice_posted_at")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN auth_blocked_notice_posted_at TEXT");
   }
 }
 
@@ -999,11 +1034,12 @@ export class StateStore {
         key, channel_id, channel_name, channel_type, root_thread_ts, workspace_path, created_at, updated_at,
         agent_session_id, active_turn_id, active_turn_started_at,
         last_observed_message_ts, last_delivered_message_ts, last_slack_reply_at, session_page_link_posted_at,
+        auth_profile_name, auth_profile_bound_at, auth_blocked_at, auth_block_reason, auth_blocked_notice_posted_at,
         last_turn_signal_turn_id, last_turn_signal_kind, last_turn_signal_reason, last_turn_signal_at,
         co_author_candidate_user_ids, co_author_candidate_revision,
         co_author_confirmed_user_ids, co_author_confirmed_revision,
         co_author_ignore_missing_revision, co_author_prompt_revision, co_author_prompted_at
-      ) VALUES (${placeholders(26)})
+      ) VALUES (${placeholders(31)})
       ON CONFLICT(key) DO UPDATE SET
         channel_id = excluded.channel_id,
         channel_name = excluded.channel_name,
@@ -1019,6 +1055,11 @@ export class StateStore {
         last_delivered_message_ts = excluded.last_delivered_message_ts,
         last_slack_reply_at = excluded.last_slack_reply_at,
         session_page_link_posted_at = excluded.session_page_link_posted_at,
+        auth_profile_name = excluded.auth_profile_name,
+        auth_profile_bound_at = excluded.auth_profile_bound_at,
+        auth_blocked_at = excluded.auth_blocked_at,
+        auth_block_reason = excluded.auth_block_reason,
+        auth_blocked_notice_posted_at = excluded.auth_blocked_notice_posted_at,
         last_turn_signal_turn_id = excluded.last_turn_signal_turn_id,
         last_turn_signal_kind = excluded.last_turn_signal_kind,
         last_turn_signal_reason = excluded.last_turn_signal_reason,
@@ -1046,6 +1087,11 @@ export class StateStore {
       record.lastDeliveredMessageTs ?? null,
       record.lastSlackReplyAt ?? null,
       record.sessionPageLinkPostedAt ?? null,
+      record.authProfileName ?? null,
+      record.authProfileBoundAt ?? null,
+      record.authBlockedAt ?? null,
+      record.authBlockReason ?? null,
+      record.authBlockedNoticePostedAt ?? null,
       record.lastTurnSignalTurnId ?? null,
       record.lastTurnSignalKind ?? null,
       record.lastTurnSignalReason ?? null,
@@ -1372,6 +1418,11 @@ export class StateStore {
       lastDeliveredMessageTs: optionalStringColumn(row, "last_delivered_message_ts"),
       lastSlackReplyAt: optionalStringColumn(row, "last_slack_reply_at"),
       sessionPageLinkPostedAt: optionalStringColumn(row, "session_page_link_posted_at"),
+      authProfileName: optionalStringColumn(row, "auth_profile_name"),
+      authProfileBoundAt: optionalStringColumn(row, "auth_profile_bound_at"),
+      authBlockedAt: optionalStringColumn(row, "auth_blocked_at"),
+      authBlockReason: optionalStringColumn(row, "auth_block_reason"),
+      authBlockedNoticePostedAt: optionalStringColumn(row, "auth_blocked_notice_posted_at"),
       lastTurnSignalTurnId: optionalStringColumn(row, "last_turn_signal_turn_id"),
       lastTurnSignalKind: optionalStringColumn(row, "last_turn_signal_kind") as SlackSessionRecord["lastTurnSignalKind"],
       lastTurnSignalReason: optionalStringColumn(row, "last_turn_signal_reason"),
@@ -1564,6 +1615,11 @@ export class StateStore {
       lastDeliveredMessageTs: session.lastDeliveredMessageTs,
       lastSlackReplyAt: session.lastSlackReplyAt,
       sessionPageLinkPostedAt: session.sessionPageLinkPostedAt,
+      authProfileName: optionalNonEmptyString(session.authProfileName),
+      authProfileBoundAt: session.authProfileBoundAt,
+      authBlockedAt: session.authBlockedAt,
+      authBlockReason: optionalNonEmptyString(session.authBlockReason),
+      authBlockedNoticePostedAt: session.authBlockedNoticePostedAt,
       lastTurnSignalTurnId: session.lastTurnSignalTurnId,
       lastTurnSignalKind: session.lastTurnSignalKind,
       lastTurnSignalReason: session.lastTurnSignalReason,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,11 @@ export interface SlackSessionRecord {
   readonly lastDeliveredMessageTs?: string | undefined;
   readonly lastSlackReplyAt?: string | undefined;
   readonly sessionPageLinkPostedAt?: string | undefined;
+  readonly authProfileName?: string | undefined;
+  readonly authProfileBoundAt?: string | undefined;
+  readonly authBlockedAt?: string | undefined;
+  readonly authBlockReason?: string | undefined;
+  readonly authBlockedNoticePostedAt?: string | undefined;
   readonly lastTurnSignalTurnId?: string | undefined;
   readonly lastTurnSignalKind?: SlackTurnSignalKind | undefined;
   readonly lastTurnSignalReason?: string | undefined;
@@ -137,6 +142,7 @@ export type AdminOperationKind =
   | "auth_profile_add"
   | "auth_profile_delete"
   | "auth_profile_activate"
+  | "session_auth_profile_switch"
   | "github_author_upsert"
   | "github_author_delete";
 

--- a/src/worker-index.ts
+++ b/src/worker-index.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import { loadConfig } from "./config.js";
 import { createHttpHandler } from "./http/router.js";
 import { logger } from "./logger.js";
+import { AuthProfileService } from "./services/auth-profile-service.js";
 import {
   configureServiceLogger,
   createAgentRuntime,
@@ -23,10 +24,15 @@ export async function startWorkerService(): Promise<{
 
   const { sessions: sessionManager } = createSessionServices(config);
   const githubAuthorMappings = await createGitHubAuthorMappings(config);
+  const authProfiles = new AuthProfileService({
+    config
+  });
   const codexBroker = createCodexBroker(config);
   const agentRuntime = createAgentRuntime({
+    config,
     codex: codexBroker,
-    sessions: sessionManager
+    sessions: sessionManager,
+    authProfiles
   });
   const bridge = createSlackBridge({
     config,

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { loadConfig } from "../src/config.js";
 import { createHttpHandler } from "../src/http/router.js";
 import { AdminService } from "../src/services/admin-service.js";
+import type { AuthProfilesStatus } from "../src/services/auth-profile-service.js";
 import { SessionManager } from "../src/services/session-manager.js";
 import { StateStore } from "../src/store/state-store.js";
 import type { AppConfig } from "../src/config.js";
@@ -180,6 +181,73 @@ describe("admin control plane e2e", () => {
     );
   });
 
+  it("switches a blocked session auth profile and asks the worker to resume pending dispatch", async () => {
+    const workerResumePaths: string[] = [];
+    const worker = http.createServer((request, response) => {
+      workerResumePaths.push(request.url ?? "");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, resumedCount: 1 }));
+    });
+    await new Promise<void>((resolve) => worker.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        worker.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    });
+    const address = worker.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start worker fixture");
+    }
+
+    const { baseUrl, sessions } = await startAdminFixture({
+      workerBaseUrl: `http://127.0.0.1:${address.port}`,
+      authProfilesStatus: authProfilesStatusFixture()
+    });
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "old-thread");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "old-turn");
+    session = await sessions.setSessionAuthProfile(session.key, "empty-profile", {
+      boundAt: "2026-05-09T00:00:00.000Z"
+    });
+    await sessions.markSessionAuthBlocked(session.key, {
+      reason: "primary_quota_exhausted",
+      blockedAt: "2026-05-09T01:00:00.000Z"
+    });
+
+    const result = await postJson(
+      `${baseUrl}/admin/api/sessions/${encodeURIComponent(session.key)}/auth-profile`,
+      { name: "usable-profile" }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      workerResume: {
+        ok: true,
+        resumedCount: 1
+      },
+      session: {
+        key: session.key,
+        authProfileName: "usable-profile",
+        authBlockedAt: null,
+        agentSessionId: null,
+        activeTurnId: null
+      }
+    });
+    expect(workerResumePaths).toEqual([
+      `/slack/sessions/${encodeURIComponent(session.key)}/resume-pending`
+    ]);
+    expect(sessions.getSessionByKey(session.key)).toMatchObject({
+      authProfileName: "usable-profile",
+      authBlockedAt: undefined,
+      authBlockReason: undefined,
+      agentSessionId: undefined,
+      activeTurnId: undefined
+    });
+  });
+
   it("records deploy requests as durable admin operations with audit events", async () => {
     const { baseUrl, deploymentCalls } = await startAdminFixture();
 
@@ -288,7 +356,10 @@ describe("admin control plane e2e", () => {
     });
   });
 
-  async function startAdminFixture(): Promise<{
+  async function startAdminFixture(options?: {
+    readonly authProfilesStatus?: AuthProfilesStatus | undefined;
+    readonly workerBaseUrl?: string | undefined;
+  }): Promise<{
     readonly baseUrl: string;
     readonly config: AppConfig;
     readonly sessions: SessionManager;
@@ -307,7 +378,8 @@ describe("admin control plane e2e", () => {
       ADMIN_LAUNCHD_LABEL: "admin.test",
       WORKER_LAUNCHD_LABEL: "worker.test",
       ADMIN_PLIST_PATH: path.join(dataRoot, "admin.plist"),
-      WORKER_PLIST_PATH: path.join(dataRoot, "worker.plist")
+      WORKER_PLIST_PATH: path.join(dataRoot, "worker.plist"),
+      ...(options?.workerBaseUrl ? { WORKER_BASE_URL: options.workerBaseUrl } : {})
     } as NodeJS.ProcessEnv);
     await fs.mkdir(config.codexHome, { recursive: true });
     await fs.mkdir(config.logDir, { recursive: true });
@@ -328,7 +400,7 @@ describe("admin control plane e2e", () => {
       sessions,
       startedAt: new Date("2026-03-19T00:00:00.000Z"),
       authProfiles: {
-        listProfilesStatus: async () => ({
+        listProfilesStatus: async () => options?.authProfilesStatus ?? ({
           managedRoot: path.join(dataRoot, "auth-profiles"),
           profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
           activeProfile: null,
@@ -668,6 +740,58 @@ function deploymentStatus(config: AppConfig): Record<string, unknown> {
       readyOk: true,
       healthBody: "{\"ok\":true}",
       readyError: null
+    }
+  };
+}
+
+function authProfilesStatusFixture(): AuthProfilesStatus {
+  return {
+    managedRoot: "/tmp/auth-profiles",
+    profilesRoot: "/tmp/auth-profiles/docker/profiles",
+    activeProfile: "empty-profile",
+    activeAuthPath: "/tmp/codex-home/auth.json",
+    profiles: [
+      authProfileFixture("empty-profile", 100, 20),
+      authProfileFixture("usable-profile", 10, 15)
+    ]
+  };
+}
+
+function authProfileFixture(name: string, primaryUsed: number, secondaryUsed: number): AuthProfilesStatus["profiles"][number] {
+  return {
+    name,
+    path: `/tmp/auth-profiles/docker/profiles/${name}.json`,
+    active: name === "empty-profile",
+    source: "probe",
+    checkedAt: "2026-05-09T00:00:00.000Z",
+    account: {
+      ok: true,
+      account: {
+        email: `${name}@example.com`,
+        type: "chatgpt",
+        planType: "pro"
+      },
+      requiresOpenaiAuth: false
+    },
+    rateLimits: {
+      ok: true,
+      rateLimits: {
+        limitId: "codex",
+        limitName: "Codex",
+        primary: {
+          usedPercent: primaryUsed,
+          windowDurationMins: 300,
+          resetsAt: 1_779_000_000
+        },
+        secondary: {
+          usedPercent: secondaryUsed,
+          windowDurationMins: 10_080,
+          resetsAt: 1_780_000_000
+        },
+        credits: null,
+        planType: "pro"
+      },
+      rateLimitsByLimitId: {}
     }
   };
 }

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -76,8 +76,18 @@ describe("admin token usage e2e", () => {
 
     const codex = createCodexBroker(config);
     const agentRuntime = createAgentRuntime({
+      config,
       codex,
-      sessions
+      sessions,
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
+          activeProfile: null,
+          activeAuthPath: path.join(config.codexHome, "auth.json"),
+          profiles: []
+        })
+      } as never
     });
     await agentRuntime.start();
     cleanups.push(async () => {

--- a/test/session-auth-profile-runtime.test.ts
+++ b/test/session-auth-profile-runtime.test.ts
@@ -1,0 +1,282 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+import {
+  AuthProfileUnavailableError,
+  SessionAuthProfileRuntime
+} from "../src/services/agent-runtime/session-auth-profile-runtime.js";
+import type {
+  AgentRuntime,
+  AgentRuntimeCapabilities,
+  AgentSession,
+  AgentSubmitInputResult,
+  AgentTurnSnapshot,
+  SubmitAgentInput
+} from "../src/services/agent-runtime/types.js";
+import type { AuthProfileSummary, AuthProfilesStatus } from "../src/services/auth-profile-service.js";
+import type { SlackSessionRecord, SlackUserIdentity } from "../src/types.js";
+
+describe("SessionAuthProfileRuntime", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+  });
+
+  it("binds a new session to the best usable auth profile and routes through that runtime", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "session-auth-runtime-"));
+    tempDirs.push(dataRoot);
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot
+    } as NodeJS.ProcessEnv);
+    const session = createSession();
+    const sessions = createSessionManagerMock(session);
+    const runtimes = new Map<string, MockAgentRuntime>();
+    const runtime = new SessionAuthProfileRuntime({
+      config,
+      sessions: sessions as never,
+      authProfiles: authProfilesMock(profileStatus([
+        profile("low", 10, 80),
+        profile("best", 20, 10)
+      ])) as never,
+      createProfileRuntime: ({ profile }) => {
+        const mockRuntime = new MockAgentRuntime(profile.name);
+        runtimes.set(profile.name, mockRuntime);
+        return mockRuntime;
+      }
+    });
+
+    const agentSession = await runtime.ensureSession(session);
+
+    expect(agentSession).toMatchObject({
+      id: "best-thread",
+      runtime: "codex-app-server"
+    });
+    expect(sessions.get(session.key)?.authProfileName).toBe("best");
+    expect(runtimes.get("best")?.ensureSession).toHaveBeenCalledWith(expect.objectContaining({
+      authProfileName: "best"
+    }));
+    expect(runtimes.has("low")).toBe(false);
+  });
+
+  it("keeps an existing usable binding instead of switching to a higher quota profile", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "session-auth-runtime-bound-"));
+    tempDirs.push(dataRoot);
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot
+    } as NodeJS.ProcessEnv);
+    const session = createSession({
+      authProfileName: "bound",
+      authProfileBoundAt: "2026-05-09T00:00:00.000Z"
+    });
+    const sessions = createSessionManagerMock(session);
+    const runtimes = new Map<string, MockAgentRuntime>();
+    const runtime = new SessionAuthProfileRuntime({
+      config,
+      sessions: sessions as never,
+      authProfiles: authProfilesMock(profileStatus([
+        profile("bound", 60, 40),
+        profile("bigger", 1, 1)
+      ])) as never,
+      createProfileRuntime: ({ profile }) => {
+        const mockRuntime = new MockAgentRuntime(profile.name);
+        runtimes.set(profile.name, mockRuntime);
+        return mockRuntime;
+      }
+    });
+
+    await runtime.submitInput({
+      session,
+      input: [],
+      inputId: "input-1",
+      source: "slack_user"
+    });
+
+    expect(runtimes.get("bound")?.submitInput).toHaveBeenCalledTimes(1);
+    expect(runtimes.has("bigger")).toBe(false);
+    expect(sessions.get(session.key)?.authProfileName).toBe("bound");
+  });
+
+  it("does not auto-switch when the bound auth profile is unavailable", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "session-auth-runtime-blocked-"));
+    tempDirs.push(dataRoot);
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot
+    } as NodeJS.ProcessEnv);
+    const session = createSession({
+      authProfileName: "empty",
+      authProfileBoundAt: "2026-05-09T00:00:00.000Z"
+    });
+    const sessions = createSessionManagerMock(session);
+    const runtimes = new Map<string, MockAgentRuntime>();
+    const runtime = new SessionAuthProfileRuntime({
+      config,
+      sessions: sessions as never,
+      authProfiles: authProfilesMock(profileStatus([
+        profile("empty", 100, 10),
+        profile("usable", 0, 0)
+      ])) as never,
+      createProfileRuntime: ({ profile }) => {
+        const mockRuntime = new MockAgentRuntime(profile.name);
+        runtimes.set(profile.name, mockRuntime);
+        return mockRuntime;
+      }
+    });
+
+    await expect(runtime.submitInput({
+      session,
+      input: [],
+      inputId: "input-1",
+      source: "slack_user"
+    })).rejects.toBeInstanceOf(AuthProfileUnavailableError);
+
+    expect(runtimes.size).toBe(0);
+    expect(sessions.get(session.key)?.authProfileName).toBe("empty");
+  });
+});
+
+class MockAgentRuntime extends EventEmitter implements AgentRuntime {
+  readonly ensureSession = vi.fn(async (session: SlackSessionRecord): Promise<AgentSession> => ({
+    id: `${this.profileName}-thread`,
+    brokerSessionKey: session.key,
+    runtime: "codex-app-server",
+    createdAt: "2026-05-09T00:00:00.000Z"
+  }));
+  readonly submitInput = vi.fn(async (input: SubmitAgentInput): Promise<AgentSubmitInputResult> => ({
+    receipt: {
+      agentSessionId: `${this.profileName}-thread`,
+      turnId: `${this.profileName}-turn`,
+      inputId: input.inputId,
+      delivery: "started_turn",
+      deliveredAt: "2026-05-09T00:00:00.000Z"
+    },
+    completion: Promise.resolve({
+      agentSessionId: `${this.profileName}-thread`,
+      turnId: `${this.profileName}-turn`,
+      finalMessage: "",
+      aborted: false
+    })
+  }));
+  readonly interrupt = vi.fn(async () => undefined);
+  readonly readSession = vi.fn(async () => null);
+  readonly readTurn = vi.fn(async (): Promise<AgentTurnSnapshot | null> => null);
+  readonly start = vi.fn(async () => undefined);
+  readonly stop = vi.fn(async () => undefined);
+  readonly setSlackBotIdentity = vi.fn((_identity: SlackUserIdentity | null) => undefined);
+
+  constructor(private readonly profileName: string) {
+    super();
+  }
+
+  getCapabilities(): AgentRuntimeCapabilities {
+    return {
+      submitWhileActive: true,
+      interrupt: true,
+      readTurn: true,
+      readSession: true,
+      rawEvents: true,
+      tokenUsage: "exact",
+      toolCalls: true,
+      systemPromptEcho: true
+    };
+  }
+}
+
+function createSession(patch: Partial<SlackSessionRecord> = {}): SlackSessionRecord {
+  return {
+    key: "C123:111.222",
+    channelId: "C123",
+    rootThreadTs: "111.222",
+    workspacePath: "/tmp/workspace",
+    createdAt: "2026-05-09T00:00:00.000Z",
+    updatedAt: "2026-05-09T00:00:00.000Z",
+    ...patch
+  };
+}
+
+function createSessionManagerMock(initial: SlackSessionRecord) {
+  const sessions = new Map<string, SlackSessionRecord>([[initial.key, initial]]);
+  return {
+    get: (key: string) => sessions.get(key),
+    getSessionByKey: vi.fn((key: string) => sessions.get(key)),
+    listSessions: vi.fn(() => [...sessions.values()]),
+    setSessionAuthProfile: vi.fn(async (sessionKey: string, profileName: string) => {
+      const existing = sessions.get(sessionKey);
+      if (!existing) throw new Error(`Unknown session: ${sessionKey}`);
+      const updated = {
+        ...existing,
+        authProfileName: profileName,
+        authProfileBoundAt: "2026-05-09T00:00:01.000Z",
+        updatedAt: "2026-05-09T00:00:01.000Z"
+      };
+      sessions.set(sessionKey, updated);
+      return updated;
+    })
+  };
+}
+
+function authProfilesMock(status: AuthProfilesStatus) {
+  return {
+    listProfilesStatus: vi.fn(async () => status)
+  };
+}
+
+function profileStatus(profiles: readonly AuthProfileSummary[]): AuthProfilesStatus {
+  return {
+    managedRoot: "/tmp/auth-profiles",
+    profilesRoot: "/tmp/auth-profiles/docker/profiles",
+    activeProfile: profiles[0]?.name ?? null,
+    activeAuthPath: "/tmp/codex-home/auth.json",
+    profiles
+  };
+}
+
+function profile(name: string, primaryUsed: number, secondaryUsed: number): AuthProfileSummary {
+  return {
+    name,
+    path: `/tmp/auth-profiles/docker/profiles/${name}.json`,
+    active: false,
+    source: "probe",
+    checkedAt: "2026-05-09T00:00:00.000Z",
+    account: {
+      ok: true,
+      account: {
+        email: `${name}@example.com`,
+        type: "chatgpt",
+        planType: "pro"
+      },
+      requiresOpenaiAuth: false
+    },
+    rateLimits: {
+      ok: true,
+      rateLimits: {
+        limitId: "codex",
+        limitName: "Codex",
+        primary: {
+          usedPercent: primaryUsed,
+          windowDurationMins: 300,
+          resetsAt: 1_779_000_000
+        },
+        secondary: {
+          usedPercent: secondaryUsed,
+          windowDurationMins: 10_080,
+          resetsAt: 1_780_000_000
+        },
+        credits: null,
+        planType: "pro"
+      },
+      rateLimitsByLimitId: {}
+    }
+  };
+}

--- a/test/session-auth-profile-selector.test.ts
+++ b/test/session-auth-profile-selector.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateAuthProfile,
+  selectBestAuthProfile
+} from "../src/services/session-auth-profile-selector.js";
+import type { AuthProfileSummary, AuthProfilesStatus } from "../src/services/auth-profile-service.js";
+
+describe("session auth profile selector", () => {
+  it("selects the usable profile with the highest conservative remaining quota", () => {
+    const status = profileStatus([
+      profile("low", {
+        primaryUsed: 5,
+        secondaryUsed: 90
+      }),
+      profile("best", {
+        primaryUsed: 25,
+        secondaryUsed: 20
+      }),
+      profile("invalid", {
+        rateLimitsOk: false
+      }),
+      profile("exhausted", {
+        primaryUsed: 100,
+        secondaryUsed: 1
+      })
+    ]);
+
+    expect(selectBestAuthProfile(status)?.name).toBe("best");
+  });
+
+  it("keeps a usable bound profile even when another profile has more quota", () => {
+    const status = profileStatus([
+      profile("bound", {
+        primaryUsed: 60,
+        secondaryUsed: 50
+      }),
+      profile("bigger", {
+        primaryUsed: 1,
+        secondaryUsed: 2
+      })
+    ]);
+
+    expect(evaluateAuthProfile(status.profiles[0]!).usable).toBe(true);
+    expect(selectBestAuthProfile(status)?.name).toBe("bigger");
+  });
+
+  it("marks a profile unavailable when either quota window is exhausted", () => {
+    expect(evaluateAuthProfile(profile("primary-empty", {
+      primaryUsed: 100,
+      secondaryUsed: 0
+    }))).toMatchObject({
+      usable: false,
+      reason: "primary_quota_exhausted"
+    });
+
+    expect(evaluateAuthProfile(profile("secondary-empty", {
+      primaryUsed: 0,
+      secondaryUsed: 100
+    }))).toMatchObject({
+      usable: false,
+      reason: "secondary_quota_exhausted"
+    });
+  });
+});
+
+function profileStatus(profiles: readonly AuthProfileSummary[]): AuthProfilesStatus {
+  return {
+    managedRoot: "/tmp/auth-profiles",
+    profilesRoot: "/tmp/auth-profiles/docker/profiles",
+    activeProfile: profiles[0]?.name ?? null,
+    activeAuthPath: "/tmp/codex-home/auth.json",
+    profiles
+  };
+}
+
+function profile(
+  name: string,
+  options: {
+    readonly primaryUsed?: number | undefined;
+    readonly secondaryUsed?: number | undefined;
+    readonly rateLimitsOk?: boolean | undefined;
+  } = {}
+): AuthProfileSummary {
+  const rateLimitsOk = options.rateLimitsOk ?? true;
+  return {
+    name,
+    path: `/tmp/auth-profiles/docker/profiles/${name}.json`,
+    active: false,
+    source: "probe",
+    checkedAt: "2026-05-09T00:00:00.000Z",
+    account: {
+      ok: true,
+      account: {
+        email: `${name}@example.com`,
+        type: "chatgpt",
+        planType: "pro"
+      },
+      requiresOpenaiAuth: false
+    },
+    rateLimits: rateLimitsOk
+      ? {
+          ok: true,
+          rateLimits: {
+            limitId: "codex",
+            limitName: "Codex",
+            primary: {
+              usedPercent: options.primaryUsed ?? 0,
+              windowDurationMins: 300,
+              resetsAt: 1_779_000_000
+            },
+            secondary: {
+              usedPercent: options.secondaryUsed ?? 0,
+              windowDurationMins: 10_080,
+              resetsAt: 1_780_000_000
+            },
+            credits: null,
+            planType: "pro"
+          },
+          rateLimitsByLimitId: {}
+        }
+      : {
+          ok: false,
+          error: "refresh_token_reused"
+        }
+  };
+}

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -71,6 +71,56 @@ describe("SessionManager", () => {
     expect(cleared.activeTurnStartedAt).toBeUndefined();
   });
 
+  it("persists auth profile binding and blocked state", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));
+    const store = new StateStore(stateDir, sessionsRoot);
+    const manager = new SessionManager({
+      stateStore: store,
+      sessionsRoot
+    });
+
+    await manager.load();
+    const session = await manager.ensureSession("C123", "111.222");
+    await manager.setSessionAuthProfile(session.key, "profile-a", {
+      boundAt: "2026-05-09T00:00:00.000Z"
+    });
+    await manager.markSessionAuthBlocked(session.key, {
+      reason: "primary_quota_exhausted",
+      blockedAt: "2026-05-09T01:00:00.000Z"
+    });
+    await manager.setSessionAuthBlockedNoticePostedAt(session.key, "2026-05-09T01:00:05.000Z");
+
+    const reloadedStore = new StateStore(stateDir, sessionsRoot);
+    const reloadedManager = new SessionManager({
+      stateStore: reloadedStore,
+      sessionsRoot
+    });
+    await reloadedManager.load();
+
+    expect(reloadedManager.getSession("C123", "111.222")).toMatchObject({
+      authProfileName: "profile-a",
+      authProfileBoundAt: "2026-05-09T00:00:00.000Z",
+      authBlockedAt: "2026-05-09T01:00:00.000Z",
+      authBlockReason: "primary_quota_exhausted",
+      authBlockedNoticePostedAt: "2026-05-09T01:00:05.000Z"
+    });
+
+    const switched = await reloadedManager.switchSessionAuthProfileAndClearBlock(session.key, "profile-b", {
+      boundAt: "2026-05-09T02:00:00.000Z"
+    });
+
+    expect(switched).toMatchObject({
+      authProfileName: "profile-b",
+      authProfileBoundAt: "2026-05-09T02:00:00.000Z",
+      authBlockedAt: undefined,
+      authBlockReason: undefined,
+      authBlockedNoticePostedAt: undefined,
+      agentSessionId: undefined,
+      activeTurnId: undefined
+    });
+  });
+
   it("persists observed and delivered cursors plus inbound queue state", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
     const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));

--- a/test/slack-conversation-service.test.ts
+++ b/test/slack-conversation-service.test.ts
@@ -1,9 +1,15 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AppConfig } from "../src/config.js";
+import { AuthProfileUnavailableError } from "../src/services/agent-runtime/session-auth-profile-runtime.js";
 import { SlackConversationService } from "../src/services/slack/slack-conversation-service.js";
+import { SessionManager } from "../src/services/session-manager.js";
+import { StateStore } from "../src/store/state-store.js";
 import type { PersistedAgentTraceEvent, PersistedInboundMessage, SlackSessionRecord } from "../src/types.js";
 
 const TEST_SESSION: SlackSessionRecord = {
@@ -21,7 +27,8 @@ const TEST_CONFIG = {
   slackInitialThreadHistoryCount: 8,
   slackHistoryApiMaxLimit: 50,
   slackActiveTurnReconcileIntervalMs: 15_000,
-  slackMissedThreadRecoveryIntervalMs: 15_000
+  slackMissedThreadRecoveryIntervalMs: 15_000,
+  adminBaseUrl: "https://admin.example"
 } as AppConfig;
 
 afterEach(() => {
@@ -282,7 +289,7 @@ describe("SlackConversationService", () => {
       ...TEST_SESSION,
       activeTurnId: undefined
     }));
-    const postThreadMessage = vi.fn(async () => "333.444");
+    const postThreadMessage = vi.fn(async (_channelId: string, _threadTs: string, _text: string) => "333.444");
     const setLastSlackReplyAt = vi.fn(async () => TEST_SESSION);
 
     const service = new SlackConversationService({
@@ -322,5 +329,105 @@ describe("SlackConversationService", () => {
     expect(setActiveTurnId).not.toHaveBeenCalled();
 
     await service.stop();
+  });
+
+  it("keeps Slack input pending and posts one session link when auth profile is unavailable", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-conversation-auth-block-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-conversation-auth-block-sessions-"));
+    const stateStore = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot
+    });
+    await sessions.load();
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setSessionAuthProfile(session.key, "empty-profile", {
+      boundAt: "2026-05-09T00:00:00.000Z"
+    });
+    const agentRuntime = Object.assign(new EventEmitter(), {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      setSlackBotIdentity: vi.fn(),
+      getCapabilities: vi.fn(),
+      ensureSession: vi.fn(async () => {
+        throw new AuthProfileUnavailableError({
+          sessionKey: session.key,
+          profileName: "empty-profile",
+          reason: "primary_quota_exhausted"
+        });
+      }),
+      submitInput: vi.fn(),
+      interrupt: vi.fn(),
+      readSession: vi.fn(),
+      readTurn: vi.fn()
+    });
+    const postThreadMessage = vi.fn(async () => "333.444");
+
+    const service = new SlackConversationService({
+      config: TEST_CONFIG,
+      sessions,
+      agentRuntime: agentRuntime as never,
+      slackApi: {
+        postThreadMessage,
+        setAssistantThreadStatus: vi.fn(),
+        addReaction: vi.fn(),
+        removeReaction: vi.fn(),
+        getUserIdentity: vi.fn(async () => null)
+      } as never,
+      selfMessageFilter: {
+        rememberPostedMessageTs: vi.fn(),
+        shouldIgnoreThreadMessage: vi.fn(() => false)
+      } as never
+    });
+
+    await service.acceptInboundMessage(session, {
+      source: "thread_reply",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      messageTs: "111.223",
+      userId: "U123",
+      text: "继续"
+    });
+
+    await vi.waitFor(() => {
+      expect(postThreadMessage).toHaveBeenCalledTimes(2);
+    });
+    const postCalls = postThreadMessage.mock.calls as unknown as Array<[string, string, string]>;
+    expect(postCalls[0]).toEqual([
+      "C123",
+      "111.222",
+      "<https://admin.example/admin/sessions/C123%3A111.222|查看会话活动时间线>"
+    ]);
+    expect(postCalls[1]?.[2]).toContain("账号额度不可用");
+    expect(postCalls[1]?.[2]).toContain("https://admin.example/admin/sessions/C123%3A111.222");
+
+    expect(sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      status: "pending"
+    })).toHaveLength(1);
+    expect(sessions.getSessionByKey(session.key)).toMatchObject({
+      authProfileName: "empty-profile",
+      authBlockReason: "primary_quota_exhausted",
+      authBlockedNoticePostedAt: expect.any(String)
+    });
+
+    await service.acceptInboundMessage(sessions.getSessionByKey(session.key)!, {
+      source: "thread_reply",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      messageTs: "111.224",
+      userId: "U123",
+      text: "再发一条"
+    });
+    await vi.waitFor(() => {
+      expect(agentRuntime.ensureSession).toHaveBeenCalledTimes(2);
+    });
+    expect(postThreadMessage).toHaveBeenCalledTimes(2);
+
+    await service.stop();
+    stateStore.close();
+    await fs.rm(stateDir, { force: true, recursive: true });
+    await fs.rm(sessionsRoot, { force: true, recursive: true });
   });
 });

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -287,8 +287,12 @@ describe("StateStore", () => {
           name: "admin_realtime_events"
         },
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 10,
           name: "session_page_link_announcement"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "session_auth_profile_binding"
         }
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- bind each Slack session to a managed auth profile and route agent runtime calls through a per-profile runtime pool
- choose the best usable auth profile only when a session is first created; do not auto-switch existing sessions
- block dispatch when the bound profile is unavailable, post one Slack notice with the session link, and add a session-page manual switch-and-resume action

## Tests
- pnpm test
- pnpm build