### PR TITLE
Show account labels for session auth profiles

### DIFF
--- a/src/admin-ui/auth-profile-display.ts
+++ b/src/admin-ui/auth-profile-display.ts
@@ -1,0 +1,87 @@
+type AuthProfileRecord = Record<string, any>;
+
+export function profileAccountLabel(profile: AuthProfileRecord): string {
+  const accountStatus = profile.account || {};
+  if (accountStatus.ok === false) {
+    return "账号不可用";
+  }
+
+  const account = accountStatus.account || {};
+  return readString(account.email) ||
+    readString(account.name) ||
+    readString(account.id) ||
+    "未知账号";
+}
+
+export function profilePlanLabel(profile: AuthProfileRecord): string {
+  const accountStatus = profile.account || {};
+  if (accountStatus.ok === false) {
+    return "";
+  }
+
+  const account = accountStatus.account || {};
+  const plan = readString(account.planType) || readString(account.type);
+  if (!plan) {
+    return "";
+  }
+
+  if (plan === "prolite") return "Pro Lite";
+  if (plan === "pro") return "Pro";
+  if (plan === "chatgpt") return "ChatGPT";
+  return plan;
+}
+
+export function profileDisplayLabel(profile: AuthProfileRecord): string {
+  return [profileAccountLabel(profile), profilePlanLabel(profile)]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function profileOptionLabel(profile: AuthProfileRecord): string {
+  return [profileDisplayLabel(profile), profileQuotaLabel(profile)]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function profileTitle(profile: AuthProfileRecord): string {
+  const internalName = readString(profile.name);
+  return [profileOptionLabel(profile), internalName ? `内部标识 ${internalName}` : ""]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function profileIsSelectable(profile: AuthProfileRecord): boolean {
+  return profile.account?.ok !== false && profile.rateLimits?.ok !== false;
+}
+
+export function profileQuotaLabel(profile: AuthProfileRecord): string {
+  const rateLimits = profile.rateLimits || {};
+  if (rateLimits.ok === false) {
+    return "不可用";
+  }
+
+  const limits = rateLimits.rateLimits || {};
+  const primary = remainingPercent(limits.primary?.usedPercent);
+  const secondary = remainingPercent(limits.secondary?.usedPercent);
+  const parts = [];
+  if (primary !== null) parts.push("短窗 " + Math.round(primary) + "%");
+  if (secondary !== null) parts.push("周 " + Math.round(secondary) + "%");
+  return parts.length ? parts.join(" / ") : "额度未知";
+}
+
+function remainingPercent(usedPercent: unknown): number | null {
+  const used = Number(usedPercent);
+  if (!Number.isFinite(used)) {
+    return null;
+  }
+  return Math.max(0, Math.min(100, 100 - used));
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
 import {
+  profileDisplayLabel,
+  profileIsSelectable,
+  profileOptionLabel,
+  profileQuotaLabel,
+  profileTitle
+} from "./auth-profile-display";
+import {
   getAdminStatusSnapshot,
   getTimelineSnapshot,
   publishTimelinePayload,
@@ -36,6 +43,11 @@ export function AdminSessionsView(): React.JSX.Element {
   const status = (snapshot.status || {}) as Record<string, any>;
   const sessions = (status.state?.sessions || []) as SessionRecord[];
   const state = status.state || {};
+  const authProfiles = (status.authProfiles?.profiles || []) as SessionRecord[];
+  const authProfileByName = useMemo(
+    () => new Map(authProfiles.map((profile) => [String(profile.name), profile])),
+    [authProfiles]
+  );
   const [uiState, setUiState] = useState(loadUiState);
   const query = uiState.sessionSearch.trim().toLowerCase();
   const mode = uiState.sessionFilter;
@@ -113,6 +125,7 @@ export function AdminSessionsView(): React.JSX.Element {
                 key={session.key}
                 session={session}
                 selected={selectedSession?.key === session.key}
+                authProfileByName={authProfileByName}
                 onSelect={() => updateSessionUiState({ selectedSessionKey: session.key })}
               />
             ))
@@ -193,9 +206,10 @@ function SessionPermalinkView({ sessionKey }: { readonly sessionKey: string }): 
   );
 }
 
-function SessionRow({ session, selected, onSelect }: {
+function SessionRow({ session, selected, authProfileByName, onSelect }: {
   readonly session: SessionRecord;
   readonly selected: boolean;
+  readonly authProfileByName: ReadonlyMap<string, SessionRecord>;
   readonly onSelect: () => void;
 }): React.JSX.Element {
   const state = sessionQueueState(session);
@@ -217,7 +231,7 @@ function SessionRow({ session, selected, onSelect }: {
         </div>
         <div className="session-channel" title={first}>起始：{first}</div>
         <div className="session-meta-line">
-          {renderSessionMeta(session).map((pill) => (
+          {renderSessionMeta(session, authProfileByName).map((pill) => (
             <span key={pill.key} className={"session-meta-pill " + classSafeValue(pill.tone, "")} title={pill.title}>
               {pill.label}
             </span>
@@ -334,6 +348,9 @@ function AuthProfilePanel({ session, profiles }: {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const currentProfile = profiles.find((profile) => profile.name === session.authProfileName);
+  const currentLabel = currentProfile
+    ? profileDisplayLabel(currentProfile)
+    : (session.authProfileName ? "账号状态加载中" : "未绑定");
   const blocked = Boolean(session.authBlockedAt);
 
   useEffect(() => {
@@ -368,7 +385,9 @@ function AuthProfilePanel({ session, profiles }: {
     <div className="auth-profile-panel">
       <div className="auth-profile-current">
         <span>当前</span>
-        <strong>{session.authProfileName || "未绑定"}</strong>
+        <strong title={currentProfile ? profileTitle(currentProfile) : String(session.authProfileName || "")}>
+          {currentLabel}
+        </strong>
         {currentProfile ? <span>{profileQuotaLabel(currentProfile)}</span> : null}
       </div>
       {blocked ? (
@@ -381,8 +400,8 @@ function AuthProfilePanel({ session, profiles }: {
         <select value={selected} onChange={(event) => setSelected(event.target.value)}>
           <option value="">选择账号</option>
           {profiles.map((profile) => (
-            <option key={profile.name} value={profile.name}>
-              {profile.name} · {profileQuotaLabel(profile)}
+            <option key={profile.name} value={profile.name} disabled={!profileIsSelectable(profile)}>
+              {profileOptionLabel(profile)}
             </option>
           ))}
         </select>
@@ -594,15 +613,24 @@ function resolveSelectedSession(sessions: readonly SessionRecord[], selectedSess
   return sessions.find((session) => session.key === selectedSessionKey) || sessions[0] || null;
 }
 
-function renderSessionMeta(session: SessionRecord): Array<{ key: string; label: string; tone: string; title?: string }> {
+function renderSessionMeta(
+  session: SessionRecord,
+  authProfileByName: ReadonlyMap<string, SessionRecord>
+): Array<{ key: string; label: string; tone: string; title?: string }> {
   const usage = session.usage || {};
   const pendingDetail = Number(session.openInboundCount || 0)
     ? "待处理 " + (session.openInboundCount || 0) + "（人 " + (session.openHumanInboundCount || 0) + " / 系统 " + (session.openSystemInboundCount || 0) + "）"
     : "";
+  const authProfile = session.authProfileName ? authProfileByName.get(String(session.authProfileName)) : null;
   return [
     { key: "channel", label: session.channelLabel || session.channelId || "未知频道", tone: "info", title: session.key },
     session.authBlockedAt ? { key: "auth-blocked", label: "账号待切换", tone: "danger", title: session.authBlockReasonLabel || session.authBlockReason } : null,
-    session.authProfileName ? { key: "auth-profile", label: "Auth " + session.authProfileName, tone: "info" } : null,
+    session.authProfileName ? {
+      key: "auth-profile",
+      label: authProfile ? "账号 " + profileDisplayLabel(authProfile) : "账号已绑定",
+      tone: "info",
+      title: authProfile ? profileTitle(authProfile) : String(session.authProfileName)
+    } : null,
     pendingDetail ? { key: "pending", label: pendingDetail, tone: Number(session.openHumanInboundCount || 0) ? "warn" : "" } : null,
     { key: "jobs", label: "Jobs " + (session.backgroundJobCount || 0), tone: Number(session.failedBackgroundJobCount || 0) ? "danger" : (Number(session.runningBackgroundJobCount || 0) ? "good" : "") },
     Number(session.failedBackgroundJobCount || 0) ? { key: "failed", label: "失败 " + session.failedBackgroundJobCount, tone: "danger" } : null,
@@ -664,29 +692,6 @@ function sessionQueueState(session: SessionRecord): { label: string; tone: strin
     return { label: "有记录", tone: "info", rank: 10, detail: fmtTokens(session.usage?.totalTokens || 0) };
   }
   return { label: "空闲", tone: "", rank: 0, detail: "" };
-}
-
-function profileQuotaLabel(profile: SessionRecord): string {
-  const rateLimits = profile.rateLimits || {};
-  if (rateLimits.ok === false) {
-    return "不可用";
-  }
-
-  const limits = rateLimits.rateLimits || {};
-  const primary = remainingPercent(limits.primary?.usedPercent);
-  const secondary = remainingPercent(limits.secondary?.usedPercent);
-  const parts = [];
-  if (primary !== null) parts.push("短窗 " + Math.round(primary) + "%");
-  if (secondary !== null) parts.push("周 " + Math.round(secondary) + "%");
-  return parts.length ? parts.join(" / ") : "额度未知";
-}
-
-function remainingPercent(usedPercent: unknown): number | null {
-  const used = Number(usedPercent);
-  if (!Number.isFinite(used)) {
-    return null;
-  }
-  return Math.max(0, Math.min(100, 100 - used));
 }
 
 function compareSessionsForMode(mode: string, left: SessionRecord, right: SessionRecord): number {

--- a/test/admin-auth-profile-display.test.ts
+++ b/test/admin-auth-profile-display.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  profileAccountLabel,
+  profileDisplayLabel,
+  profileOptionLabel,
+  profileQuotaLabel,
+  profileTitle
+} from "../src/admin-ui/auth-profile-display.js";
+
+describe("admin auth profile display", () => {
+  it("uses the account identity instead of the internal profile name", () => {
+    const profile = authProfile({
+      name: "575d9997-db66-4b21-979d-4d3b9597b36e",
+      email: "hejiachen@toeverything.info",
+      planType: "prolite",
+      primaryUsed: 4,
+      secondaryUsed: 36
+    });
+
+    expect(profileAccountLabel(profile)).toBe("hejiachen@toeverything.info");
+    expect(profileDisplayLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite");
+    expect(profileQuotaLabel(profile)).toBe("短窗 96% / 周 64%");
+    expect(profileOptionLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite · 短窗 96% / 周 64%");
+    expect(profileTitle(profile)).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
+  });
+
+  it("keeps unusable profiles readable without presenting their UUID as the label", () => {
+    const profile = {
+      name: "39c7bde2-02d0-4cf2-a87e-20374ea71c74",
+      account: {
+        ok: false,
+        error: "refresh_token_reused"
+      },
+      rateLimits: {
+        ok: false,
+        error: "refresh_token_reused"
+      }
+    };
+
+    expect(profileAccountLabel(profile)).toBe("账号不可用");
+    expect(profileOptionLabel(profile)).toBe("账号不可用 · 不可用");
+  });
+});
+
+function authProfile(options: {
+  readonly name: string;
+  readonly email: string;
+  readonly planType: string;
+  readonly primaryUsed: number;
+  readonly secondaryUsed: number;
+}): Record<string, any> {
+  return {
+    name: options.name,
+    account: {
+      ok: true,
+      account: {
+        email: options.email,
+        type: "chatgpt",
+        planType: options.planType
+      },
+      requiresOpenaiAuth: false
+    },
+    rateLimits: {
+      ok: true,
+      rateLimits: {
+        primary: {
+          usedPercent: options.primaryUsed,
+          windowDurationMins: 300,
+          resetsAt: 1_779_000_000
+        },
+        secondary: {
+          usedPercent: options.secondaryUsed,
+          windowDurationMins: 10_080,
+          resetsAt: 1_780_000_000
+        }
+      },
+      rateLimitsByLimitId: {}
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- show auth profile account email/plan in session detail and switcher instead of internal UUID names
- use account labels for session-list auth pills and keep UUID only in hover title
- disable unusable auth profiles in the session switcher

## Verification
- pnpm exec vitest run test/admin-auth-profile-display.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm build
- pnpm test
- browser-verified mock admin render: current account and select options show account labels, not UUID labels