### PR TITLE
Prioritize session actions and simplify list rows

### DIFF
--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -92,19 +92,21 @@
     .session-detail-panel > .panel-body { flex: 1; min-height: 0; padding: 0; display: flex; flex-direction: column; overflow: hidden; }
     .session-detail-empty { min-height: 200px; display: grid; place-items: center; color: var(--muted); }
     .selected-session-head { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: center; padding: 6px 8px; border-bottom: 1px solid var(--line); }
+    .session-action-head { display: flex; justify-content: flex-end; }
     .selected-session-title { min-width: 0; }
+    .session-meta-title { display: grid; gap: 3px; margin-bottom: 6px; }
     .session-detail-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); font-size: 13px; font-weight: 700; }
     .session-detail-subtitle { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 10px; }
     .session-detail-actions { display: flex; gap: 6px; align-items: center; }
     .link-button { display: inline-flex; align-items: center; padding: 2px 7px; border: 1px solid var(--cyan); color: var(--cyan); background: transparent; font: 11px var(--mono); text-decoration: none; white-space: nowrap; }
     .link-button:hover { background: rgba(61,181,199,0.08); }
-    .session-detail-summary { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 1px; margin-bottom: 6px; background: var(--line); }
+    .session-detail-summary { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 1px; background: var(--line); }
     .session-detail-kpi { min-width: 0; padding: 5px 6px; background: #05080c; }
     .session-detail-kpi span { display: block; color: var(--muted); font-size: 9px; text-transform: uppercase; }
     .session-detail-kpi strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); font-size: 11px; }
     .session-body { flex: 1; min-height: 0; overflow: auto; padding: 6px 8px; }
     .session-inspector { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-    .trace-panel { grid-column: 1 / -1; }
+    .session-action-panel, .trace-panel, .session-meta-panel { grid-column: 1 / -1; }
 
     .mini-panel { border: 1px solid var(--line); }
     .mini-title { padding: 3px 6px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 9px; text-transform: uppercase; }
@@ -116,7 +118,9 @@
     .auth-profile-blocked span:last-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .auth-profile-switcher { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px; align-items: center; }
 
-    .timeline { display: grid; gap: 0; max-height: min(420px, 52vh); overflow: auto; border: 1px solid var(--line); }
+    .session-timeline-panel .mini-body { min-height: 0; }
+    .timeline { display: grid; gap: 0; max-height: min(660px, 62vh); overflow: auto; border: 1px solid var(--line); }
+    .session-permalink-panel .timeline { max-height: none; height: min(54dvh, 640px); }
     .timeline-event { display: grid; grid-template-columns: 72px 90px minmax(0, 1fr); gap: 6px; align-items: start; padding: 4px 6px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 10px; }
     .timeline-event:last-child { border-bottom: 0; }
     .timeline-main { min-width: 0; }
@@ -221,7 +225,7 @@
       .mini-body { padding: 4px; }
       .trace-summary { overflow-x: auto; flex-wrap: nowrap; padding-bottom: 2px; }
       .timeline { max-height: none; height: min(60dvh, 540px); }
-      .session-permalink-panel .timeline { height: min(64dvh, 640px); }
+      .session-permalink-panel .timeline { height: min(56dvh, 560px); }
       .timeline-event { grid-template-columns: 54px 78px minmax(0, 1fr); gap: 4px; padding: 6px 4px; }
       .timeline-title { display: block; }
       .timeline-title strong,

--- a/src/admin-ui/session-row-display.ts
+++ b/src/admin-ui/session-row-display.ts
@@ -1,0 +1,101 @@
+import {
+  profileDisplayLabel,
+  profileTitle
+} from "./auth-profile-display.js";
+
+type SessionRecord = Record<string, any>;
+
+export interface SessionMetaPill {
+  readonly key: string;
+  readonly label: string;
+  readonly tone: string;
+  readonly title?: string;
+}
+
+export function shouldShowSessionState(state: { readonly rank: number }): boolean {
+  return state.rank > 10;
+}
+
+export function buildChannelLabelById(sessions: readonly SessionRecord[]): ReadonlyMap<string, string> {
+  const labels = new Map<string, string>();
+  for (const session of sessions) {
+    const channelId = String(session.channelId || "");
+    const label = sessionHumanChannelLabel(session);
+    if (channelId && label) {
+      labels.set(channelId, label);
+    }
+  }
+  return labels;
+}
+
+export function resolveSessionChannelLabel(
+  session: SessionRecord,
+  channelLabelById?: ReadonlyMap<string, string>
+): string {
+  const channelId = String(session.channelId || "");
+  return sessionHumanChannelLabel(session) || (channelId ? channelLabelById?.get(channelId) : undefined) || channelId || "未知频道";
+}
+
+export function renderSessionMeta(
+  session: SessionRecord,
+  authProfileByName: ReadonlyMap<string, SessionRecord>,
+  channelLabelById?: ReadonlyMap<string, string>
+): SessionMetaPill[] {
+  const usage = session.usage || {};
+  const pendingDetail = Number(session.openInboundCount || 0)
+    ? "待处理 " + (session.openInboundCount || 0) + "（人 " + (session.openHumanInboundCount || 0) + " / 系统 " + (session.openSystemInboundCount || 0) + "）"
+    : "";
+  const authProfile = session.authProfileName ? authProfileByName.get(String(session.authProfileName)) : null;
+  const backgroundJobCount = Number(session.backgroundJobCount || 0);
+  return [
+    { key: "channel", label: resolveSessionChannelLabel(session, channelLabelById), tone: "info", title: stringOrUndefined(session.channelId || session.key) },
+    session.authBlockedAt ? { key: "auth-blocked", label: "账号待切换", tone: "danger", title: stringOrUndefined(session.authBlockReasonLabel || session.authBlockReason) } : null,
+    session.authProfileName ? {
+      key: "auth-profile",
+      label: authProfile ? "账号 " + profileDisplayLabel(authProfile) : "账号已绑定",
+      tone: "info",
+      title: authProfile ? profileTitle(authProfile) : String(session.authProfileName)
+    } : null,
+    pendingDetail ? { key: "pending", label: pendingDetail, tone: Number(session.openHumanInboundCount || 0) ? "warn" : "" } : null,
+    backgroundJobCount > 0 ? { key: "jobs", label: "Jobs " + backgroundJobCount, tone: Number(session.failedBackgroundJobCount || 0) ? "danger" : (Number(session.runningBackgroundJobCount || 0) ? "good" : "") } : null,
+    Number(session.failedBackgroundJobCount || 0) ? { key: "failed", label: "失败 " + session.failedBackgroundJobCount, tone: "danger" } : null,
+    { key: "tokens", label: "Token " + formatSessionTokens(usage.totalTokens || 0), tone: "info" }
+  ].filter((item): item is SessionMetaPill => Boolean(item));
+}
+
+function sessionHumanChannelLabel(session: SessionRecord): string | undefined {
+  const channelId = String(session.channelId || "");
+  const channelName = String(session.channelName || "").trim();
+  if (channelName) {
+    return formatSlackChannelName(channelName);
+  }
+
+  const channelLabel = String(session.channelLabel || "").trim();
+  if (channelLabel && channelLabel !== channelId && !looksLikeSlackChannelId(channelLabel)) {
+    return channelLabel;
+  }
+
+  if (session.channelType === "im") return "私信";
+  if (session.channelType === "mpim") return "群聊";
+  return undefined;
+}
+
+function formatSessionTokens(value: unknown): string {
+  const count = Math.max(0, Number(value || 0));
+  if (count >= 1000000) return (count / 1000000).toFixed(2).replace(/\.00$/, "") + "M";
+  if (count >= 1000) return (count / 1000).toFixed(1).replace(/\.0$/, "") + "K";
+  return String(Math.round(count));
+}
+
+function formatSlackChannelName(channelName: string): string {
+  return channelName.startsWith("#") ? channelName : "#" + channelName;
+}
+
+function looksLikeSlackChannelId(value: string): boolean {
+  return /^[CDG][A-Z0-9]{8,}$/.test(value);
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  const text = String(value || "");
+  return text || undefined;
+}

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -15,6 +15,12 @@ import {
   subscribeTimeline
 } from "./admin-status-store";
 import { stableSessionOrder } from "./session-order";
+import {
+  buildChannelLabelById,
+  renderSessionMeta,
+  resolveSessionChannelLabel,
+  shouldShowSessionState
+} from "./session-row-display";
 import { getTimelineEventDisplay, isTimelineEventVisible, statusLabel, type TimelineEvent } from "./timeline-display";
 
 type UiState = {
@@ -48,6 +54,7 @@ export function AdminSessionsView(): React.JSX.Element {
     () => new Map(authProfiles.map((profile) => [String(profile.name), profile])),
     [authProfiles]
   );
+  const channelLabelById = useMemo(() => buildChannelLabelById(sessions), [sessions]);
   const [uiState, setUiState] = useState(loadUiState);
   const query = uiState.sessionSearch.trim().toLowerCase();
   const mode = uiState.sessionFilter;
@@ -126,6 +133,7 @@ export function AdminSessionsView(): React.JSX.Element {
                 session={session}
                 selected={selectedSession?.key === session.key}
                 authProfileByName={authProfileByName}
+                channelLabelById={channelLabelById}
                 onSelect={() => updateSessionUiState({ selectedSessionKey: session.key })}
               />
             ))
@@ -196,7 +204,7 @@ function SessionPermalinkView({ sessionKey }: { readonly sessionKey: string }): 
           {error ? (
             <div className="empty-state">{error}</div>
           ) : session ? (
-            <SessionDetail key={session.key} session={session} />
+            <SessionDetail key={session.key} session={session} isPermalink />
           ) : (
             <div className="empty-state">正在加载会话</div>
           )}
@@ -206,16 +214,18 @@ function SessionPermalinkView({ sessionKey }: { readonly sessionKey: string }): 
   );
 }
 
-function SessionRow({ session, selected, authProfileByName, onSelect }: {
+function SessionRow({ session, selected, authProfileByName, channelLabelById, onSelect }: {
   readonly session: SessionRecord;
   readonly selected: boolean;
   readonly authProfileByName: ReadonlyMap<string, SessionRecord>;
+  readonly channelLabelById?: ReadonlyMap<string, string>;
   readonly onSelect: () => void;
 }): React.JSX.Element {
   const state = sessionQueueState(session);
   const activityAt = sessionActivityAt(session);
   const primary = sessionPrimaryText(session);
   const first = sessionFirstText(session);
+  const stateBadge = shouldShowSessionState(state) ? <Badge label={state.label} tone={state.tone} /> : null;
   return (
     <button
       type="button"
@@ -226,12 +236,12 @@ function SessionRow({ session, selected, authProfileByName, onSelect }: {
       <div className="session-summary">
         <div className="session-line">
           <div className="session-lead" title={primary}>{primary}</div>
-          <Badge label={state.label} tone={state.tone} />
-          <div className="session-time" title={fmtDateTime(activityAt)}>更新 {fmtRelativeTime(activityAt)}</div>
+          {stateBadge}
+          <div className="session-time" title={fmtDateTime(activityAt)}>{fmtRelativeTime(activityAt)}</div>
         </div>
-        <div className="session-channel" title={first}>起始：{first}</div>
+        <div className="session-channel" title={first}>{first}</div>
         <div className="session-meta-line">
-          {renderSessionMeta(session, authProfileByName).map((pill) => (
+          {renderSessionMeta(session, authProfileByName, channelLabelById).map((pill) => (
             <span key={pill.key} className={"session-meta-pill " + classSafeValue(pill.tone, "")} title={pill.title}>
               {pill.label}
             </span>
@@ -242,11 +252,15 @@ function SessionRow({ session, selected, authProfileByName, onSelect }: {
   );
 }
 
-function SessionDetail({ session }: {
+function SessionDetail({ session, isPermalink = false }: {
   readonly session: SessionRecord;
+  readonly isPermalink?: boolean;
 }): React.JSX.Element {
   const snapshot = useSyncExternalStore(subscribeAdminStatus, getAdminStatusSnapshot, getAdminStatusSnapshot);
   const authProfiles = (((snapshot.status || {}) as Record<string, any>).authProfiles?.profiles || []) as SessionRecord[];
+  const sessions = (((snapshot.status || {}) as Record<string, any>).state?.sessions || []) as SessionRecord[];
+  const channelLabelById = buildChannelLabelById([...sessions, session]);
+  const channelLabel = resolveSessionChannelLabel(session, channelLabelById);
   const usage = session.usage || {};
   const state = sessionQueueState(session);
   const activityAt = sessionActivityAt(session);
@@ -254,35 +268,25 @@ function SessionDetail({ session }: {
   const first = sessionFirstText(session);
   return (
     <>
-      <div className="selected-session-head">
-        <div className="selected-session-title">
-          <div className="session-detail-title" title={primary}>{primary}</div>
-          <div className="session-detail-subtitle" title={first}>起始：{first}</div>
-        </div>
+      <div className="selected-session-head session-action-head">
         <div className="session-detail-actions">
-          <Badge label={state.label} tone={state.tone} />
-          <a className="link-button" href={adminSessionPath(String(session.key || ""))}>打开 Session 页面</a>
+          {!isPermalink ? (
+            <a className="link-button" href={adminSessionPath(String(session.key || ""))}>打开 Session 页面</a>
+          ) : null}
           {session.threadUrl ? (
             <a className="link-button" href={session.threadUrl} target="_blank" rel="noreferrer">打开 Slack Thread</a>
           ) : null}
         </div>
       </div>
       <div className="session-body">
-        <div className="session-detail-summary">
-          <Kpi label="频道" value={session.channelLabel || session.channelId || "--"} title={session.channelId} />
-          <Kpi label="最近活动" value={fmtRelativeTime(activityAt)} title={fmtDateTime(activityAt)} />
-          <Kpi label="待处理" value={(session.openInboundCount || 0) + " 条"} />
-          <Kpi label="Jobs" value={(session.backgroundJobCount || 0) + " / 运行 " + (session.runningBackgroundJobCount || 0)} />
-          <Kpi label="Token / 轮次" value={fmtTokens(usage.totalTokens || 0) + " / " + (usage.turnCount || 0)} />
-        </div>
         <div className="session-inspector">
-          <div className="mini-panel">
-            <div className="mini-title">Auth Profile</div>
+          <div className="mini-panel session-action-panel">
+            <div className="mini-title">操作</div>
             <div className="mini-body">
               <AuthProfilePanel session={session} profiles={authProfiles} />
             </div>
           </div>
-          <div className="mini-panel trace-panel">
+          <div className="mini-panel trace-panel session-timeline-panel">
             <div className="mini-title">Agent 活动时间线</div>
             <div className="mini-body">
               <SessionTimeline session={session} />
@@ -299,6 +303,26 @@ function SessionDetail({ session }: {
             <div className="mini-body">
               <InboundTable items={session.openInbound || []} />
               <JobsTable jobs={session.backgroundJobs || []} />
+            </div>
+          </div>
+          <div className="mini-panel session-meta-panel">
+            <div className="mini-title">会话信息</div>
+            <div className="mini-body">
+              <div className="selected-session-title session-meta-title">
+                <div className="session-detail-title" title={primary}>{primary}</div>
+                <div className="session-detail-subtitle" title={first}>{first}</div>
+                <div className="session-compact-meta">
+                  {shouldShowSessionState(state) ? <Badge label={state.label} tone={state.tone} /> : null}
+                  <span>{fmtRelativeTime(activityAt)}</span>
+                </div>
+              </div>
+              <div className="session-detail-summary">
+                <Kpi label="频道" value={channelLabel} title={session.channelId} />
+                <Kpi label="最近活动" value={fmtRelativeTime(activityAt)} title={fmtDateTime(activityAt)} />
+                <Kpi label="待处理" value={(session.openInboundCount || 0) + " 条"} />
+                <Kpi label="Jobs" value={(session.backgroundJobCount || 0) + " / 运行 " + (session.runningBackgroundJobCount || 0)} />
+                <Kpi label="Token" value={fmtTokens(usage.totalTokens || 0)} />
+              </div>
             </div>
           </div>
         </div>
@@ -456,7 +480,7 @@ function TraceSummary({ trace }: { readonly trace: Record<string, any> }): React
 
 function Timeline({ events }: { readonly events: readonly TimelineEvent[] }): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
-  const shouldFollowRef = useRef(false);
+  const shouldFollowRef = useRef(true);
 
   useLayoutEffect(() => {
     const container = containerRef.current;
@@ -611,32 +635,6 @@ function sessionMatchesFilter(session: SessionRecord, mode: string, query: strin
 function resolveSelectedSession(sessions: readonly SessionRecord[], selectedSessionKey: string | null): SessionRecord | null {
   if (!sessions.length) return null;
   return sessions.find((session) => session.key === selectedSessionKey) || sessions[0] || null;
-}
-
-function renderSessionMeta(
-  session: SessionRecord,
-  authProfileByName: ReadonlyMap<string, SessionRecord>
-): Array<{ key: string; label: string; tone: string; title?: string }> {
-  const usage = session.usage || {};
-  const pendingDetail = Number(session.openInboundCount || 0)
-    ? "待处理 " + (session.openInboundCount || 0) + "（人 " + (session.openHumanInboundCount || 0) + " / 系统 " + (session.openSystemInboundCount || 0) + "）"
-    : "";
-  const authProfile = session.authProfileName ? authProfileByName.get(String(session.authProfileName)) : null;
-  return [
-    { key: "channel", label: session.channelLabel || session.channelId || "未知频道", tone: "info", title: session.key },
-    session.authBlockedAt ? { key: "auth-blocked", label: "账号待切换", tone: "danger", title: session.authBlockReasonLabel || session.authBlockReason } : null,
-    session.authProfileName ? {
-      key: "auth-profile",
-      label: authProfile ? "账号 " + profileDisplayLabel(authProfile) : "账号已绑定",
-      tone: "info",
-      title: authProfile ? profileTitle(authProfile) : String(session.authProfileName)
-    } : null,
-    pendingDetail ? { key: "pending", label: pendingDetail, tone: Number(session.openHumanInboundCount || 0) ? "warn" : "" } : null,
-    { key: "jobs", label: "Jobs " + (session.backgroundJobCount || 0), tone: Number(session.failedBackgroundJobCount || 0) ? "danger" : (Number(session.runningBackgroundJobCount || 0) ? "good" : "") },
-    Number(session.failedBackgroundJobCount || 0) ? { key: "failed", label: "失败 " + session.failedBackgroundJobCount, tone: "danger" } : null,
-    { key: "turns", label: "轮次 " + (usage.turnCount || 0), tone: "" },
-    { key: "tokens", label: "Token " + fmtTokens(usage.totalTokens || 0), tone: "info" }
-  ].filter((item): item is { key: string; label: string; tone: string; title?: string } => Boolean(item));
 }
 
 function sessionPrimaryText(session: SessionRecord): string {

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -152,12 +152,14 @@ export class AdminService {
     const snapshot = await this.#readSessionSnapshot();
     const runtime = await this.#readRuntimeStatus();
     const usage = this.#readUsageOverview();
+    const channelLabels = buildChannelLabelLookup(snapshot.allSessions, snapshot.inboundBySession);
     const sessionSummaries = snapshot.allSessions.slice(0, 50).map((session) =>
       this.#summarizeSession(session, {
         inbound: snapshot.inboundBySession.get(session.key) ?? [],
         openInbound: snapshot.openInboundBySession.get(session.key) ?? [],
         jobs: snapshot.jobsBySession.get(session.key) ?? [],
-        usage: snapshot.usageBySession.get(session.key)
+        usage: snapshot.usageBySession.get(session.key),
+        channelLabels
       })
     );
     const stateCounts = this.#summarizeStateCounts(snapshot);
@@ -218,6 +220,7 @@ export class AdminService {
 
   async listSessionSummaries(): Promise<Record<string, unknown>> {
     const snapshot = await this.#readSessionSnapshot();
+    const channelLabels = buildChannelLabelLookup(snapshot.allSessions, snapshot.inboundBySession);
     return {
       ok: true,
       realtime: this.#realtimeInfo(),
@@ -226,7 +229,8 @@ export class AdminService {
           inbound: snapshot.inboundBySession.get(session.key) ?? [],
           openInbound: snapshot.openInboundBySession.get(session.key) ?? [],
           jobs: snapshot.jobsBySession.get(session.key) ?? [],
-          usage: snapshot.usageBySession.get(session.key)
+          usage: snapshot.usageBySession.get(session.key),
+          channelLabels
         })
       )
     };
@@ -311,7 +315,8 @@ export class AdminService {
         inbound,
         openInbound,
         jobs,
-        usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key)
+        usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key),
+        channelLabels: buildChannelLabelLookup([session], new Map([[session.key, inbound]]))
       }),
       trace: summarizeAgentTrace(agentEvents),
       events: [...events, ...agentEvents.map(agentTraceEventToTimelineEvent)].sort(compareTimelineEvents)
@@ -725,11 +730,16 @@ export class AdminService {
       rootThreadTs: session.rootThreadTs
     });
 
+    const channelLabels = buildChannelLabelLookup(
+      this.options.sessions.listSessions(),
+      groupBySession(this.options.sessions.listInboundMessages())
+    );
     return this.#summarizeSession(session, {
       inbound,
       openInbound,
       jobs,
-      usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key)
+      usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key),
+      channelLabels
     });
   }
 
@@ -1041,6 +1051,7 @@ export class AdminService {
       readonly openInbound: readonly PersistedInboundMessage[];
       readonly jobs: readonly PersistedBackgroundJob[];
       readonly usage?: SessionUsageSummary | undefined;
+      readonly channelLabels?: ReadonlyMap<string, string> | undefined;
     }
   ): Record<string, unknown> {
     const runningBackgroundJobCount = related.jobs.filter((job) => job.status === "running").length;
@@ -1053,7 +1064,7 @@ export class AdminService {
     return {
       key: session.key,
       channelId: session.channelId,
-      channelLabel: channelLabelForSession(session, related.inbound),
+      channelLabel: channelLabelForSession(session, related.inbound, related.channelLabels),
       channelName: session.channelName ?? null,
       channelType: session.channelType ?? related.inbound.find((message) => message.channelType)?.channelType ?? null,
       rootThreadTs: session.rootThreadTs,
@@ -1451,8 +1462,32 @@ function isUserInboundMessage(message: PersistedInboundMessage): boolean {
 
 function channelLabelForSession(
   session: SlackSessionRecord,
-  inbound: readonly PersistedInboundMessage[]
+  inbound: readonly PersistedInboundMessage[],
+  channelLabels?: ReadonlyMap<string, string> | undefined
 ): string {
+  return channelHumanLabelForSession(session, inbound)
+    ?? channelLabels?.get(session.channelId)
+    ?? session.channelId;
+}
+
+function buildChannelLabelLookup(
+  sessions: readonly SlackSessionRecord[],
+  inboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>
+): ReadonlyMap<string, string> {
+  const labels = new Map<string, string>();
+  for (const session of sessions) {
+    const label = channelHumanLabelForSession(session, inboundBySession.get(session.key) ?? []);
+    if (label) {
+      labels.set(session.channelId, label);
+    }
+  }
+  return labels;
+}
+
+function channelHumanLabelForSession(
+  session: SlackSessionRecord,
+  inbound: readonly PersistedInboundMessage[]
+): string | undefined {
   if (session.channelName) {
     return formatSlackChannelName(session.channelName);
   }
@@ -1471,7 +1506,7 @@ function channelLabelForSession(
   if (channelType === "mpim") {
     return "群聊";
   }
-  return session.channelId;
+  return undefined;
 }
 
 function formatSlackChannelName(channelName: string): string {

--- a/test/admin-service.test.ts
+++ b/test/admin-service.test.ts
@@ -346,6 +346,17 @@ describe("AdminService", () => {
         ]
       }
     });
+
+    await writerSessions.ensureSession("C123", "222.333");
+
+    status = await service.getStatus();
+    const legacySession = ((status as Record<string, any>).state.sessions as Record<string, any>[])
+      .find((session) => session.key === "C123:222.333");
+    expect(legacySession).toMatchObject({
+      channelId: "C123",
+      channelName: null,
+      channelLabel: "#deep-review"
+    });
   });
 
   it("splits open inbound counts into human and system messages", async () => {

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import {
+  renderSessionMeta,
+  shouldShowSessionState
+} from "../src/admin-ui/session-row-display.js";
 import { getTimelineEventDisplay, isTimelineEventVisible } from "../src/admin-ui/timeline-display.js";
 
 describe("admin session timeline display", () => {
@@ -254,5 +258,59 @@ describe("admin session timeline display", () => {
       title: "工具调用",
       summary: "exec_command"
     })).toBe(true);
+  });
+});
+
+describe("admin session row display", () => {
+  it("keeps common session list metadata out of the row", () => {
+    const meta = renderSessionMeta({
+      key: "C123:111.222",
+      channelId: "C123",
+      channelLabel: "C123",
+      firstUserMessage: {
+        textPreview: "@codex-3720 你好"
+      },
+      lastUserMessage: {
+        textPreview: "后面 GPT 改了点"
+      },
+      usage: {
+        turnCount: 3,
+        totalTokens: 5120
+      },
+      backgroundJobCount: 0,
+      updatedAt: new Date().toISOString()
+    }, new Map(), new Map([["C123", "#ops"]]));
+    const labels = meta.map((item) => item.label);
+
+    expect(labels).toEqual(["#ops", "Token 5.1K"]);
+    expect(shouldShowSessionState({ rank: 10 })).toBe(false);
+  });
+
+  it("only shows job count when jobs exist and keeps distinct states visible", () => {
+    const meta = renderSessionMeta({
+      key: "C123:111.222",
+      channelId: "C123",
+      channelName: "deep-review",
+      firstUserMessage: {
+        textPreview: "看一下"
+      },
+      lastUserMessage: {
+        textPreview: "看一下"
+      },
+      openHumanInboundCount: 1,
+      openInboundCount: 1,
+      usage: {
+        turnCount: 1,
+        totalTokens: 1725
+      },
+      backgroundJobCount: 2,
+      runningBackgroundJobCount: 1,
+      updatedAt: new Date().toISOString()
+    }, new Map());
+    const labels = meta.map((item) => item.label);
+
+    expect(labels).toContain("#deep-review");
+    expect(labels).toContain("Jobs 2");
+    expect(shouldShowSessionState({ rank: 50 })).toBe(true);
   });
 });

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -267,7 +267,8 @@ describe("admin token usage e2e", () => {
     expect(shell).toContain("session-react-root");
     expect(sessionViewSource).toContain("会话详情");
     expect(sessionViewSource).toContain("Token 消耗");
-    expect(sessionViewSource).toContain("Token / 轮次");
+    expect(sessionViewSource).toContain('<Kpi label="Token"');
+    expect(sessionViewSource).not.toContain("Token / 轮次");
   });
 });
 


### PR DESCRIPTION
## Summary
- move read-only session title/KPI metadata to the bottom of the session detail view
- keep the top of the session page focused on operation actions and auth profile switching
- start the timeline in follow mode so session pages default to the latest activity
- simplify session list rows: hide common "有记录" state, remove 起始/更新 prefixes, hide Jobs 0 and rounds, and keep only meaningful status badges
- reuse known channel labels across sessions so old sessions on the same channel can show the channel name instead of only the raw Slack channel ID

## Verification
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm build
- pnpm exec vitest run test/admin-session-view.test.ts test/admin-service.test.ts test/admin-token-usage.e2e.test.ts
- pnpm test
- browser-verified mock admin session list: #ops displayed through channel-label fallback, no 有记录/J0/轮次/起始/更新 noise, Jobs only shown when >0