### PR TITLE
Resolve admin Slack channel labels

### DIFF
--- a/src/admin-index.ts
+++ b/src/admin-index.ts
@@ -11,7 +11,8 @@ import { ReleaseDeploymentService } from "./services/deploy/release-deployment-s
 import {
   configureServiceLogger,
   createGitHubAuthorMappings,
-  createSessionServices
+  createSessionServices,
+  createSlackApi
 } from "./services/service-components.js";
 
 export async function startAdminService(): Promise<{
@@ -43,7 +44,8 @@ export async function startAdminService(): Promise<{
     authProfiles,
     githubAuthorMappings,
     startedAt,
-    deployment
+    deployment,
+    slackConversations: createSlackApi(config)
   });
   const server = http.createServer(
     createHttpHandler({

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   createIsolatedMcpService,
   createJobManager,
   createSessionServices,
+  createSlackApi,
   createSlackBridge
 } from "./services/service-components.js";
 
@@ -59,7 +60,8 @@ export async function startService(): Promise<{
     runtime: new CodexRuntimeControl(codexBroker),
     authProfiles,
     githubAuthorMappings,
-    startedAt
+    startedAt,
+    slackConversations: createSlackApi(config)
   });
   const server = http.createServer(
     createHttpHandler({

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { AppConfig } from "../config.js";
-import { getBrokerLogDirectory } from "../logger.js";
+import { getBrokerLogDirectory, logger } from "../logger.js";
 import type {
   AdminOperationKind,
   JsonLike,
@@ -72,6 +72,14 @@ interface RuntimeStatus {
   };
 }
 
+interface SlackConversationLookup {
+  getConversationInfo(channelId: string): Promise<{
+    readonly channelId: string;
+    readonly name?: string | undefined;
+    readonly channelType?: string | undefined;
+  } | null>;
+}
+
 interface OperationPreflight {
   readonly operation: string;
   readonly safe: boolean;
@@ -126,6 +134,8 @@ interface SessionUsageSummary {
 type MutableSessionUsageSummary = { -readonly [Key in keyof SessionUsageSummary]: SessionUsageSummary[Key] };
 
 export class AdminService {
+  readonly #channelLabelCache = new Map<string, string | null>();
+
   constructor(
     private readonly options: {
       readonly config: AppConfig;
@@ -135,6 +145,7 @@ export class AdminService {
       readonly githubAuthorMappings: GitHubAuthorMappingService;
       readonly startedAt: Date;
       readonly deployment?: ReleaseDeploymentService | undefined;
+      readonly slackConversations?: SlackConversationLookup | undefined;
     }
   ) {}
 
@@ -152,7 +163,7 @@ export class AdminService {
     const snapshot = await this.#readSessionSnapshot();
     const runtime = await this.#readRuntimeStatus();
     const usage = this.#readUsageOverview();
-    const channelLabels = buildChannelLabelLookup(snapshot.allSessions, snapshot.inboundBySession);
+    const channelLabels = await this.#buildChannelLabelLookup(snapshot.allSessions, snapshot.inboundBySession);
     const sessionSummaries = snapshot.allSessions.slice(0, 50).map((session) =>
       this.#summarizeSession(session, {
         inbound: snapshot.inboundBySession.get(session.key) ?? [],
@@ -220,7 +231,7 @@ export class AdminService {
 
   async listSessionSummaries(): Promise<Record<string, unknown>> {
     const snapshot = await this.#readSessionSnapshot();
-    const channelLabels = buildChannelLabelLookup(snapshot.allSessions, snapshot.inboundBySession);
+    const channelLabels = await this.#buildChannelLabelLookup(snapshot.allSessions, snapshot.inboundBySession);
     return {
       ok: true,
       realtime: this.#realtimeInfo(),
@@ -316,7 +327,7 @@ export class AdminService {
         openInbound,
         jobs,
         usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key),
-        channelLabels: buildChannelLabelLookup([session], new Map([[session.key, inbound]]))
+        channelLabels: await this.#buildChannelLabelLookup([session], new Map([[session.key, inbound]]))
       }),
       trace: summarizeAgentTrace(agentEvents),
       events: [...events, ...agentEvents.map(agentTraceEventToTimelineEvent)].sort(compareTimelineEvents)
@@ -730,7 +741,7 @@ export class AdminService {
       rootThreadTs: session.rootThreadTs
     });
 
-    const channelLabels = buildChannelLabelLookup(
+    const channelLabels = this.#knownChannelLabelLookup(
       this.options.sessions.listSessions(),
       groupBySession(this.options.sessions.listInboundMessages())
     );
@@ -741,6 +752,66 @@ export class AdminService {
       usage: summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000)).get(session.key),
       channelLabels
     });
+  }
+
+  async #buildChannelLabelLookup(
+    sessions: readonly SlackSessionRecord[],
+    inboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>
+  ): Promise<ReadonlyMap<string, string>> {
+    const labels = this.#knownChannelLabelLookup(sessions, inboundBySession);
+    const missingChannelIds = uniqueChannelIds(sessions)
+      .filter((channelId) => !labels.has(channelId) && looksLikeSlackConversationId(channelId));
+
+    if (!missingChannelIds.length || !this.options.slackConversations) {
+      return labels;
+    }
+
+    await Promise.all(missingChannelIds.map(async (channelId) => {
+      const label = await this.#resolveSlackChannelLabel(channelId);
+      if (label) {
+        labels.set(channelId, label);
+      }
+    }));
+    return labels;
+  }
+
+  #knownChannelLabelLookup(
+    sessions: readonly SlackSessionRecord[],
+    inboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>
+  ): Map<string, string> {
+    const labels = buildChannelLabelLookup(sessions, inboundBySession);
+    for (const session of sessions) {
+      const cached = this.#channelLabelCache.get(session.channelId);
+      if (cached) {
+        labels.set(session.channelId, cached);
+      }
+    }
+    return labels;
+  }
+
+  async #resolveSlackChannelLabel(channelId: string): Promise<string | undefined> {
+    if (this.#channelLabelCache.has(channelId)) {
+      return this.#channelLabelCache.get(channelId) ?? undefined;
+    }
+
+    const lookup = this.options.slackConversations;
+    if (!lookup) {
+      return undefined;
+    }
+
+    try {
+      const info = await lookup.getConversationInfo(channelId);
+      const label = channelLabelForConversationInfo(info);
+      this.#channelLabelCache.set(channelId, label ?? null);
+      return label;
+    } catch (error) {
+      logger.warn("Failed to resolve Slack channel label for admin", {
+        channelId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      this.#channelLabelCache.set(channelId, null);
+      return undefined;
+    }
   }
 
   #serviceInfo(): Record<string, unknown> {
@@ -1470,10 +1541,36 @@ function channelLabelForSession(
     ?? session.channelId;
 }
 
+function channelLabelForConversationInfo(
+  info: Awaited<ReturnType<SlackConversationLookup["getConversationInfo"]>>
+): string | undefined {
+  if (!info) {
+    return undefined;
+  }
+  if (info.name) {
+    return formatSlackChannelName(info.name);
+  }
+  if (info.channelType === "im") {
+    return "私信";
+  }
+  if (info.channelType === "mpim") {
+    return "群聊";
+  }
+  return undefined;
+}
+
+function uniqueChannelIds(sessions: readonly SlackSessionRecord[]): string[] {
+  return [...new Set(sessions.map((session) => session.channelId).filter((channelId) => channelId))];
+}
+
+function looksLikeSlackConversationId(channelId: string): boolean {
+  return /^[CDG][A-Z0-9]+$/.test(channelId);
+}
+
 function buildChannelLabelLookup(
   sessions: readonly SlackSessionRecord[],
   inboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>
-): ReadonlyMap<string, string> {
+): Map<string, string> {
   const labels = new Map<string, string>();
   for (const session of sessions) {
     const label = channelHumanLabelForSession(session, inboundBySession.get(session.key) ?? []);

--- a/src/services/service-components.ts
+++ b/src/services/service-components.ts
@@ -11,6 +11,7 @@ import { DiskPressureCleanupService } from "./disk-pressure-cleanup-service.js";
 import { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
 import { JobManager } from "./job-manager.js";
 import { SessionManager } from "./session-manager.js";
+import { SlackApi } from "./slack/slack-api.js";
 import { SlackAgentBridge } from "./slack/slack-agent-bridge.js";
 
 export function configureServiceLogger(config: AppConfig): void {
@@ -38,6 +39,14 @@ export function createSessionServices(config: AppConfig): {
     stateStore,
     sessions
   };
+}
+
+export function createSlackApi(config: AppConfig): SlackApi {
+  return new SlackApi({
+    baseUrl: config.slackApiBaseUrl,
+    appToken: config.slackAppToken,
+    botToken: config.slackBotToken
+  });
 }
 
 export async function createGitHubAuthorMappings(config: AppConfig): Promise<GitHubAuthorMappingService> {

--- a/test/admin-service.test.ts
+++ b/test/admin-service.test.ts
@@ -359,6 +359,104 @@ describe("AdminService", () => {
     });
   });
 
+  it("resolves legacy channel labels from Slack when persisted metadata is missing", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-service-channel-lookup-"));
+    tempDirs.push(dataRoot);
+
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot
+    } as NodeJS.ProcessEnv);
+
+    await fs.mkdir(config.codexHome, { recursive: true });
+    await fs.mkdir(config.logDir, { recursive: true });
+
+    const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot: config.sessionsRoot
+    });
+    await sessions.load();
+    await sessions.ensureSession("C123", "111.222");
+    await sessions.ensureSession("C123", "222.333");
+
+    const lookupCalls: string[] = [];
+    const service = new AdminService({
+      config,
+      startedAt: new Date("2026-03-19T00:00:00.000Z"),
+      sessions,
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
+          activeProfile: null,
+          activeAuthPath: path.join(config.codexHome, "auth.json"),
+          profiles: []
+        })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => []
+      } as never,
+      runtime: {
+        restartRuntime: async () => {},
+        readAccountSummary: async () => ({
+          account: null,
+          requiresOpenaiAuth: true
+        }),
+        readAccountRateLimits: async () => ({
+          rateLimits: null,
+          rateLimitsByLimitId: {}
+        })
+      } as never,
+      slackConversations: {
+        getConversationInfo: async (channelId) => {
+          lookupCalls.push(channelId);
+          return {
+            channelId,
+            name: "ops",
+            channelType: "channel"
+          };
+        }
+      }
+    });
+
+    const timeline = await service.getSessionTimeline("C123:111.222");
+    expect((timeline as Record<string, any>).session).toMatchObject({
+      key: "C123:111.222",
+      channelName: null,
+      channelLabel: "#ops"
+    });
+
+    const status = await service.getStatus();
+    expect((status as Record<string, any>).state.sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "C123:111.222",
+          channelName: null,
+          channelLabel: "#ops"
+        }),
+        expect.objectContaining({
+          key: "C123:222.333",
+          channelName: null,
+          channelLabel: "#ops"
+        })
+      ])
+    );
+
+    const summaries = await service.listSessionSummaries();
+    expect((summaries as Record<string, any>).sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "C123:111.222",
+          channelLabel: "#ops"
+        })
+      ])
+    );
+    expect(lookupCalls).toEqual(["C123"]);
+  });
+
   it("splits open inbound counts into human and system messages", async () => {
     const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-service-open-inbound-"));
     tempDirs.push(dataRoot);


### PR DESCRIPTION
## Summary
- resolve missing admin channel labels through Slack conversations.info
- cache resolved labels in AdminService for list/detail/status reads
- inject Slack API lookup into admin and combined service runtimes

## Tests
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm build
- pnpm test