### PR TITLE
Score auth profiles by weekly quota refresh

### DIFF
--- a/src/admin-ui/auth-profile-display.ts
+++ b/src/admin-ui/auth-profile-display.ts
@@ -69,6 +69,17 @@ export function profileQuotaLabel(profile: AuthProfileRecord): string {
   return parts.length ? parts.join(" / ") : "额度未知";
 }
 
+export function profileWeeklyQuotaLabel(profile: AuthProfileRecord): string {
+  const rateLimits = profile.rateLimits || {};
+  if (rateLimits.ok === false) {
+    return "不可用";
+  }
+
+  const limits = rateLimits.rateLimits || {};
+  const secondary = remainingPercent(limits.secondary?.usedPercent);
+  return secondary !== null ? "周 " + Math.round(secondary) + "%" : "周额度未知";
+}
+
 function remainingPercent(usedPercent: unknown): number | null {
   const used = Number(usedPercent);
   if (!Number.isFinite(used)) {

--- a/src/admin-ui/session-row-display.ts
+++ b/src/admin-ui/session-row-display.ts
@@ -1,6 +1,6 @@
 import {
-  profileDisplayLabel,
-  profileTitle
+  profileTitle,
+  profileWeeklyQuotaLabel
 } from "./auth-profile-display.js";
 
 type SessionRecord = Record<string, any>;
@@ -52,7 +52,7 @@ export function renderSessionMeta(
     session.authBlockedAt ? { key: "auth-blocked", label: "账号待切换", tone: "danger", title: stringOrUndefined(session.authBlockReasonLabel || session.authBlockReason) } : null,
     session.authProfileName ? {
       key: "auth-profile",
-      label: authProfile ? "账号 " + profileDisplayLabel(authProfile) : "账号已绑定",
+      label: authProfile ? profileWeeklyQuotaLabel(authProfile) : "账号已绑定",
       tone: "info",
       title: authProfile ? profileTitle(authProfile) : String(session.authProfileName)
     } : null,

--- a/src/services/session-auth-profile-selector.ts
+++ b/src/services/session-auth-profile-selector.ts
@@ -13,22 +13,28 @@ export interface AuthProfileEvaluation {
   readonly profileName: string;
   readonly usable: boolean;
   readonly reason?: AuthProfileUnavailableReason | undefined;
-  readonly effectiveRemainingPercent: number;
+  readonly effectiveQuotaScore: number;
   readonly primaryRemainingPercent?: number | undefined;
   readonly secondaryRemainingPercent?: number | undefined;
+  readonly secondaryRefreshDays?: number | undefined;
+  readonly secondaryRemainingPercentPerDay?: number | undefined;
 }
 
-export function selectBestAuthProfile(status: AuthProfilesStatus): AuthProfileSummary | null {
+export function selectBestAuthProfile(
+  status: AuthProfilesStatus,
+  options: { readonly now?: Date | number | string | undefined } = {}
+): AuthProfileSummary | null {
+  const nowMs = timestampMs(options.now);
   const candidates = status.profiles
     .map((profile) => ({
       profile,
-      evaluation: evaluateAuthProfile(profile)
+      evaluation: evaluateAuthProfile(profile, { now: nowMs })
     }))
     .filter((candidate) => candidate.evaluation.usable)
     .sort((left, right) => {
-      const remainingDelta = right.evaluation.effectiveRemainingPercent - left.evaluation.effectiveRemainingPercent;
-      if (remainingDelta) {
-        return remainingDelta;
+      const scoreDelta = right.evaluation.effectiveQuotaScore - left.evaluation.effectiveQuotaScore;
+      if (scoreDelta) {
+        return scoreDelta;
       }
 
       const secondaryDelta =
@@ -55,7 +61,10 @@ export function findAuthProfile(status: AuthProfilesStatus, profileName: string)
   return status.profiles.find((profile) => profile.name === profileName) ?? null;
 }
 
-export function evaluateAuthProfile(profile: AuthProfileSummary): AuthProfileEvaluation {
+export function evaluateAuthProfile(
+  profile: AuthProfileSummary,
+  options: { readonly now?: Date | number | string | undefined } = {}
+): AuthProfileEvaluation {
   if (!profile.account.ok) {
     return unavailable(profile.name, "account_probe_failed");
   }
@@ -67,6 +76,8 @@ export function evaluateAuthProfile(profile: AuthProfileSummary): AuthProfileEva
   const limits = profile.rateLimits.rateLimits;
   const primaryRemaining = remainingPercent(limits?.primary?.usedPercent);
   const secondaryRemaining = remainingPercent(limits?.secondary?.usedPercent);
+  const secondaryRefreshDays = daysUntilReset(limits?.secondary?.resetsAt, timestampMs(options.now));
+  const secondaryRemainingPerDay = remainingPercentPerDay(secondaryRemaining, secondaryRefreshDays);
   const credits = limits?.credits;
 
   if (primaryRemaining !== undefined && primaryRemaining <= 0) {
@@ -93,9 +104,11 @@ export function evaluateAuthProfile(profile: AuthProfileSummary): AuthProfileEva
   return {
     profileName: profile.name,
     usable: true,
-    effectiveRemainingPercent: Math.min(primaryRemaining ?? 100, secondaryRemaining ?? 100),
+    effectiveQuotaScore: secondaryRemainingPerDay ?? secondaryRemaining ?? primaryRemaining ?? 100,
     primaryRemainingPercent: primaryRemaining,
-    secondaryRemainingPercent: secondaryRemaining
+    secondaryRemainingPercent: secondaryRemaining,
+    secondaryRefreshDays,
+    secondaryRemainingPercentPerDay: secondaryRemainingPerDay
   };
 }
 
@@ -128,6 +141,45 @@ function remainingPercent(usedPercent: number | undefined): number | undefined {
   return Math.max(0, Math.min(100, 100 - Number(usedPercent)));
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MIN_REFRESH_DAYS = 1 / (24 * 60);
+
+function remainingPercentPerDay(
+  remaining: number | undefined,
+  refreshDays: number | undefined
+): number | undefined {
+  if (remaining === undefined) {
+    return undefined;
+  }
+  if (refreshDays === undefined) {
+    return remaining;
+  }
+  return remaining / refreshDays;
+}
+
+function daysUntilReset(resetsAt: number | null | undefined, nowMs: number): number | undefined {
+  if (!Number.isFinite(resetsAt)) {
+    return undefined;
+  }
+
+  const deltaDays = (Number(resetsAt) * 1000 - nowMs) / MS_PER_DAY;
+  return Math.max(deltaDays, MIN_REFRESH_DAYS);
+}
+
+function timestampMs(value: Date | number | string | undefined): number {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : Date.now();
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : Date.now();
+  }
+  return Date.now();
+}
+
 function unavailable(
   profileName: string,
   reason: AuthProfileUnavailableReason,
@@ -140,7 +192,7 @@ function unavailable(
     profileName,
     usable: false,
     reason,
-    effectiveRemainingPercent: 0,
+    effectiveQuotaScore: 0,
     primaryRemainingPercent: partial?.primaryRemainingPercent,
     secondaryRemainingPercent: partial?.secondaryRemainingPercent
   };

--- a/test/admin-auth-profile-display.test.ts
+++ b/test/admin-auth-profile-display.test.ts
@@ -5,7 +5,8 @@ import {
   profileDisplayLabel,
   profileOptionLabel,
   profileQuotaLabel,
-  profileTitle
+  profileTitle,
+  profileWeeklyQuotaLabel
 } from "../src/admin-ui/auth-profile-display.js";
 
 describe("admin auth profile display", () => {
@@ -21,6 +22,7 @@ describe("admin auth profile display", () => {
     expect(profileAccountLabel(profile)).toBe("hejiachen@toeverything.info");
     expect(profileDisplayLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite");
     expect(profileQuotaLabel(profile)).toBe("短窗 96% / 周 64%");
+    expect(profileWeeklyQuotaLabel(profile)).toBe("周 64%");
     expect(profileOptionLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite · 短窗 96% / 周 64%");
     expect(profileTitle(profile)).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
   });

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -263,10 +263,34 @@ describe("admin session timeline display", () => {
 
 describe("admin session row display", () => {
   it("keeps common session list metadata out of the row", () => {
+    const authProfiles = new Map<string, Record<string, any>>([
+      ["profile-a", {
+        name: "profile-a",
+        account: {
+          ok: true,
+          account: {
+            email: "hejiachen@toeverything.info",
+            planType: "prolite"
+          }
+        },
+        rateLimits: {
+          ok: true,
+          rateLimits: {
+            primary: {
+              usedPercent: 4
+            },
+            secondary: {
+              usedPercent: 36
+            }
+          }
+        }
+      }]
+    ]);
     const meta = renderSessionMeta({
       key: "C123:111.222",
       channelId: "C123",
       channelLabel: "C123",
+      authProfileName: "profile-a",
       firstUserMessage: {
         textPreview: "@codex-3720 你好"
       },
@@ -279,10 +303,12 @@ describe("admin session row display", () => {
       },
       backgroundJobCount: 0,
       updatedAt: new Date().toISOString()
-    }, new Map(), new Map([["C123", "#ops"]]));
+    }, authProfiles, new Map([["C123", "#ops"]]));
     const labels = meta.map((item) => item.label);
 
-    expect(labels).toEqual(["#ops", "Token 5.1K"]);
+    expect(labels).toEqual(["#ops", "周 64%", "Token 5.1K"]);
+    expect(labels.join(" ")).not.toContain("hejiachen@toeverything.info");
+    expect(labels.join(" ")).not.toContain("Pro Lite");
     expect(shouldShowSessionState({ rank: 10 })).toBe(false);
   });
 

--- a/test/session-auth-profile-selector.test.ts
+++ b/test/session-auth-profile-selector.test.ts
@@ -7,7 +7,9 @@ import {
 import type { AuthProfileSummary, AuthProfilesStatus } from "../src/services/auth-profile-service.js";
 
 describe("session auth profile selector", () => {
-  it("selects the usable profile with the highest conservative remaining quota", () => {
+  const now = new Date("2026-05-09T00:00:00.000Z");
+
+  it("selects the usable profile with the highest weekly quota velocity", () => {
     const status = profileStatus([
       profile("low", {
         primaryUsed: 5,
@@ -26,10 +28,10 @@ describe("session auth profile selector", () => {
       })
     ]);
 
-    expect(selectBestAuthProfile(status)?.name).toBe("best");
+    expect(selectBestAuthProfile(status, { now })?.name).toBe("best");
   });
 
-  it("keeps a usable bound profile even when another profile has more quota", () => {
+  it("still treats a lower quota bound profile as usable without auto-switching it here", () => {
     const status = profileStatus([
       profile("bound", {
         primaryUsed: 60,
@@ -41,8 +43,31 @@ describe("session auth profile selector", () => {
       })
     ]);
 
-    expect(evaluateAuthProfile(status.profiles[0]!).usable).toBe(true);
-    expect(selectBestAuthProfile(status)?.name).toBe("bigger");
+    expect(evaluateAuthProfile(status.profiles[0]!, { now }).usable).toBe(true);
+    expect(selectBestAuthProfile(status, { now })?.name).toBe("bigger");
+  });
+
+  it("prefers weekly quota that refreshes sooner when remaining quota is equal", () => {
+    const oneDay = Math.floor((now.getTime() + 24 * 60 * 60 * 1000) / 1000);
+    const sevenDays = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
+    const status = profileStatus([
+      profile("later-refresh", {
+        primaryUsed: 0,
+        secondaryUsed: 50,
+        secondaryResetsAt: sevenDays
+      }),
+      profile("sooner-refresh", {
+        primaryUsed: 0,
+        secondaryUsed: 50,
+        secondaryResetsAt: oneDay
+      })
+    ]);
+
+    const later = evaluateAuthProfile(status.profiles[0]!, { now });
+    const sooner = evaluateAuthProfile(status.profiles[1]!, { now });
+    expect(later.secondaryRemainingPercentPerDay).toBeCloseTo(50 / 7);
+    expect(sooner.secondaryRemainingPercentPerDay).toBeCloseTo(50);
+    expect(selectBestAuthProfile(status, { now })?.name).toBe("sooner-refresh");
   });
 
   it("marks a profile unavailable when either quota window is exhausted", () => {
@@ -79,6 +104,7 @@ function profile(
   options: {
     readonly primaryUsed?: number | undefined;
     readonly secondaryUsed?: number | undefined;
+    readonly secondaryResetsAt?: number | undefined;
     readonly rateLimitsOk?: boolean | undefined;
   } = {}
 ): AuthProfileSummary {
@@ -112,7 +138,7 @@ function profile(
             secondary: {
               usedPercent: options.secondaryUsed ?? 0,
               windowDurationMins: 10_080,
-              resetsAt: 1_780_000_000
+              resetsAt: options.secondaryResetsAt ?? 1_780_000_000
             },
             credits: null,
             planType: "pro"


### PR DESCRIPTION
## Summary
- show only weekly quota in session-list auth metadata
- score new session auth profile selection by weekly remaining quota divided by days until weekly reset
- keep short-window quota as a usability gate and tie-breaker instead of the primary allocation score

## Tests
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm build
- pnpm test