### PR TITLE
[codex] Track semantic session activity time

### DIFF
--- a/src/admin-ui/session-row-display.ts
+++ b/src/admin-ui/session-row-display.ts
@@ -63,6 +63,24 @@ export function renderSessionMeta(
   ].filter((item): item is SessionMetaPill => Boolean(item));
 }
 
+export function sessionActivityAt(session: SessionRecord): unknown {
+  const candidates = [
+    session.lastActivityAt,
+    session.lastTurnSignalAt,
+    session.lastSlackReplyAt,
+    session.activeTurnStartedAt,
+    session.usage?.lastTurnAt,
+    ...(session.openInbound || []).map((message: Record<string, any>) => message.updatedAt || message.createdAt),
+    ...(session.backgroundJobs || []).flatMap(jobActivityTimestamps)
+  ];
+  const latestMs = newestTimestamp(candidates);
+  return candidates.find((value) => timestampMs(value) === latestMs) || session.createdAt || session.updatedAt;
+}
+
+export function sessionActivityMs(session: SessionRecord): number {
+  return timestampMs(sessionActivityAt(session));
+}
+
 function sessionHumanChannelLabel(session: SessionRecord): string | undefined {
   const channelId = String(session.channelId || "");
   const channelName = String(session.channelName || "").trim();
@@ -98,4 +116,21 @@ function looksLikeSlackChannelId(value: string): boolean {
 function stringOrUndefined(value: unknown): string | undefined {
   const text = String(value || "");
   return text || undefined;
+}
+
+function jobActivityTimestamps(job: Record<string, any>): unknown[] {
+  return [
+    job.lastEventAt,
+    job.status === "running" ? null : job.updatedAt,
+    job.createdAt
+  ];
+}
+
+function timestampMs(value: unknown): number {
+  const parsed = typeof value === "string" ? Date.parse(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function newestTimestamp(values: readonly unknown[]): number {
+  return values.reduce<number>((latest, value) => Math.max(latest, timestampMs(value)), 0);
 }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -19,6 +19,8 @@ import {
   buildChannelLabelById,
   renderSessionMeta,
   resolveSessionChannelLabel,
+  sessionActivityAt,
+  sessionActivityMs,
   shouldShowSessionState
 } from "./session-row-display";
 import { getTimelineEventDisplay, isTimelineEventVisible, statusLabel, type TimelineEvent } from "./timeline-display";
@@ -706,24 +708,6 @@ function compareSessionsForMode(mode: string, left: SessionRecord, right: Sessio
   const activityDelta = sessionActivityMs(right) - sessionActivityMs(left);
   if (activityDelta) return activityDelta;
   return String(left.key).localeCompare(String(right.key));
-}
-
-function sessionActivityAt(session: SessionRecord): unknown {
-  const candidates = [
-    session.updatedAt,
-    session.lastTurnSignalAt,
-    session.lastSlackReplyAt,
-    session.activeTurnStartedAt,
-    session.usage?.lastTurnAt,
-    ...(session.openInbound || []).map((message: Record<string, any>) => message.updatedAt || message.createdAt),
-    ...(session.backgroundJobs || []).flatMap((job: Record<string, any>) => [job.lastEventAt, job.heartbeatAt, job.updatedAt, job.createdAt])
-  ];
-  const latestMs = newestTimestamp(candidates);
-  return candidates.find((value) => timestampMs(value) === latestMs) || session.updatedAt || session.createdAt;
-}
-
-function sessionActivityMs(session: SessionRecord): number {
-  return timestampMs(sessionActivityAt(session));
 }
 
 async function requestJson(path: string, init?: RequestInit): Promise<unknown> {

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -607,10 +607,7 @@ export class AdminService {
 
   async #readSessionSnapshot(): Promise<SessionSnapshot> {
     await this.#refreshSessions();
-    const allSessions = this.options.sessions
-      .listSessions()
-      .sort((left, right) => compareSessions(left, right));
-    const activeSessions = allSessions.filter((session) => Boolean(session.activeTurnId));
+    const sessions = this.options.sessions.listSessions();
     const inbound = this.options.sessions.listInboundMessages();
     const openInbound = this.options.sessions
       .listInboundMessages({
@@ -620,7 +617,17 @@ export class AdminService {
     const backgroundJobs = this.options.sessions
       .listBackgroundJobs()
       .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
+    const inboundBySession = groupBySession(inbound);
+    const openInboundBySession = groupBySession(openInbound);
+    const jobsBySession = groupBySession(backgroundJobs);
     const usageBySession = summarizeUsageBySessionMap(this.#listAgentTurnUsage(1000));
+    const allSessions = sessions
+      .sort((left, right) => compareSessions(left, right, {
+        inboundBySession,
+        jobsBySession,
+        usageBySession
+      }));
+    const activeSessions = allSessions.filter((session) => Boolean(session.activeTurnId));
 
     return {
       allSessions,
@@ -628,9 +635,9 @@ export class AdminService {
       inbound,
       openInbound,
       backgroundJobs,
-      inboundBySession: groupBySession(inbound),
-      openInboundBySession: groupBySession(openInbound),
-      jobsBySession: groupBySession(backgroundJobs),
+      inboundBySession,
+      openInboundBySession,
+      jobsBySession,
       usageBySession
     };
   }
@@ -1132,6 +1139,11 @@ export class AdminService {
     const userMessages = related.inbound.filter(isUserInboundMessage);
     const firstUserMessage = userMessages.at(0);
     const lastUserMessage = userMessages.at(-1);
+    const lastActivityAt = sessionLastActivityAt(session, {
+      inbound: related.inbound,
+      jobs: related.jobs,
+      usage: related.usage
+    });
     return {
       key: session.key,
       channelId: session.channelId,
@@ -1143,6 +1155,7 @@ export class AdminService {
       workspacePath: session.workspacePath,
       agentSessionId: session.agentSessionId ?? null,
       updatedAt: session.updatedAt,
+      lastActivityAt,
       createdAt: session.createdAt,
       firstUserMessage: firstUserMessage ? this.#summarizeInbound(firstUserMessage) : null,
       lastUserMessage: lastUserMessage ? this.#summarizeInbound(lastUserMessage) : null,
@@ -1364,13 +1377,77 @@ function usageTimestampMs(record: PersistedAgentTurnUsage): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function compareSessions(left: SlackSessionRecord, right: SlackSessionRecord): number {
+function compareSessions(
+  left: SlackSessionRecord,
+  right: SlackSessionRecord,
+  related: {
+    readonly inboundBySession: ReadonlyMap<string, readonly PersistedInboundMessage[]>;
+    readonly jobsBySession: ReadonlyMap<string, readonly PersistedBackgroundJob[]>;
+    readonly usageBySession: ReadonlyMap<string, SessionUsageSummary>;
+  }
+): number {
   const leftActive = left.activeTurnId ? 1 : 0;
   const rightActive = right.activeTurnId ? 1 : 0;
   if (leftActive !== rightActive) {
     return rightActive - leftActive;
   }
-  return String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? ""));
+  return sessionLastActivityMs(right, {
+    inbound: related.inboundBySession.get(right.key) ?? [],
+    jobs: related.jobsBySession.get(right.key) ?? [],
+    usage: related.usageBySession.get(right.key)
+  }) - sessionLastActivityMs(left, {
+    inbound: related.inboundBySession.get(left.key) ?? [],
+    jobs: related.jobsBySession.get(left.key) ?? [],
+    usage: related.usageBySession.get(left.key)
+  }) || String(left.key).localeCompare(String(right.key));
+}
+
+function sessionLastActivityAt(
+  session: SlackSessionRecord,
+  related: {
+    readonly inbound: readonly PersistedInboundMessage[];
+    readonly jobs: readonly PersistedBackgroundJob[];
+    readonly usage?: SessionUsageSummary | undefined;
+  }
+): string {
+  const candidates = [
+    session.lastTurnSignalAt,
+    session.lastSlackReplyAt,
+    session.activeTurnStartedAt,
+    related.usage?.lastTurnAt,
+    ...related.inbound.flatMap((message) => [message.updatedAt, message.createdAt]),
+    ...related.jobs.flatMap(jobActivityTimestamps)
+  ];
+  const latestMs = newestTimestamp(candidates);
+  return candidates.find((value) => timestampMs(value) === latestMs) ?? session.createdAt ?? session.updatedAt;
+}
+
+function sessionLastActivityMs(
+  session: SlackSessionRecord,
+  related: {
+    readonly inbound: readonly PersistedInboundMessage[];
+    readonly jobs: readonly PersistedBackgroundJob[];
+    readonly usage?: SessionUsageSummary | undefined;
+  }
+): number {
+  return timestampMs(sessionLastActivityAt(session, related));
+}
+
+function jobActivityTimestamps(job: PersistedBackgroundJob): Array<string | null | undefined> {
+  return [
+    job.lastEventAt,
+    job.status === "running" ? null : job.updatedAt,
+    job.createdAt
+  ];
+}
+
+function timestampMs(value: unknown): number {
+  const parsed = typeof value === "string" ? Date.parse(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function newestTimestamp(values: readonly unknown[]): number {
+  return values.reduce<number>((latest, value) => Math.max(latest, timestampMs(value)), 0);
 }
 
 function compareTimelineEvents(left: Record<string, JsonLike>, right: Record<string, JsonLike>): number {

--- a/test/admin-service.test.ts
+++ b/test/admin-service.test.ts
@@ -457,6 +457,96 @@ describe("AdminService", () => {
     expect(lookupCalls).toEqual(["C123"]);
   });
 
+  it("reports session activity time from real activity instead of metadata updates", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-service-activity-time-"));
+    tempDirs.push(dataRoot);
+
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot
+    } as NodeJS.ProcessEnv);
+
+    await fs.mkdir(config.codexHome, { recursive: true });
+    await fs.mkdir(config.logDir, { recursive: true });
+
+    const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot: config.sessionsRoot
+    });
+    await sessions.load();
+    await sessions.ensureSession("C123", "111.222");
+    await sessions.ensureSession("C123", "222.333");
+    await sessions.upsertInboundMessage({
+      key: "C123:111.222:111.223",
+      sessionKey: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      messageTs: "111.223",
+      source: "thread_reply",
+      userId: "U123",
+      text: "old activity",
+      status: "done",
+      createdAt: "2026-03-19T00:00:00.000Z",
+      updatedAt: "2026-03-19T00:00:00.000Z"
+    });
+    await sessions.upsertInboundMessage({
+      key: "C123:222.333:222.334",
+      sessionKey: "C123:222.333",
+      channelId: "C123",
+      rootThreadTs: "222.333",
+      messageTs: "222.334",
+      source: "thread_reply",
+      userId: "U123",
+      text: "new activity",
+      status: "done",
+      createdAt: "2026-03-20T00:00:00.000Z",
+      updatedAt: "2026-03-20T00:00:00.000Z"
+    });
+
+    const service = new AdminService({
+      config,
+      startedAt: new Date("2026-03-19T00:00:00.000Z"),
+      sessions,
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "docker", "profiles"),
+          activeProfile: null,
+          activeAuthPath: path.join(config.codexHome, "auth.json"),
+          profiles: []
+        })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => []
+      } as never,
+      runtime: {
+        restartRuntime: async () => {},
+        readAccountSummary: async () => ({
+          account: null,
+          requiresOpenaiAuth: true
+        }),
+        readAccountRateLimits: async () => ({
+          rateLimits: null,
+          rateLimitsByLimitId: {}
+        })
+      } as never
+    });
+
+    const status = await service.getStatus();
+    const summaries = (status as Record<string, any>).state.sessions as Record<string, any>[];
+    expect(summaries.map((session) => session.key).slice(0, 2)).toEqual([
+      "C123:222.333",
+      "C123:111.222"
+    ]);
+    expect(summaries.find((session) => session.key === "C123:111.222")).toMatchObject({
+      updatedAt: expect.any(String),
+      lastActivityAt: "2026-03-19T00:00:00.000Z"
+    });
+  });
+
   it("splits open inbound counts into human and system messages", async () => {
     const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-service-open-inbound-"));
     tempDirs.push(dataRoot);

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   renderSessionMeta,
+  sessionActivityAt,
   shouldShowSessionState
 } from "../src/admin-ui/session-row-display.js";
 import { getTimelineEventDisplay, isTimelineEventVisible } from "../src/admin-ui/timeline-display.js";
@@ -338,5 +339,17 @@ describe("admin session row display", () => {
     expect(labels).toContain("#deep-review");
     expect(labels).toContain("Jobs 2");
     expect(shouldShowSessionState({ rank: 50 })).toBe(true);
+  });
+
+  it("uses semantic session activity time instead of metadata updatedAt", () => {
+    expect(sessionActivityAt({
+      key: "C123:111.222",
+      createdAt: "2026-03-18T00:00:00.000Z",
+      updatedAt: "2026-05-10T00:00:00.000Z",
+      lastActivityAt: "2026-03-19T00:00:00.000Z",
+      usage: {
+        lastTurnAt: "2026-03-19T00:00:00.000Z"
+      }
+    })).toBe("2026-03-19T00:00:00.000Z");
   });
 });


### PR DESCRIPTION
## Summary
- add `lastActivityAt` to admin session summaries based on real session activity
- sort and display session rows by semantic activity instead of metadata `updatedAt`
- ignore running-job heartbeat/metadata updates so deploy/reconcile writes do not move session rows

## Root cause
Admin list recency used `session.updatedAt`. Deploy/startup reconciliation can update session metadata, such as channel-name backfill, without any user or agent activity. That made old sessions look newly updated after deployment.

## Validation
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm build`
- `pnpm test`