### PR TITLE
[codex] Show weighted weekly auth quota

### DIFF
--- a/src/admin-ui/admin-legacy.js
+++ b/src/admin-ui/admin-legacy.js
@@ -153,8 +153,29 @@ export function initAdminPage(options = {}) {
       if (n >= 1000) return (n / 1000).toFixed(1).replace(/\\.0$/, "") + "K";
       return String(Math.round(n));
     }
-    function clampPercent(value) {
-      return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
+    function remainingPercent(value) {
+      const used = Number(value);
+      if (!Number.isFinite(used)) return null;
+      return Math.max(0, Math.min(100, 100 - used));
+    }
+    function daysUntilReset(resetsAt) {
+      const seconds = Number(resetsAt);
+      if (!Number.isFinite(seconds)) return null;
+      return Math.max(((seconds * 1000) - Date.now()) / 86400000, 1 / (24 * 60));
+    }
+    function weightedWeeklyQuotaScore(remaining, refreshDays) {
+      if (remaining == null) return null;
+      return (remaining / 100) / ((refreshDays || 7) / 7);
+    }
+    function formatWeightedWeeklyQuotaScore(score) {
+      if (!Number.isFinite(Number(score))) return "0";
+      return Number(score).toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+    }
+    function weeklyQuotaDisplay(limit) {
+      const remaining = remainingPercent(limit?.usedPercent);
+      if (remaining == null) return null;
+      const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(limit?.resetsAt));
+      return Math.round(remaining) + "% | " + formatWeightedWeeklyQuotaScore(score);
     }
     function statusTone(status) {
       const v = String(status || "").toLowerCase();
@@ -270,20 +291,17 @@ export function initAdminPage(options = {}) {
       const activeProfile = (authProfiles.profiles || []).find((p) => p.active);
       const rateLimits = activeProfile?.rateLimits;
       const snapshot = rateLimits?.rateLimits || {};
-      const primary = snapshot.primary;
       const secondary = snapshot.secondary;
       const topbarQuota = document.getElementById("topbar-quota");
       const accountChip = renderAccountChip(a);
-      if (rateLimits?.ok && primary) {
-        const weeklyRemaining = secondary ? (100 - clampPercent(secondary.usedPercent)) : null;
+      if (rateLimits?.ok && secondary) {
+        const weeklyRemaining = remainingPercent(secondary.usedPercent);
         const weeklyTone = weeklyRemaining != null ? (weeklyRemaining < 10 ? "danger" : (weeklyRemaining < 30 ? "warn" : "")) : "";
-        const hourlyRemaining = 100 - clampPercent(primary.usedPercent);
-        const hourlyTone = hourlyRemaining < 10 ? "danger" : (hourlyRemaining < 30 ? "warn" : "");
+        const weeklyLabel = weeklyQuotaDisplay(secondary);
         topbarQuota.innerHTML =
           accountChip +
-          (weeklyRemaining != null ? '<span class="quota-pill ' + weeklyTone + '">周 <strong>' + weeklyRemaining + '%</strong></span>' : '') +
-          '<span class="quota-pill ' + hourlyTone + '">5h <strong>' + hourlyRemaining + '%</strong></span>' +
-          '<span class="quota-pill">重置 ' + esc(formatResetTime(primary.resetsAt)) + '</span>' +
+          (weeklyLabel ? '<span class="quota-pill ' + weeklyTone + '"><strong>' + esc(weeklyLabel) + '</strong></span>' : '') +
+          '<span class="quota-pill">周重置 ' + esc(formatResetTime(secondary.resetsAt)) + '</span>' +
           '<span class="quota-meta">' + (st.activeCount || 0) + " 活跃 · " + (st.openInboundCount || 0) + " 待处理 · " + (st.runningBackgroundJobCount || 0) + " 任务</span>";
       } else {
         topbarQuota.innerHTML = accountChip +
@@ -425,11 +443,10 @@ export function initAdminPage(options = {}) {
     function renderProfileQuota(rateLimits) {
       if (!rateLimits || !rateLimits.ok) return '<div class="summary-detail">' + esc(rateLimits?.error || "额度不可用") + '</div>';
       const snapshot = rateLimits.rateLimits || {};
-      const primary = snapshot.primary;
       const secondary = snapshot.secondary;
+      const weeklyLabel = weeklyQuotaDisplay(secondary);
       return '<div class="quota-grid">' +
-        '<div class="quota-line"><span>5 小时</span><strong>' + esc(primary ? "剩余 " + String(100 - clampPercent(primary.usedPercent)) + "%" : "--") + '</strong><span>' + esc(primary ? formatResetTime(primary.resetsAt) : "不可用") + '</span></div>' +
-        '<div class="quota-line"><span>每周</span><strong>' + esc(secondary ? "剩余 " + String(100 - clampPercent(secondary.usedPercent)) + "%" : "--") + '</strong><span>' + esc(secondary ? formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
+        '<div class="quota-line"><span>周额度</span><strong>' + esc(weeklyLabel || "--") + '</strong><span>' + esc(secondary ? formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
       '</div>';
     }
     function renderAuthProfiles(data) {

--- a/src/admin-ui/auth-profile-display.ts
+++ b/src/admin-ui/auth-profile-display.ts
@@ -1,4 +1,9 @@
+import { formatWeeklyQuotaDisplay } from "../auth-profile-quota.js";
+
 type AuthProfileRecord = Record<string, any>;
+interface QuotaLabelOptions {
+  readonly now?: Date | number | string | undefined;
+}
 
 export function profileAccountLabel(profile: AuthProfileRecord): string {
   const accountStatus = profile.account || {};
@@ -37,15 +42,15 @@ export function profileDisplayLabel(profile: AuthProfileRecord): string {
     .join(" · ");
 }
 
-export function profileOptionLabel(profile: AuthProfileRecord): string {
-  return [profileDisplayLabel(profile), profileQuotaLabel(profile)]
+export function profileOptionLabel(profile: AuthProfileRecord, options: QuotaLabelOptions = {}): string {
+  return [profileDisplayLabel(profile), profileQuotaLabel(profile, options)]
     .filter(Boolean)
     .join(" · ");
 }
 
-export function profileTitle(profile: AuthProfileRecord): string {
+export function profileTitle(profile: AuthProfileRecord, options: QuotaLabelOptions = {}): string {
   const internalName = readString(profile.name);
-  return [profileOptionLabel(profile), internalName ? `内部标识 ${internalName}` : ""]
+  return [profileOptionLabel(profile, options), internalName ? `内部标识 ${internalName}` : ""]
     .filter(Boolean)
     .join(" · ");
 }
@@ -54,38 +59,33 @@ export function profileIsSelectable(profile: AuthProfileRecord): boolean {
   return profile.account?.ok !== false && profile.rateLimits?.ok !== false;
 }
 
-export function profileQuotaLabel(profile: AuthProfileRecord): string {
+export function profileQuotaLabel(profile: AuthProfileRecord, options: QuotaLabelOptions = {}): string {
   const rateLimits = profile.rateLimits || {};
   if (rateLimits.ok === false) {
     return "不可用";
   }
 
   const limits = rateLimits.rateLimits || {};
-  const primary = remainingPercent(limits.primary?.usedPercent);
-  const secondary = remainingPercent(limits.secondary?.usedPercent);
-  const parts = [];
-  if (primary !== null) parts.push("短窗 " + Math.round(primary) + "%");
-  if (secondary !== null) parts.push("周 " + Math.round(secondary) + "%");
-  return parts.length ? parts.join(" / ") : "额度未知";
+  const label = formatWeeklyQuotaDisplay({
+    usedPercent: limits.secondary?.usedPercent,
+    resetsAt: limits.secondary?.resetsAt,
+    now: options.now
+  });
+  return label ?? "周额度未知";
 }
 
-export function profileWeeklyQuotaLabel(profile: AuthProfileRecord): string {
+export function profileWeeklyQuotaLabel(profile: AuthProfileRecord, options: QuotaLabelOptions = {}): string {
   const rateLimits = profile.rateLimits || {};
   if (rateLimits.ok === false) {
     return "不可用";
   }
 
   const limits = rateLimits.rateLimits || {};
-  const secondary = remainingPercent(limits.secondary?.usedPercent);
-  return secondary !== null ? "周 " + Math.round(secondary) + "%" : "周额度未知";
-}
-
-function remainingPercent(usedPercent: unknown): number | null {
-  const used = Number(usedPercent);
-  if (!Number.isFinite(used)) {
-    return null;
-  }
-  return Math.max(0, Math.min(100, 100 - used));
+  return formatWeeklyQuotaDisplay({
+    usedPercent: limits.secondary?.usedPercent,
+    resetsAt: limits.secondary?.resetsAt,
+    now: options.now
+  }) ?? "周额度未知";
 }
 
 function readString(value: unknown): string | null {

--- a/src/auth-profile-quota.ts
+++ b/src/auth-profile-quota.ts
@@ -1,0 +1,75 @@
+export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+export const MIN_REFRESH_DAYS = 1 / (24 * 60);
+
+export function remainingPercent(usedPercent: unknown): number | undefined {
+  const used = Number(usedPercent);
+  if (!Number.isFinite(used)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.min(100, 100 - used));
+}
+
+export function daysUntilReset(
+  resetsAt: unknown,
+  now: Date | number | string | undefined = undefined
+): number | undefined {
+  const resetSeconds = Number(resetsAt);
+  if (!Number.isFinite(resetSeconds)) {
+    return undefined;
+  }
+
+  const deltaDays = (resetSeconds * 1000 - timestampMs(now)) / MS_PER_DAY;
+  return Math.max(deltaDays, MIN_REFRESH_DAYS);
+}
+
+export function weightedWeeklyQuotaScore(
+  remaining: number | undefined,
+  refreshDays: number | undefined
+): number | undefined {
+  if (remaining === undefined) {
+    return undefined;
+  }
+
+  const days = refreshDays ?? 7;
+  return (remaining / 100) / (days / 7);
+}
+
+export function formatWeeklyQuotaDisplay(options: {
+  readonly usedPercent: unknown;
+  readonly resetsAt?: unknown;
+  readonly now?: Date | number | string | undefined;
+}): string | null {
+  const remaining = remainingPercent(options.usedPercent);
+  if (remaining === undefined) {
+    return null;
+  }
+
+  const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(options.resetsAt, options.now));
+  return `${Math.round(remaining)}% | ${formatWeightedWeeklyQuotaScore(score)}`;
+}
+
+export function formatWeightedWeeklyQuotaScore(score: number | undefined): string {
+  if (!Number.isFinite(score)) {
+    return "0";
+  }
+
+  return Number(score)
+    .toFixed(2)
+    .replace(/\.00$/, "")
+    .replace(/(\.\d)0$/, "$1");
+}
+
+export function timestampMs(value: Date | number | string | undefined): number {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : Date.now();
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : Date.now();
+  }
+  return Date.now();
+}

--- a/src/services/session-auth-profile-selector.ts
+++ b/src/services/session-auth-profile-selector.ts
@@ -1,4 +1,10 @@
 import type { AuthProfileSummary, AuthProfilesStatus } from "./auth-profile-service.js";
+import {
+  daysUntilReset,
+  remainingPercent,
+  timestampMs,
+  weightedWeeklyQuotaScore
+} from "../auth-profile-quota.js";
 
 export type AuthProfileUnavailableReason =
   | "profile_not_found"
@@ -17,7 +23,7 @@ export interface AuthProfileEvaluation {
   readonly primaryRemainingPercent?: number | undefined;
   readonly secondaryRemainingPercent?: number | undefined;
   readonly secondaryRefreshDays?: number | undefined;
-  readonly secondaryRemainingPercentPerDay?: number | undefined;
+  readonly weightedWeeklyQuotaScore?: number | undefined;
 }
 
 export function selectBestAuthProfile(
@@ -77,7 +83,7 @@ export function evaluateAuthProfile(
   const primaryRemaining = remainingPercent(limits?.primary?.usedPercent);
   const secondaryRemaining = remainingPercent(limits?.secondary?.usedPercent);
   const secondaryRefreshDays = daysUntilReset(limits?.secondary?.resetsAt, timestampMs(options.now));
-  const secondaryRemainingPerDay = remainingPercentPerDay(secondaryRemaining, secondaryRefreshDays);
+  const weightedWeeklyQuota = weightedWeeklyQuotaScore(secondaryRemaining, secondaryRefreshDays);
   const credits = limits?.credits;
 
   if (primaryRemaining !== undefined && primaryRemaining <= 0) {
@@ -104,11 +110,15 @@ export function evaluateAuthProfile(
   return {
     profileName: profile.name,
     usable: true,
-    effectiveQuotaScore: secondaryRemainingPerDay ?? secondaryRemaining ?? primaryRemaining ?? 100,
+    effectiveQuotaScore:
+      weightedWeeklyQuota ??
+      (secondaryRemaining !== undefined ? secondaryRemaining / 100 : undefined) ??
+      (primaryRemaining !== undefined ? primaryRemaining / 100 : undefined) ??
+      1,
     primaryRemainingPercent: primaryRemaining,
     secondaryRemainingPercent: secondaryRemaining,
     secondaryRefreshDays,
-    secondaryRemainingPercentPerDay: secondaryRemainingPerDay
+    weightedWeeklyQuotaScore: weightedWeeklyQuota
   };
 }
 
@@ -121,7 +131,7 @@ export function authProfileReasonLabel(reason: string | undefined): string {
     case "rate_limits_probe_failed":
       return "额度状态读取失败";
     case "primary_quota_exhausted":
-      return "短窗口额度已耗尽";
+      return "当前额度已耗尽";
     case "secondary_quota_exhausted":
       return "周额度已耗尽";
     case "credits_exhausted":
@@ -131,53 +141,6 @@ export function authProfileReasonLabel(reason: string | undefined): string {
     default:
       return reason || "账号不可用";
   }
-}
-
-function remainingPercent(usedPercent: number | undefined): number | undefined {
-  if (!Number.isFinite(usedPercent)) {
-    return undefined;
-  }
-
-  return Math.max(0, Math.min(100, 100 - Number(usedPercent)));
-}
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-const MIN_REFRESH_DAYS = 1 / (24 * 60);
-
-function remainingPercentPerDay(
-  remaining: number | undefined,
-  refreshDays: number | undefined
-): number | undefined {
-  if (remaining === undefined) {
-    return undefined;
-  }
-  if (refreshDays === undefined) {
-    return remaining;
-  }
-  return remaining / refreshDays;
-}
-
-function daysUntilReset(resetsAt: number | null | undefined, nowMs: number): number | undefined {
-  if (!Number.isFinite(resetsAt)) {
-    return undefined;
-  }
-
-  const deltaDays = (Number(resetsAt) * 1000 - nowMs) / MS_PER_DAY;
-  return Math.max(deltaDays, MIN_REFRESH_DAYS);
-}
-
-function timestampMs(value: Date | number | string | undefined): number {
-  if (value instanceof Date) {
-    return value.getTime();
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : Date.now();
-  }
-  if (typeof value === "string") {
-    const parsed = Date.parse(value);
-    return Number.isFinite(parsed) ? parsed : Date.now();
-  }
-  return Date.now();
 }
 
 function unavailable(

--- a/test/admin-auth-profile-display.test.ts
+++ b/test/admin-auth-profile-display.test.ts
@@ -11,20 +11,64 @@ import {
 
 describe("admin auth profile display", () => {
   it("uses the account identity instead of the internal profile name", () => {
+    const now = new Date("2026-05-09T00:00:00.000Z");
+    const sevenDays = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
     const profile = authProfile({
       name: "575d9997-db66-4b21-979d-4d3b9597b36e",
       email: "hejiachen@toeverything.info",
       planType: "prolite",
       primaryUsed: 4,
-      secondaryUsed: 36
+      secondaryUsed: 36,
+      secondaryResetsAt: sevenDays
     });
 
     expect(profileAccountLabel(profile)).toBe("hejiachen@toeverything.info");
     expect(profileDisplayLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite");
-    expect(profileQuotaLabel(profile)).toBe("短窗 96% / 周 64%");
-    expect(profileWeeklyQuotaLabel(profile)).toBe("周 64%");
-    expect(profileOptionLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite · 短窗 96% / 周 64%");
-    expect(profileTitle(profile)).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
+    expect(profileQuotaLabel(profile, { now })).toBe("64% | 0.64");
+    expect(profileWeeklyQuotaLabel(profile, { now })).toBe("64% | 0.64");
+    expect(profileOptionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 64% | 0.64");
+    expect(profileTitle(profile, { now })).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
+  });
+
+  it("shows weighted weekly quota normalized by reset time", () => {
+    const now = new Date("2026-05-09T00:00:00.000Z");
+    const daysFromNow = (days: number) => Math.floor((now.getTime() + days * 24 * 60 * 60 * 1000) / 1000);
+
+    expect(profileWeeklyQuotaLabel(authProfile({
+      name: "full-week",
+      email: "full@example.com",
+      planType: "pro",
+      primaryUsed: 0,
+      secondaryUsed: 0,
+      secondaryResetsAt: daysFromNow(7)
+    }), { now })).toBe("100% | 1");
+
+    expect(profileWeeklyQuotaLabel(authProfile({
+      name: "half-half-week",
+      email: "half@example.com",
+      planType: "pro",
+      primaryUsed: 0,
+      secondaryUsed: 50,
+      secondaryResetsAt: daysFromNow(3.5)
+    }), { now })).toBe("50% | 1");
+
+    expect(profileWeeklyQuotaLabel(authProfile({
+      name: "full-half-week",
+      email: "fast@example.com",
+      planType: "pro",
+      primaryUsed: 0,
+      secondaryUsed: 0,
+      secondaryResetsAt: daysFromNow(3.5)
+    }), { now })).toBe("100% | 2");
+
+    expect(profileWeeklyQuotaLabel(authProfile({
+      name: "slow",
+      email: "slow@example.com",
+      planType: "pro",
+      primaryUsed: 0,
+      secondaryUsed: 43,
+      secondaryResetsAt: daysFromNow(12)
+    }), { now })).toBe("57% | 0.33");
   });
 
   it("keeps unusable profiles readable without presenting their UUID as the label", () => {
@@ -51,6 +95,7 @@ function authProfile(options: {
   readonly planType: string;
   readonly primaryUsed: number;
   readonly secondaryUsed: number;
+  readonly secondaryResetsAt?: number | undefined;
 }): Record<string, any> {
   return {
     name: options.name,
@@ -74,7 +119,7 @@ function authProfile(options: {
         secondary: {
           usedPercent: options.secondaryUsed,
           windowDurationMins: 10_080,
-          resetsAt: 1_780_000_000
+          resetsAt: options.secondaryResetsAt ?? 1_780_000_000
         }
       },
       rateLimitsByLimitId: {}

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -307,7 +307,7 @@ describe("admin session row display", () => {
     }, authProfiles, new Map([["C123", "#ops"]]));
     const labels = meta.map((item) => item.label);
 
-    expect(labels).toEqual(["#ops", "周 64%", "Token 5.1K"]);
+    expect(labels).toEqual(["#ops", "64% | 0.64", "Token 5.1K"]);
     expect(labels.join(" ")).not.toContain("hejiachen@toeverything.info");
     expect(labels.join(" ")).not.toContain("Pro Lite");
     expect(shouldShowSessionState({ rank: 10 })).toBe(false);

--- a/test/session-auth-profile-selector.test.ts
+++ b/test/session-auth-profile-selector.test.ts
@@ -65,9 +65,30 @@ describe("session auth profile selector", () => {
 
     const later = evaluateAuthProfile(status.profiles[0]!, { now });
     const sooner = evaluateAuthProfile(status.profiles[1]!, { now });
-    expect(later.secondaryRemainingPercentPerDay).toBeCloseTo(50 / 7);
-    expect(sooner.secondaryRemainingPercentPerDay).toBeCloseTo(50);
+    expect(later.weightedWeeklyQuotaScore).toBeCloseTo(0.5);
+    expect(sooner.weightedWeeklyQuotaScore).toBeCloseTo(3.5);
     expect(selectBestAuthProfile(status, { now })?.name).toBe("sooner-refresh");
+  });
+
+  it("normalizes weighted weekly quota to a full week baseline", () => {
+    const halfWeek = Math.floor((now.getTime() + 3.5 * 24 * 60 * 60 * 1000) / 1000);
+    const fullWeek = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
+
+    expect(evaluateAuthProfile(profile("full-week", {
+      primaryUsed: 0,
+      secondaryUsed: 0,
+      secondaryResetsAt: fullWeek
+    }), { now }).weightedWeeklyQuotaScore).toBeCloseTo(1);
+    expect(evaluateAuthProfile(profile("half-quota-half-week", {
+      primaryUsed: 0,
+      secondaryUsed: 50,
+      secondaryResetsAt: halfWeek
+    }), { now }).weightedWeeklyQuotaScore).toBeCloseTo(1);
+    expect(evaluateAuthProfile(profile("full-quota-half-week", {
+      primaryUsed: 0,
+      secondaryUsed: 0,
+      secondaryResetsAt: halfWeek
+    }), { now }).weightedWeeklyQuotaScore).toBeCloseTo(2);
   });
 
   it("marks a profile unavailable when either quota window is exhausted", () => {


### PR DESCRIPTION
## Summary
- replace auth quota display with weekly remaining percent plus normalized weighted weekly quota, e.g. `57% | 0.33`
- remove 5-hour/short-window quota display from the admin topbar, auth profile list, session rows, and auth switcher labels
- normalize auth profile selection score to the same weekly baseline: `(weekly remaining percent / 100) / (days until reset / 7)`

## Notes
The primary/short-window quota is still used internally to decide whether a profile is usable, but it is no longer shown in admin quota labels.

## Validation
- `pnpm exec vitest run test/admin-auth-profile-display.test.ts test/session-auth-profile-selector.test.ts test/admin-session-view.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm build`
- `pnpm test`