### PR TITLE
[codex] Show auth quota pool in admin topbar

### DIFF
--- a/src/admin-ui/admin-legacy.js
+++ b/src/admin-ui/admin-legacy.js
@@ -2,11 +2,9 @@ import { applyAdminRealtimeEventToStatus, publishTimelineRealtimeEvent } from ".
 
 export function initAdminPage(options = {}) {
     const useReactSessions = options.useReactSessions === true;
-    const refreshButton = document.getElementById("refresh-button");
     const replaceStatus = document.getElementById("replace-status");
     const deployStatus = document.getElementById("deploy-status");
     const githubAuthorsStatus = document.getElementById("github-authors-status");
-    const lastRefresh = document.getElementById("last-refresh");
     const sessionSearch = document.getElementById("session-search");
     const sessionFilter = document.getElementById("session-filter");
     const githubAuthorSearch = document.getElementById("github-author-search");
@@ -177,6 +175,64 @@ export function initAdminPage(options = {}) {
       const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(limit?.resetsAt));
       return Math.round(remaining) + "% | " + formatWeightedWeeklyQuotaScore(score);
     }
+    function weeklyQuotaScore(limit) {
+      const remaining = remainingPercent(limit?.usedPercent);
+      if (remaining == null) return null;
+      return weightedWeeklyQuotaScore(remaining, daysUntilReset(limit?.resetsAt));
+    }
+    function profileAccountLabel(profile) {
+      const accountStatus = profile.account || {};
+      if (accountStatus.ok === false) return "账号不可用";
+      const account = accountStatus.account || {};
+      return account.email || account.name || account.id || "未知账号";
+    }
+    function profilePlanLabel(profile) {
+      const accountStatus = profile.account || {};
+      if (accountStatus.ok === false) return "";
+      const plan = accountStatus.account?.planType || accountStatus.account?.type || "";
+      if (plan === "prolite") return "Pro Lite";
+      if (plan === "pro") return "Pro";
+      if (plan === "chatgpt") return "ChatGPT";
+      return plan;
+    }
+    function profileTooltip(profile, weeklyLabel, secondary) {
+      return [
+        profileAccountLabel(profile),
+        profilePlanLabel(profile),
+        weeklyLabel ? "周额度 " + weeklyLabel : "",
+        secondary ? "周重置 " + formatResetTime(secondary.resetsAt) : "",
+        profile.name ? "内部标识 " + profile.name : ""
+      ].filter(Boolean).join(" · ");
+    }
+    function authProfileQuotaItems(profiles) {
+      return profiles
+        .map((profile) => {
+          const rateLimits = profile.rateLimits || {};
+          if (rateLimits.ok === false) return null;
+          const secondary = rateLimits.rateLimits?.secondary;
+          const label = weeklyQuotaDisplay(secondary);
+          if (!label) return null;
+          const remaining = remainingPercent(secondary?.usedPercent);
+          const score = weeklyQuotaScore(secondary);
+          return {
+            label,
+            title: profileTooltip(profile, label, secondary),
+            score: score ?? -1,
+            remaining: remaining ?? 0
+          };
+        })
+        .filter(Boolean)
+        .sort((left, right) =>
+          (right.score - left.score) ||
+          (right.remaining - left.remaining) ||
+          left.title.localeCompare(right.title)
+        );
+    }
+    function quotaTone(remaining) {
+      if (remaining < 10) return "danger";
+      if (remaining < 30) return "warn";
+      return "";
+    }
     function statusTone(status) {
       const v = String(status || "").toLowerCase();
       if (["succeeded", "running", "active", "ok", "completed", "done"].includes(v)) return "good";
@@ -277,36 +333,17 @@ export function initAdminPage(options = {}) {
       const element = document.getElementById(id);
       if (element) element.textContent = String(value ?? "");
     }
-    function renderAccountChip(account) {
-      const label = account.ok ? (account.account?.email || account.account?.planType || "已登录") : "账号异常";
-      const title = account.ok ? label : (account.error || "账号异常");
-      return '<span class="quota-account' + (account.ok ? "" : " is-error") + '" title="' + esc(title) + '">' + esc(label) + '</span>';
-    }
-
     function renderSummary(data) {
-      const s = data.service || {};
       const st = data.state || {};
-      const a = data.account || {};
       const authProfiles = data.authProfiles || {};
-      const activeProfile = (authProfiles.profiles || []).find((p) => p.active);
-      const rateLimits = activeProfile?.rateLimits;
-      const snapshot = rateLimits?.rateLimits || {};
-      const secondary = snapshot.secondary;
       const topbarQuota = document.getElementById("topbar-quota");
-      const accountChip = renderAccountChip(a);
-      if (rateLimits?.ok && secondary) {
-        const weeklyRemaining = remainingPercent(secondary.usedPercent);
-        const weeklyTone = weeklyRemaining != null ? (weeklyRemaining < 10 ? "danger" : (weeklyRemaining < 30 ? "warn" : "")) : "";
-        const weeklyLabel = weeklyQuotaDisplay(secondary);
-        topbarQuota.innerHTML =
-          accountChip +
-          (weeklyLabel ? '<span class="quota-pill ' + weeklyTone + '"><strong>' + esc(weeklyLabel) + '</strong></span>' : '') +
-          '<span class="quota-pill">周重置 ' + esc(formatResetTime(secondary.resetsAt)) + '</span>' +
-          '<span class="quota-meta">' + (st.activeCount || 0) + " 活跃 · " + (st.openInboundCount || 0) + " 待处理 · " + (st.runningBackgroundJobCount || 0) + " 任务</span>";
-      } else {
-        topbarQuota.innerHTML = accountChip +
-          '<span class="quota-meta">' + (st.activeCount || 0) + " 活跃 · " + (st.openInboundCount || 0) + " 待处理 · " + (st.runningBackgroundJobCount || 0) + " 任务</span>";
-      }
+      const quotaItems = authProfileQuotaItems(authProfiles.profiles || []);
+      const quotaHtml = quotaItems.length
+        ? quotaItems.map((item) => {
+            return '<span class="quota-pill ' + quotaTone(item.remaining) + '" title="' + esc(item.title) + '"><strong>' + esc(item.label) + '</strong></span>';
+          }).join("")
+        : '<span class="quota-meta">账号池额度未知</span>';
+      topbarQuota.innerHTML = quotaHtml;
       setText("session-open-count", st.openInboundCount || 0);
       setText("session-human-count", st.openHumanInboundCount || 0);
       setText("session-system-count", st.openSystemInboundCount || 0);
@@ -869,7 +906,6 @@ export function initAdminPage(options = {}) {
     }
 
     async function refresh() {
-      refreshButton.disabled = true;
       try {
         const status = await requestJson("/admin/api/status");
         const sessionsPayload = await requestJson("/admin/api/sessions");
@@ -878,11 +914,8 @@ export function initAdminPage(options = {}) {
         });
         render(status);
         startRealtime();
-        lastRefresh.textContent = "已同步：" + fmtTime(new Date());
       } catch (error) {
-        lastRefresh.textContent = "错误：" + (error instanceof Error ? error.message : String(error));
-      } finally {
-        refreshButton.disabled = false;
+        console.warn("Admin refresh failed", error);
       }
     }
     function startRealtime() {
@@ -897,9 +930,8 @@ export function initAdminPage(options = {}) {
           latestStatus = applyAdminRealtimeEventToStatus(latestStatus, payload.event);
           publishTimelineRealtimeEvent(payload.event);
           render(latestStatus);
-          lastRefresh.textContent = "实时同步：" + fmtTime(new Date());
         } catch (error) {
-          lastRefresh.textContent = "实时事件错误：" + (error instanceof Error ? error.message : String(error));
+          console.warn("Admin realtime event failed", error);
         }
       });
       source.addEventListener("error", () => {
@@ -1042,7 +1074,6 @@ export function initAdminPage(options = {}) {
         if (target) switchAdminView(target);
       });
     });
-    refreshButton.onclick = refresh;
     if (!useReactSessions && sessionSearch && sessionFilter) {
       sessionSearch.oninput = () => {
         updateUiState({ sessionSearch: sessionSearch.value }, { deferPersist: true });

--- a/src/admin-ui/admin-shell.ts
+++ b/src/admin-ui/admin-shell.ts
@@ -6,11 +6,6 @@ export function renderAdminShellHtml(serviceName: string): string {
         <button class="nav-item" data-view-target="ops">操作</button>
       </nav>
       <div class="topbar-center" id="topbar-quota"></div>
-      <div class="top-actions">
-        <span class="pill">实时</span>
-        <span class="pill" id="last-refresh">就绪</span>
-        <button id="refresh-button" class="secondary">刷新</button>
-      </div>
     </header>
 
     <div class="admin-content">

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -22,7 +22,6 @@
     .shell { width: 100%; height: 100dvh; min-height: 0; margin: 0; padding: 10px 14px; display: grid; grid-template-rows: auto minmax(0, 1fr); overflow: hidden; }
     .topbar { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; border-bottom: 1px solid var(--line); }
 
-    .top-actions { display: flex; gap: 6px; align-items: center; }
     .pill { padding: 2px 6px; border: 1px solid var(--line); color: var(--muted); font-size: 10px; }
     button { padding: 3px 8px; border: 1px solid var(--line); background: #111820; color: var(--text); font-family: inherit; font-size: 11px; cursor: pointer; }
     button:hover { border-color: var(--cyan); }
@@ -31,10 +30,8 @@
     button.danger { color: var(--red); border-color: var(--red); }
     button:disabled { opacity: 0.4; cursor: default; }
 
-    .topbar-center { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; overflow: hidden; flex-wrap: nowrap; }
-    .quota-account { min-width: 0; max-width: min(520px, 44vw); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); font-size: 11px; font-weight: 700; }
-    .quota-account.is-error { color: var(--red); }
-    .quota-pill { display: inline-flex; align-items: center; gap: 4px; padding: 1px 6px; border: 1px solid var(--line); font-size: 10px; }
+    .topbar-center { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; overflow-x: auto; overflow-y: hidden; flex-wrap: nowrap; }
+    .quota-pill { display: inline-flex; align-items: center; gap: 4px; flex: 0 0 auto; padding: 1px 6px; border: 1px solid var(--line); font-size: 10px; }
     .quota-pill strong { color: var(--cyan); font-size: 11px; }
     .quota-pill.danger strong { color: var(--red); }
     .quota-pill.warn strong { color: var(--amber); }
@@ -209,8 +206,6 @@
       .topbar { align-items: flex-start; flex-wrap: wrap; gap: 6px; padding: 4px 0 6px; }
       .admin-nav { max-width: 100%; }
       .topbar-center { order: 3; flex-basis: 100%; width: 100%; gap: 4px; overflow-x: auto; padding-bottom: 2px; }
-      .top-actions { margin-left: auto; max-width: 100%; overflow-x: auto; padding-bottom: 2px; }
-      .quota-account { max-width: 100%; }
       .nav-item { padding: 6px 12px; }
       .admin-content { padding-top: 6px; }
       .panel-head { align-items: flex-start; flex-wrap: wrap; gap: 6px; padding: 5px 6px; }
@@ -244,7 +239,6 @@
     }
     @media (max-width: 520px) {
       .topbar { display: grid; grid-template-columns: 1fr; }
-      .top-actions { width: 100%; margin-left: 0; }
       .topbar-center { order: initial; }
       .session-master-detail { grid-template-rows: minmax(190px, 38dvh) minmax(0, 1fr); }
       .session-list { max-height: 38dvh; }

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -153,6 +153,11 @@ describe("admin routes", () => {
     expect(shell).toContain('data-view-target="sessions"');
     expect(shell).toContain('data-view-target="ops"');
     expect(shell).toContain('id="topbar-quota"');
+    expect(shell).not.toContain("top-actions");
+    expect(shell).not.toContain("refresh-button");
+    expect(shell).not.toContain("last-refresh");
+    expect(shell).not.toContain("实时");
+    expect(shell).not.toContain("刷新");
     expect(shell).toContain("auth-profiles-panel");
     expect(shell).toContain("认证档案");
     expect(shell).toContain("github-authors-panel");
@@ -249,8 +254,13 @@ describe("admin routes", () => {
     expect(adminClientSource).not.toContain('row.addEventListener("toggle"');
     expect(adminClientSource).toContain("sessionSearch.onblur");
     expect(sessionViewSource).toContain("ongoing");
-    expect(adminClientSource).toContain("renderAccountChip");
-    expect(adminClientSource).toContain("账号异常");
+    expect(adminClientSource).toContain("authProfileQuotaItems");
+    expect(adminClientSource).toContain("profileTooltip");
+    expect(adminClientSource).not.toContain("renderAccountChip");
+    expect(adminClientSource).not.toContain("refreshButton");
+    expect(adminClientSource).not.toContain("lastRefresh");
+    expect(adminClientSource).not.toContain(" 活跃 · ");
+    expect(adminClientSource).not.toContain(" 待处理 · ");
     expect(sessionViewSource).toContain("sessionQueueState");
     expect(sessionViewSource).toContain("compareSessionsForMode");
     expect(sessionViewSource).toContain("session-card");
@@ -259,7 +269,8 @@ describe("admin routes", () => {
     expect(sessionViewSource).toContain('mode === "usage"');
     expect(sessionViewSource).toContain("fmtRelativeTime");
     expect(adminCssSource).toContain("text-overflow: ellipsis");
-    expect(adminCssSource).toContain(".quota-account.is-error");
+    expect(adminCssSource).toContain("overflow-x: auto");
+    expect(adminCssSource).toContain("flex: 0 0 auto");
     expect(adminCssSource).toContain("html, body { width: 100%; height: 100%; overflow: hidden; }");
     expect(adminCssSource).toContain(".shell { width: 100%; height: 100dvh;");
     expect(adminCssSource).toContain("grid-template-columns: minmax(320px, 420px)");
@@ -270,6 +281,7 @@ describe("admin routes", () => {
     expect(adminCssSource).toContain(".session-meta-pill { min-width: 0; max-width: 100%; flex: 0 1 auto;");
     expect(adminCssSource).toContain(".session-card");
     expect(adminCssSource).toContain(".session-priority-danger");
+    expect(adminCssSource).not.toContain(".top-actions");
     expect(adminCssSource).not.toContain(".admin-nav { grid-template-columns: 1fr; }");
   });
 


### PR DESCRIPTION
## Summary
- show the admin topbar as an account quota pool with quota-only chips and account details only in hover text
- remove the topbar realtime/refresh controls and the active/pending/job counter noise
- keep realtime syncing active behind the scenes without visible status text

## Validation
- pnpm exec vitest run test/admin-routes.test.ts test/admin-auth-profile-display.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm build
- pnpm test