### PR TITLE
Store Slack attachments in session workspace

### DIFF
--- a/src/input-trace-summary.ts
+++ b/src/input-trace-summary.ts
@@ -67,11 +67,15 @@ function summarizePayload(
 
   const slackText = compactText(extractSlackText(payload), 220);
   const sender = summarizeSender(asRecord(payload.sender));
-  const imageCount = Array.isArray(payload.images) ? payload.images.length : 0;
+  const attachmentCount = Array.isArray(payload.attachments)
+    ? payload.attachments.length
+    : Array.isArray(payload.images)
+      ? payload.images.length
+      : 0;
   const summary = [
     sender,
     sourceLabel(normalizeString(payload.source) || source),
-    imageCount > 0 ? `${imageCount} 张图` : ""
+    attachmentCount > 0 ? `${attachmentCount} 个附件` : ""
   ].filter(Boolean).join(" · ");
 
   return {
@@ -82,7 +86,7 @@ function summarizePayload(
       source: normalizeString(payload.source) || source,
       messageTs: normalizeString(payload.message_ts),
       sender,
-      imageCount
+      attachmentCount
     })
   };
 }
@@ -159,7 +163,12 @@ function extractInputPayload(text: string): ExtractedInputPayload | undefined {
     .filter((payload): payload is Record<string, unknown> => Boolean(payload));
   const currentMessage = [...blocks].reverse().find((payload) =>
     normalizeString(payload.source) !== "thread_history" &&
-      (payload.text !== undefined || payload.text_with_resolved_mentions !== undefined || payload.images !== undefined)
+      (
+        payload.text !== undefined ||
+        payload.text_with_resolved_mentions !== undefined ||
+        payload.attachments !== undefined ||
+        payload.images !== undefined
+      )
   );
   const payload = currentMessage ?? blocks[blocks.length - 1];
   return payload ? {

--- a/src/services/slack/slack-api.ts
+++ b/src/services/slack/slack-api.ts
@@ -29,6 +29,11 @@ export interface SlackUploadedFile {
   readonly size?: number | undefined;
 }
 
+export interface SlackDownloadedFile {
+  readonly bytes: Buffer;
+  readonly contentType: string;
+}
+
 export interface SlackConversationInfo {
   readonly channelId: string;
   readonly name?: string | undefined;
@@ -336,7 +341,7 @@ export class SlackApi {
       const author = resolveSlackMessageAuthor(message);
       const messageTs = typeof message.ts === "string" ? message.ts : undefined;
       const text = typeof message.text === "string" ? message.text : "";
-      const images = normalizeSlackImageAttachments(message.files);
+      const images = normalizeSlackFileAttachments(message.files);
       const isSupportedSubtype = isSupportedSlackMessageSubtype(message.subtype);
       const slackMessage = normalizeSlackJson(message);
 
@@ -363,8 +368,8 @@ export class SlackApi {
     });
   }
 
-  async downloadImageAsDataUrl(image: SlackImageAttachment): Promise<string> {
-    const response = await fetch(image.url, {
+  async downloadFileAttachment(file: SlackImageAttachment): Promise<SlackDownloadedFile> {
+    const response = await fetch(file.url, {
       method: "GET",
       headers: {
         authorization: `Bearer ${this.#botToken}`
@@ -373,18 +378,21 @@ export class SlackApi {
 
     if (!response.ok) {
       throw new Error(
-        `Slack image download failed (${response.status} ${response.statusText}) for ${image.fileId}`
+        `Slack file download failed (${response.status} ${response.statusText}) for ${file.fileId}`
       );
     }
 
     const rawContentType = response.headers.get("content-type");
-    const mediaType =
+    const contentType =
       rawContentType?.split(";")[0]?.trim() ||
-      image.mimetype ||
+      file.mimetype ||
       "application/octet-stream";
     const bytes = Buffer.from(await response.arrayBuffer());
 
-    return `data:${mediaType};base64,${bytes.toString("base64")}`;
+    return {
+      bytes,
+      contentType
+    };
   }
 
   async #uploadExternalFile(
@@ -523,7 +531,7 @@ export class SlackApi {
   }
 }
 
-export function normalizeSlackImageAttachments(files: unknown): SlackImageAttachment[] {
+export function normalizeSlackFileAttachments(files: unknown): SlackImageAttachment[] {
   if (!Array.isArray(files)) {
     return [];
   }
@@ -537,11 +545,11 @@ export function normalizeSlackImageAttachments(files: unknown): SlackImageAttach
     const fileId = normalizeSlackField(file.id);
     const mimetype = normalizeSlackField(file.mimetype);
 
-    if (!fileId || !mimetype?.startsWith("image/")) {
+    if (!fileId) {
       return [];
     }
 
-    const url = pickSlackImageUrl(file);
+    const url = pickSlackFileUrl(file);
     if (!url) {
       return [];
     }
@@ -552,6 +560,8 @@ export function normalizeSlackImageAttachments(files: unknown): SlackImageAttach
         name: normalizeSlackField(file.name),
         title: normalizeSlackField(file.title),
         mimetype,
+        filetype: normalizeSlackField(file.filetype),
+        size: normalizeSlackNumber(file.size),
         width: normalizeSlackNumber(
           file.original_w ??
             file.thumb_1024_w ??
@@ -573,6 +583,8 @@ export function normalizeSlackImageAttachments(files: unknown): SlackImageAttach
     ];
   });
 }
+
+export const normalizeSlackImageAttachments = normalizeSlackFileAttachments;
 
 export function normalizeSlackJson(value: unknown): JsonLike | undefined {
   if (value === null) {
@@ -675,7 +687,7 @@ function isSupportedSlackMessageSubtype(value: unknown): boolean {
   ].includes(subtype);
 }
 
-function pickSlackImageUrl(file: Record<string, unknown>): string | undefined {
+function pickSlackFileUrl(file: Record<string, unknown>): string | undefined {
   const candidates = [
     file.thumb_1024,
     file.thumb_960,

--- a/src/services/slack/slack-event-parser.ts
+++ b/src/services/slack/slack-event-parser.ts
@@ -6,7 +6,7 @@ import type {
   SlackThreadMessage
 } from "../../types.js";
 import {
-  normalizeSlackImageAttachments,
+  normalizeSlackFileAttachments,
   normalizeSlackJson
 } from "./slack-api.js";
 
@@ -35,7 +35,7 @@ export function parseSlackEvent(event: Record<string, any>, botUserId: string): 
   const messageTs = typeof event.ts === "string" ? event.ts : undefined;
   const author = resolveSlackEventAuthor(event);
   const metadata = parseSlackTextMetadata(String(event.text ?? ""));
-  const images = normalizeSlackImageAttachments(event.files);
+  const images = normalizeSlackFileAttachments(event.files);
   const slackMessage = normalizeSlackJson(event);
 
   if (eventType === "app_mention" && channelId && messageTs) {

--- a/src/services/slack/slack-message-format.ts
+++ b/src/services/slack/slack-message-format.ts
@@ -209,14 +209,18 @@ function buildSlackMessagePayload(
       : undefined,
     text: message.text || "[no text body]",
     text_with_resolved_mentions: resolveMentionText(message.text || "[no text body]", message.mentionedUsers),
-    images: (message.images ?? []).map((image) => ({
-      file_id: image.fileId,
-      name: image.name,
-      title: image.title,
-      mimetype: image.mimetype,
-      width: image.width,
-      height: image.height,
-      dimensions: formatImageDimensions(image)
+    attachments: (message.images ?? []).map((attachment) => ({
+      file_id: attachment.fileId,
+      name: attachment.name,
+      title: attachment.title,
+      mimetype: attachment.mimetype,
+      filetype: attachment.filetype,
+      size: attachment.size,
+      width: attachment.width,
+      height: attachment.height,
+      dimensions: formatImageDimensions(attachment),
+      local_path: attachment.localPath,
+      download_error: attachment.downloadError
     })),
     slack_message: buildSelectedSlackPayload(message),
     unexpected_turn_stop: message.unexpectedTurnStop

--- a/src/services/slack/slack-turn-runner.ts
+++ b/src/services/slack/slack-turn-runner.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
 import { logger } from "../../logger.js";
 import type {
   AgentInputItem,
@@ -7,6 +10,8 @@ import type {
 import type {
   PersistedAgentTurnStatus,
   PersistedAgentTurnUsage,
+  SlackBatchInputMessage,
+  SlackImageAttachment,
   SlackInputMessage,
   SlackSessionRecord
 } from "../../types.js";
@@ -38,7 +43,7 @@ export class SlackTurnRunner {
   }
 
   async submitAdditionalInput(session: SlackSessionRecord, item: SlackInputMessage): Promise<void> {
-    const input = await this.#buildImmediateSlackInput(item);
+    const input = await this.#buildImmediateSlackInput(session, item);
     const result = await this.#agentRuntime.submitInput({
       session,
       input,
@@ -50,17 +55,24 @@ export class SlackTurnRunner {
     }
   }
 
-  async buildTurnInput(message: SlackInputMessage): Promise<readonly AgentInputItem[]> {
-    const enrichedMessage = await this.#enrichMentionedUsers(message);
+  async buildTurnInput(message: SlackInputMessage): Promise<readonly AgentInputItem[]>;
+  async buildTurnInput(session: SlackSessionRecord, message: SlackInputMessage): Promise<readonly AgentInputItem[]>;
+  async buildTurnInput(
+    sessionOrMessage: SlackSessionRecord | SlackInputMessage,
+    maybeMessage?: SlackInputMessage
+  ): Promise<readonly AgentInputItem[]> {
+    const message = maybeMessage ?? sessionOrMessage as SlackInputMessage;
+    const session = maybeMessage
+      ? sessionOrMessage as SlackSessionRecord
+      : this.#sessions.getSession(message.channelId, message.rootThreadTs);
+    const enrichedMessage = session
+      ? await this.#prepareSlackInput(session, message)
+      : await this.#enrichMentionedUsers(message);
     const sender = enrichedMessage.source !== "background_job_event" && enrichedMessage.source !== "recovered_thread_batch" && enrichedMessage.senderKind === "user"
       ? await this.#slackApi.getUserIdentity(enrichedMessage.userId)
       : null;
     const inputText = formatSlackMessageForAgent(enrichedMessage, sender);
-    const imageItems = await this.#buildImageInputItems(enrichedMessage);
-    return [
-      createTextInputItem(inputText),
-      ...imageItems
-    ];
+    return [createTextInputItem(inputText)];
   }
 
   async submitInputWithRecovery(options: {
@@ -201,13 +213,12 @@ export class SlackTurnRunner {
     return await this.#sessions.setAgentSessionId(session.channelId, session.rootThreadTs, agentSession.id);
   }
 
-  async #buildImmediateSlackInput(message: SlackInputMessage): Promise<readonly AgentInputItem[]> {
-    const enrichedItem = await this.#enrichMentionedUsers(message);
+  async #buildImmediateSlackInput(session: SlackSessionRecord, message: SlackInputMessage): Promise<readonly AgentInputItem[]> {
+    const enrichedItem = await this.#prepareSlackInput(session, message);
     const sender = enrichedItem.source !== "background_job_event" && enrichedItem.source !== "recovered_thread_batch" && enrichedItem.senderKind === "user"
       ? await this.#slackApi.getUserIdentity(enrichedItem.userId)
       : null;
     const formattedMessage = formatSlackMessageForAgent(enrichedItem, sender);
-    const imageItems = await this.#buildImageInputItems(enrichedItem);
     return [
       createTextInputItem([
         enrichedItem.recoveryKind === "missed_thread_messages"
@@ -218,47 +229,82 @@ export class SlackTurnRunner {
           : "Treat it as the latest instruction and adjust the ongoing work accordingly.",
         "",
         formattedMessage
-      ].join("\n")),
-      ...imageItems
+      ].join("\n"))
     ];
   }
 
-  async #buildImageInputItems(message: SlackInputMessage): Promise<readonly AgentInputItem[]> {
-    const images = [
-      ...(message.images ?? []),
-      ...((message.batchMessages ?? []).flatMap((entry) => entry.images ?? []))
-    ];
-    if (images.length === 0) {
-      return [];
+  async #prepareSlackInput(session: SlackSessionRecord, message: SlackInputMessage): Promise<SlackInputMessage> {
+    const enrichedMessage = await this.#enrichMentionedUsers(message);
+    const batchMessages = enrichedMessage.batchMessages
+      ? await Promise.all(
+        enrichedMessage.batchMessages.map((entry) => this.#materializeSlackAttachments(session, entry))
+      )
+      : undefined;
+    const messageWithAttachments = await this.#materializeSlackAttachments(session, enrichedMessage);
+
+    return {
+      ...messageWithAttachments,
+      batchMessages
+    };
+  }
+
+  async #materializeSlackAttachments<T extends SlackInputMessage | SlackBatchInputMessage>(
+    session: SlackSessionRecord,
+    message: T
+  ): Promise<T> {
+    if (!message.images || message.images.length === 0) {
+      return message;
     }
 
-    const downloaded = await Promise.allSettled(
-      images.map(async (image) => ({
-        type: "image" as const,
-        url: await this.#slackApi.downloadImageAsDataUrl(image),
-        fileId: image.fileId
-      }))
+    const images = await Promise.all(
+      message.images.map((attachment) => this.#downloadSlackAttachment(session, message, attachment))
     );
 
-    return downloaded.flatMap((result) => {
-      if (result.status === "fulfilled") {
-        return [
-          {
-            type: "image" as const,
-            url: result.value.url
-          }
-        ];
-      }
+    return {
+      ...message,
+      images
+    };
+  }
 
-      logger.warn("Failed to download Slack image attachment for agent input", {
-        source: message.source,
-        channelId: message.channelId,
-        rootThreadTs: message.rootThreadTs,
+  async #downloadSlackAttachment(
+    session: SlackSessionRecord,
+    message: Pick<SlackInputMessage | SlackBatchInputMessage, "messageTs" | "source">,
+    attachment: SlackImageAttachment
+  ): Promise<SlackImageAttachment> {
+    if (attachment.localPath || attachment.downloadError) {
+      return attachment;
+    }
+
+    try {
+      const downloaded = await this.#slackApi.downloadFileAttachment(attachment);
+      const localPath = await writeSlackAttachmentFile({
+        workspacePath: session.workspacePath,
         messageTs: message.messageTs,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason)
+        attachment,
+        bytes: downloaded.bytes
       });
-      return [];
-    });
+
+      return {
+        ...attachment,
+        mimetype: downloaded.contentType || attachment.mimetype,
+        localPath
+      };
+    } catch (error) {
+      const downloadError = error instanceof Error ? error.message : String(error);
+      logger.warn("Failed to download Slack attachment into session workspace", {
+        source: message.source,
+        channelId: session.channelId,
+        rootThreadTs: session.rootThreadTs,
+        messageTs: message.messageTs,
+        fileId: attachment.fileId,
+        error: downloadError
+      });
+
+      return {
+        ...attachment,
+        downloadError
+      };
+    }
   }
 
   async #enrichMentionedUsers(message: SlackInputMessage): Promise<SlackInputMessage> {
@@ -392,6 +438,61 @@ function createTextInputItem(text: string): AgentInputItem {
     text,
     text_elements: []
   };
+}
+
+const SLACK_ATTACHMENTS_DIRECTORY = ".slack-attachments";
+
+async function writeSlackAttachmentFile(options: {
+  readonly workspacePath: string;
+  readonly messageTs?: string | undefined;
+  readonly attachment: SlackImageAttachment;
+  readonly bytes: Buffer;
+}): Promise<string> {
+  const workspaceRoot = path.resolve(options.workspacePath);
+  const messageDirectory = sanitizePathSegment(options.messageTs ?? "unknown-message");
+  const directoryPath = path.join(workspaceRoot, SLACK_ATTACHMENTS_DIRECTORY, messageDirectory);
+  const fileName = buildAttachmentFileName(options.attachment);
+  const filePath = path.join(directoryPath, fileName);
+  const resolvedFilePath = path.resolve(filePath);
+
+  if (!resolvedFilePath.startsWith(`${workspaceRoot}${path.sep}`)) {
+    throw new Error(`Refusing to write Slack attachment outside session workspace: ${resolvedFilePath}`);
+  }
+
+  await fs.mkdir(directoryPath, { recursive: true });
+  await fs.writeFile(resolvedFilePath, options.bytes);
+  return resolvedFilePath;
+}
+
+function buildAttachmentFileName(attachment: SlackImageAttachment): string {
+  const rawName = attachment.name ?? attachment.title ?? attachment.fileId;
+  const safeBaseName = sanitizePathSegment(path.basename(rawName)) || "attachment";
+  const safeFileId = sanitizePathSegment(attachment.fileId) || "slack-file";
+  const prefixedName = safeBaseName.startsWith(`${safeFileId}-`)
+    ? safeBaseName
+    : `${safeFileId}-${safeBaseName}`;
+  return truncateFileName(prefixedName, 180);
+}
+
+function sanitizePathSegment(value: string): string {
+  return value
+    .replaceAll(/[\\/]/g, "_")
+    .replaceAll(/[^A-Za-z0-9._-]+/g, "_")
+    .replaceAll(/^\.{1,2}$/g, "_")
+    .replaceAll(/^\.+/g, "_")
+    .replaceAll(/_+/g, "_")
+    .slice(0, 180);
+}
+
+function truncateFileName(fileName: string, maxLength: number): string {
+  if (fileName.length <= maxLength) {
+    return fileName;
+  }
+
+  const extension = path.extname(fileName);
+  const baseName = path.basename(fileName, extension);
+  const allowedBaseLength = Math.max(1, maxLength - extension.length);
+  return `${baseName.slice(0, allowedBaseLength)}${extension}`;
 }
 
 function inputIdForSessionInput(session: SlackSessionRecord, scope: string, kind: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,9 +308,13 @@ export interface SlackImageAttachment {
   readonly name?: string | undefined;
   readonly title?: string | undefined;
   readonly mimetype?: string | undefined;
+  readonly filetype?: string | undefined;
+  readonly size?: number | undefined;
   readonly width?: number | undefined;
   readonly height?: number | undefined;
   readonly url: string;
+  readonly localPath?: string | undefined;
+  readonly downloadError?: string | undefined;
 }
 
 export interface SlackThreadMessage {

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -100,7 +100,7 @@ describe("admin token usage e2e", () => {
         mention: "<@U123>",
         realName: "User One"
       }),
-      downloadImageAsDataUrl: async () => "data:image/png;base64,"
+      downloadFileAttachment: async () => ({ bytes: Buffer.from(""), contentType: "image/png" })
     } as never;
     const inboundStore = new SlackInboundStore({
       sessions,

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  normalizeSlackImageAttachments,
+  normalizeSlackFileAttachments,
   SlackApi
 } from "../src/services/slack/slack-api.js";
 
@@ -9,14 +9,16 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("normalizeSlackImageAttachments", () => {
-  it("extracts image metadata and prefers thumbnail URLs", () => {
-    const images = normalizeSlackImageAttachments([
+describe("normalizeSlackFileAttachments", () => {
+  it("extracts file metadata and prefers thumbnail URLs for images", () => {
+    const files = normalizeSlackFileAttachments([
       {
         id: "F123",
         name: "screenshot.png",
         title: "Screenshot",
         mimetype: "image/png",
+        filetype: "png",
+        size: 12345,
         thumb_1024: "https://example.com/thumb-1024.png",
         url_private_download: "https://example.com/original.png",
         original_w: 1600,
@@ -24,12 +26,14 @@ describe("normalizeSlackImageAttachments", () => {
       }
     ]);
 
-    expect(images).toEqual([
+    expect(files).toEqual([
       {
         fileId: "F123",
         name: "screenshot.png",
         title: "Screenshot",
         mimetype: "image/png",
+        filetype: "png",
+        size: 12345,
         width: 1600,
         height: 900,
         url: "https://example.com/thumb-1024.png"
@@ -37,21 +41,63 @@ describe("normalizeSlackImageAttachments", () => {
     ]);
   });
 
-  it("ignores non-image files and malformed entries", () => {
-    const images = normalizeSlackImageAttachments([
-      null,
+  it("extracts non-image files and SVG attachments", () => {
+    const files = normalizeSlackFileAttachments([
       {
         id: "F234",
+        name: "report.pdf",
         mimetype: "application/pdf",
         url_private_download: "https://example.com/file.pdf"
       },
       {
         id: "F345",
+        name: "screen.svg",
+        mimetype: "image/svg+xml",
+        url_private_download: "https://example.com/screen.svg"
+      }
+    ]);
+
+    expect(files).toMatchObject([
+      {
+        fileId: "F234",
+        name: "report.pdf",
+        mimetype: "application/pdf",
+        url: "https://example.com/file.pdf"
+      },
+      {
+        fileId: "F345",
+        name: "screen.svg",
+        mimetype: "image/svg+xml",
+        url: "https://example.com/screen.svg"
+      }
+    ]);
+  });
+
+  it("ignores malformed file entries", () => {
+    const files = normalizeSlackFileAttachments([
+      null,
+      {
+        mimetype: "application/pdf",
+        url_private_download: "https://example.com/missing-id.pdf"
+      },
+      {
+        id: "F456",
+        mimetype: "application/pdf",
+        url_private_download: "https://example.com/file.pdf"
+      },
+      {
+        id: "F789",
         mimetype: "image/jpeg"
       }
     ]);
 
-    expect(images).toEqual([]);
+    expect(files).toEqual([
+      {
+        fileId: "F456",
+        mimetype: "application/pdf",
+        url: "https://example.com/file.pdf"
+      }
+    ]);
   });
 });
 

--- a/test/slack-message-format.test.ts
+++ b/test/slack-message-format.test.ts
@@ -73,7 +73,7 @@ describe("formatSlackMessageForAgent", () => {
     expect(result).toContain("\"mentioned_user_mentions\": [");
     expect(result).toContain("\"<@U456>\"");
     expect(result).toContain("\"mentioned_users\": [");
-    expect(result).toContain("\"images\": [");
+    expect(result).toContain("\"attachments\": [");
     expect(result).toContain("\"title\": \"Screenshot\"");
     expect(result).toContain("\"dimensions\": \"1280x720\"");
     expect(result).toContain("\"text\": \"Please fix the flaky test.\"");
@@ -178,7 +178,7 @@ describe("formatSlackMessageForAgent", () => {
       null
     );
 
-    expect(result).toContain("\"images\": [");
+    expect(result).toContain("\"attachments\": [");
     expect(result).toContain("\"text\": \"[no text body]\"");
   });
 
@@ -424,7 +424,7 @@ describe("formatSlackHistoryContextForAgent", () => {
     expect(result).toContain("\"mentioned_user_ids\": [");
     expect(result).toContain("\"U345\"");
     expect(result).toContain("\"display_name\": \"Bob\"");
-    expect(result).toContain("\"images\": [");
+    expect(result).toContain("\"attachments\": [");
     expect(result).toContain("\"text\": \"Earlier note\"");
     expect(result).not.toContain("\"slack_message\":");
   });

--- a/test/slack-turn-runner.test.ts
+++ b/test/slack-turn-runner.test.ts
@@ -1,10 +1,20 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentRuntime } from "../src/services/agent-runtime/types.js";
 import { SlackTurnRunner } from "../src/services/slack/slack-turn-runner.js";
 import type { SlackSessionRecord } from "../src/types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+});
 
 function createRuntime(overrides: Partial<AgentRuntime>): AgentRuntime {
   const runtime = new EventEmitter() as AgentRuntime;
@@ -68,7 +78,7 @@ describe("SlackTurnRunner", () => {
       agentRuntime: createRuntime({ ensureSession }),
       slackApi: {
         getUserIdentity: vi.fn(),
-        downloadImageAsDataUrl: vi.fn()
+        downloadFileAttachment: vi.fn()
       } as never,
       sessions: {
         setActiveTurnId,
@@ -123,7 +133,7 @@ describe("SlackTurnRunner", () => {
       }),
       slackApi: {
         getUserIdentity: vi.fn(),
-        downloadImageAsDataUrl: vi.fn()
+        downloadFileAttachment: vi.fn()
       } as never,
       sessions: {
         setActiveTurnId: vi.fn(async (_channelId: string, _rootThreadTs: string, turnId: string | undefined) => {
@@ -160,5 +170,61 @@ describe("SlackTurnRunner", () => {
     });
 
     expect(calls.slice(0, 2)).toEqual(["set-active", "mark-inflight"]);
+  });
+
+  it("downloads Slack attachments into the session workspace instead of sending image input items", async () => {
+    const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "slack-attachments-"));
+    tempDirs.push(workspacePath);
+    const session: SlackSessionRecord = {
+      key: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      workspacePath,
+      agentSessionId: "thread-1",
+      createdAt: "2026-03-16T00:00:00.000Z",
+      updatedAt: "2026-03-16T00:00:00.000Z"
+    };
+    const downloadFileAttachment = vi.fn(async () => ({
+      bytes: Buffer.from("<svg/>"),
+      contentType: "image/svg+xml"
+    }));
+
+    const runner = new SlackTurnRunner({
+      agentRuntime: createRuntime({}),
+      slackApi: {
+        getUserIdentity: vi.fn(async () => null),
+        downloadFileAttachment
+      } as never,
+      sessions: {} as never,
+      inboundStore: {} as never
+    });
+
+    const input = await runner.buildTurnInput(session, {
+      source: "thread_reply",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      messageTs: "111.223",
+      userId: "U123",
+      senderKind: "user",
+      text: "use the attached icon",
+      images: [
+        {
+          fileId: "F123",
+          name: "../screen.svg",
+          mimetype: "image/svg+xml",
+          url: "https://files.slack.test/screen.svg"
+        }
+      ]
+    });
+
+    expect(downloadFileAttachment).toHaveBeenCalledTimes(1);
+    expect(input).toHaveLength(1);
+    expect(input[0]).toMatchObject({ type: "text" });
+    expect(input.some((item) => item.type === "image")).toBe(false);
+    const text = input[0]?.type === "text" ? input[0].text : "";
+    const expectedPath = path.join(workspacePath, ".slack-attachments", "111.223", "F123-screen.svg");
+    expect(text).toContain("\"attachments\": [");
+    expect(text).toContain(`"local_path": "${expectedPath}"`);
+    expect(await fs.readFile(expectedPath, "utf8")).toBe("<svg/>");
   });
 });


### PR DESCRIPTION
## Summary

- Stop passing Slack attachments directly to Codex/agent as image input items.
- Normalize all Slack file attachments, download them into the session workspace under `.slack-attachments/<message-ts>/`, and include local file paths in the structured Slack payload.
- Keep attachment metadata visible in traces and message formatting, including download failures when Slack file download fails.

## Validation

- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vitest run test/slack-api.test.ts test/slack-message-format.test.ts test/slack-turn-runner.test.ts test/admin-token-usage.e2e.test.ts`
- `pnpm test` — 48 files / 250 tests passed
- `pnpm build`
- Manual Node smoke test against built `dist`: SVG attachment produced only a text input, wrote the file to `.slack-attachments/111.223/Fsvg-screen.svg`, and included the local path in the structured payload.
