### PR TITLE
[codex] Preserve trace linkage across session switches

### DIFF
--- a/src/services/agent-runtime/agent-trace-recorder.ts
+++ b/src/services/agent-runtime/agent-trace-recorder.ts
@@ -56,6 +56,14 @@ export class AgentTraceRecorder {
       return undefined;
     }
 
+    const byAgentActivity = this.#sessions.findSessionByAgentActivity({
+      agentSessionId,
+      turnId
+    });
+    if (byAgentActivity) {
+      return byAgentActivity;
+    }
+
     return this.#sessions.listSessions().find((session) =>
       Boolean(agentSessionId && session.agentSessionId === agentSessionId) ||
       Boolean(turnId && session.activeTurnId === turnId)

--- a/src/services/agent-runtime/codex-app-server-runtime.ts
+++ b/src/services/agent-runtime/codex-app-server-runtime.ts
@@ -217,6 +217,14 @@ export class CodexAppServerRuntime extends EventEmitter implements AgentRuntime 
       return undefined;
     }
 
+    const byAgentActivity = this.#sessions.findSessionByAgentActivity({
+      agentSessionId,
+      turnId
+    });
+    if (byAgentActivity) {
+      return byAgentActivity;
+    }
+
     for (const session of this.#sessions.listSessions()) {
       if (turnId && session.activeTurnId === turnId) {
         return session;

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -143,22 +143,50 @@ export class SessionManager {
     return candidates[0];
   }
 
+  findSessionByAgentActivity(options: {
+    readonly agentSessionId?: string | undefined;
+    readonly turnId?: string | undefined;
+  }): SlackSessionRecord | undefined {
+    const sessionKey = this.#stateStore.getSessionKeyForAgentActivity(options);
+    return sessionKey ? this.getSessionByKey(sessionKey) : undefined;
+  }
+
   async setAgentSessionId(
     channelId: string,
     rootThreadTs: string,
     agentSessionId: string | undefined
   ): Promise<SlackSessionRecord> {
-    return await this.#patchSession(channelId, rootThreadTs, {
+    const session = await this.#patchSession(channelId, rootThreadTs, {
       agentSessionId
     });
+    if (agentSessionId) {
+      await this.#stateStore.bindAgentSession({
+        sessionKey: session.key,
+        channelId: session.channelId,
+        rootThreadTs: session.rootThreadTs,
+        agentSessionId
+      });
+    }
+    return session;
   }
 
   async setActiveTurnId(channelId: string, rootThreadTs: string, activeTurnId: string | undefined): Promise<SlackSessionRecord> {
     const now = new Date().toISOString();
-    return await this.#patchSession(channelId, rootThreadTs, {
+    const session = await this.#patchSession(channelId, rootThreadTs, {
       activeTurnId,
       activeTurnStartedAt: activeTurnId ? now : undefined
     });
+    if (activeTurnId) {
+      await this.#stateStore.bindAgentTurn({
+        sessionKey: session.key,
+        channelId: session.channelId,
+        rootThreadTs: session.rootThreadTs,
+        agentSessionId: session.agentSessionId,
+        turnId: activeTurnId,
+        at: now
+      });
+    }
+    return session;
   }
 
   async clearActiveTurnIdIfMatches(

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -19,7 +19,7 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 11;
+export const CURRENT_STATE_SCHEMA_VERSION = 12;
 const ADMIN_EVENT_RETENTION_LIMIT = 20_000;
 
 type SqlValue = string | number | bigint | null;
@@ -295,8 +295,58 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
     up(database) {
       repairSessionAuthProfileSchema(database);
     }
+  },
+  {
+    version: 12,
+    name: "agent_activity_bindings",
+    up(database) {
+      createAgentActivityBindingSchema(database);
+    }
   }
 ];
+
+function createAgentActivityBindingSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS agent_session_bindings (
+      agent_session_id TEXT PRIMARY KEY,
+      session_key TEXT NOT NULL REFERENCES sessions(key) ON DELETE CASCADE,
+      channel_id TEXT NOT NULL,
+      root_thread_ts TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS agent_turn_bindings (
+      turn_id TEXT PRIMARY KEY,
+      session_key TEXT NOT NULL REFERENCES sessions(key) ON DELETE CASCADE,
+      channel_id TEXT NOT NULL,
+      root_thread_ts TEXT NOT NULL,
+      agent_session_id TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_agent_session_bindings_session ON agent_session_bindings(session_key);
+    CREATE INDEX IF NOT EXISTS idx_agent_turn_bindings_session ON agent_turn_bindings(session_key);
+    CREATE INDEX IF NOT EXISTS idx_agent_turn_bindings_agent_session ON agent_turn_bindings(agent_session_id);
+
+    INSERT OR IGNORE INTO agent_session_bindings (
+      agent_session_id, session_key, channel_id, root_thread_ts, created_at, updated_at
+    )
+    SELECT
+      agent_session_id, key, channel_id, root_thread_ts, updated_at, updated_at
+    FROM sessions
+    WHERE agent_session_id IS NOT NULL;
+
+    INSERT OR IGNORE INTO agent_turn_bindings (
+      turn_id, session_key, channel_id, root_thread_ts, agent_session_id, created_at, updated_at
+    )
+    SELECT
+      active_turn_id, key, channel_id, root_thread_ts, agent_session_id, updated_at, updated_at
+    FROM sessions
+    WHERE active_turn_id IS NOT NULL;
+  `);
+}
 
 function createAdminEventsSchema(database: DatabaseSync): void {
   database.exec(`
@@ -542,6 +592,83 @@ export class StateStore {
       });
       return updated;
     });
+  }
+
+  async bindAgentSession(record: {
+    readonly sessionKey: string;
+    readonly channelId: string;
+    readonly rootThreadTs: string;
+    readonly agentSessionId: string;
+    readonly at?: string | undefined;
+  }): Promise<void> {
+    const agentSessionId = record.agentSessionId.trim();
+    if (!agentSessionId) {
+      return;
+    }
+    const now = record.at ?? new Date().toISOString();
+    this.#transaction(() => {
+      this.#upsertAgentSessionBinding({
+        sessionKey: record.sessionKey,
+        channelId: record.channelId,
+        rootThreadTs: record.rootThreadTs,
+        agentSessionId,
+        createdAt: now,
+        updatedAt: now
+      });
+    });
+  }
+
+  async bindAgentTurn(record: {
+    readonly sessionKey: string;
+    readonly channelId: string;
+    readonly rootThreadTs: string;
+    readonly turnId: string;
+    readonly agentSessionId?: string | undefined;
+    readonly at?: string | undefined;
+  }): Promise<void> {
+    const turnId = record.turnId.trim();
+    if (!turnId) {
+      return;
+    }
+    const agentSessionId = record.agentSessionId?.trim() || undefined;
+    const now = record.at ?? new Date().toISOString();
+    this.#transaction(() => {
+      this.#upsertAgentTurnBinding({
+        sessionKey: record.sessionKey,
+        channelId: record.channelId,
+        rootThreadTs: record.rootThreadTs,
+        agentSessionId,
+        turnId,
+        createdAt: now,
+        updatedAt: now
+      });
+    });
+  }
+
+  getSessionKeyForAgentActivity(options: {
+    readonly agentSessionId?: string | undefined;
+    readonly turnId?: string | undefined;
+  }): string | undefined {
+    const turnId = options.turnId?.trim();
+    if (turnId) {
+      const row = this.#databaseRequired()
+        .prepare("SELECT session_key FROM agent_turn_bindings WHERE turn_id = ?")
+        .get(turnId) as SqlRow | undefined;
+      const sessionKey = optionalStringColumn(row ?? {}, "session_key");
+      if (sessionKey) {
+        return sessionKey;
+      }
+    }
+
+    const agentSessionId = options.agentSessionId?.trim();
+    if (agentSessionId) {
+      const row = this.#databaseRequired()
+        .prepare("SELECT session_key FROM agent_session_bindings WHERE agent_session_id = ?")
+        .get(agentSessionId) as SqlRow | undefined;
+      return optionalStringColumn(row ?? {}, "session_key");
+    }
+
+    return undefined;
   }
 
   hasProcessedEvent(eventId: string): boolean {
@@ -1103,6 +1230,88 @@ export class StateStore {
       record.coAuthorIgnoreMissingRevision ?? null,
       record.coAuthorPromptRevision ?? null,
       record.coAuthorPromptedAt ?? null
+    );
+    this.#bindAgentActivityFromSession(record);
+  }
+
+  #bindAgentActivityFromSession(record: SlackSessionRecord): void {
+    if (record.agentSessionId) {
+      this.#upsertAgentSessionBinding({
+        sessionKey: record.key,
+        channelId: record.channelId,
+        rootThreadTs: record.rootThreadTs,
+        agentSessionId: record.agentSessionId,
+        createdAt: record.updatedAt,
+        updatedAt: record.updatedAt
+      });
+    }
+    if (record.activeTurnId) {
+      this.#upsertAgentTurnBinding({
+        sessionKey: record.key,
+        channelId: record.channelId,
+        rootThreadTs: record.rootThreadTs,
+        agentSessionId: record.agentSessionId,
+        turnId: record.activeTurnId,
+        createdAt: record.updatedAt,
+        updatedAt: record.updatedAt
+      });
+    }
+  }
+
+  #upsertAgentSessionBinding(record: {
+    readonly sessionKey: string;
+    readonly channelId: string;
+    readonly rootThreadTs: string;
+    readonly agentSessionId: string;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+  }): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO agent_session_bindings (
+        agent_session_id, session_key, channel_id, root_thread_ts, created_at, updated_at
+      ) VALUES (${placeholders(6)})
+      ON CONFLICT(agent_session_id) DO UPDATE SET
+        session_key = excluded.session_key,
+        channel_id = excluded.channel_id,
+        root_thread_ts = excluded.root_thread_ts,
+        updated_at = excluded.updated_at
+    `).run(
+      record.agentSessionId,
+      record.sessionKey,
+      record.channelId,
+      record.rootThreadTs,
+      record.createdAt,
+      record.updatedAt
+    );
+  }
+
+  #upsertAgentTurnBinding(record: {
+    readonly sessionKey: string;
+    readonly channelId: string;
+    readonly rootThreadTs: string;
+    readonly agentSessionId?: string | undefined;
+    readonly turnId: string;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+  }): void {
+    this.#databaseRequired().prepare(`
+      INSERT INTO agent_turn_bindings (
+        turn_id, session_key, channel_id, root_thread_ts, agent_session_id, created_at, updated_at
+      ) VALUES (${placeholders(7)})
+      ON CONFLICT(turn_id) DO UPDATE SET
+        session_key = excluded.session_key,
+        channel_id = excluded.channel_id,
+        root_thread_ts = excluded.root_thread_ts,
+        agent_session_id = excluded.agent_session_id,
+        updated_at = excluded.updated_at
+    `).run(
+      record.turnId,
+      record.sessionKey,
+      record.channelId,
+      record.rootThreadTs,
+      record.agentSessionId ?? null,
+      record.createdAt,
+      record.updatedAt
     );
   }
 

--- a/test/agent-trace-recorder.test.ts
+++ b/test/agent-trace-recorder.test.ts
@@ -53,6 +53,51 @@ describe("AgentTraceRecorder", () => {
     });
   });
 
+  it("records late events from an old agent turn after the session switches runtime ids", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-recorder-late-event-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const stateStore = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot
+    });
+
+    await sessions.load();
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "thread-old");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-old");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "thread-new");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-new");
+
+    const recorder = new AgentTraceRecorder({
+      sessions
+    });
+    await recorder.record({
+      type: "agent.message.completed",
+      agentSessionId: "thread-old",
+      turnId: "turn-old",
+      messageId: "message-late",
+      role: "assistant",
+      text: "旧 session 的迟到事件不能断链。",
+      at: "2026-03-19T00:00:03.000Z"
+    });
+
+    expect(sessions.listAgentTraceEvents(session.key)).toEqual([
+      expect.objectContaining({
+        type: "agent_assistant_message",
+        summary: "旧 session 的迟到事件不能断链。",
+        detail: "旧 session 的迟到事件不能断链。",
+        turnId: "turn-old"
+      })
+    ]);
+
+    stateStore.close();
+    await fs.rm(stateDir, {
+      force: true,
+      recursive: true
+    });
+  });
+
   it("does not record empty assistant message trace events", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-trace-recorder-empty-message-"));
     const sessionsRoot = path.join(stateDir, "sessions");

--- a/test/codex-app-server-runtime.test.ts
+++ b/test/codex-app-server-runtime.test.ts
@@ -164,6 +164,53 @@ describe("CodexAppServerRuntime", () => {
     ]);
   });
 
+  it("uses historical agent activity bindings after the session switches to a new runtime", () => {
+    const switchedSession: SlackSessionRecord = {
+      ...TEST_SESSION,
+      agentSessionId: "thread-new",
+      activeTurnId: "turn-new"
+    };
+    const { codex, events } = createRuntimeFixture({
+      sessions: {
+        findSessionByWorkspace: vi.fn(() => undefined),
+        findSessionByAgentActivity: vi.fn(({ agentSessionId, turnId }) =>
+          agentSessionId === "thread-old" || turnId === "turn-old" ? switchedSession : undefined
+        ),
+        listSessions: vi.fn(() => [switchedSession])
+      } as never
+    });
+
+    codex.emit("notification", "codex/event", {
+      thread_id: "thread-old",
+      turn_id: "turn-old",
+      msg: {
+        type: "response_item",
+        payload: {
+          type: "message",
+          id: "message-late",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "旧 turn 的迟到事件仍然属于这个 Slack thread。"
+            }
+          ]
+        }
+      }
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "agent.message.completed",
+        agentSessionId: "thread-old",
+        brokerSessionKey: TEST_SESSION.key,
+        turnId: "turn-old",
+        messageId: "message-late",
+        text: "旧 turn 的迟到事件仍然属于这个 Slack thread。"
+      })
+    ]);
+  });
+
   it("ignores empty assistant response_item notifications", () => {
     const { codex, events } = createRuntimeFixture();
 
@@ -185,7 +232,9 @@ describe("CodexAppServerRuntime", () => {
   });
 });
 
-function createRuntimeFixture(): {
+function createRuntimeFixture(options?: {
+  readonly sessions?: unknown;
+}): {
   readonly codex: EventEmitter;
   readonly events: AgentRuntimeEvent[];
 } {
@@ -209,10 +258,11 @@ function createRuntimeFixture(): {
   });
   const runtime = new CodexAppServerRuntime({
     codex: codex as never,
-    sessions: {
+    sessions: (options?.sessions ?? {
       findSessionByWorkspace: vi.fn(() => undefined),
+      findSessionByAgentActivity: vi.fn(() => undefined),
       listSessions: vi.fn(() => [TEST_SESSION])
-    } as never
+    }) as never
   });
   const events: AgentRuntimeEvent[] = [];
   runtime.on("event", (event: AgentRuntimeEvent) => {

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -236,6 +236,65 @@ describe("StateStore", () => {
     store.close();
   });
 
+  it("persists historical agent activity bindings when the current session runtime changes", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-agent-bindings-"));
+    const sessionsRoot = path.join(stateDir, "sessions");
+    const store = new StateStore(stateDir, sessionsRoot);
+    await store.load();
+    await store.upsertSession({
+      key: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      workspacePath: "/tmp/sessions/C123-111.222/workspace",
+      createdAt: "2026-03-15T00:00:00.000Z",
+      updatedAt: "2026-03-15T00:00:00.000Z",
+      agentSessionId: "thread-current",
+      activeTurnId: "turn-current"
+    });
+    expect(store.getSessionKeyForAgentActivity({
+      agentSessionId: "thread-current",
+      turnId: "turn-current"
+    })).toBe("C123:111.222");
+    await store.bindAgentSession({
+      sessionKey: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      agentSessionId: "thread-old",
+      at: "2026-03-15T00:00:01.000Z"
+    });
+    await store.bindAgentTurn({
+      sessionKey: "C123:111.222",
+      channelId: "C123",
+      rootThreadTs: "111.222",
+      agentSessionId: "thread-old",
+      turnId: "turn-old",
+      at: "2026-03-15T00:00:02.000Z"
+    });
+
+    expect(store.getSessionKeyForAgentActivity({
+      agentSessionId: "thread-old"
+    })).toBe("C123:111.222");
+    expect(store.getSessionKeyForAgentActivity({
+      turnId: "turn-old"
+    })).toBe("C123:111.222");
+
+    await store.patchSession("C123:111.222", {
+      agentSessionId: "thread-new",
+      activeTurnId: "turn-new"
+    });
+    expect(store.getSessionKeyForAgentActivity({
+      agentSessionId: "thread-old",
+      turnId: "turn-old"
+    })).toBe("C123:111.222");
+
+    await store.deleteSession("C123:111.222");
+    expect(store.getSessionKeyForAgentActivity({
+      agentSessionId: "thread-old",
+      turnId: "turn-old"
+    })).toBeUndefined();
+    store.close();
+  });
+
   it("records explicit schema migrations and does not treat ad hoc DDL as the migration state", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-migrations-"));
     const sessionsRoot = path.join(stateDir, "sessions");
@@ -291,8 +350,12 @@ describe("StateStore", () => {
           name: "session_page_link_announcement"
         },
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 11,
           name: "session_auth_profile_binding"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "agent_activity_bindings"
         }
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- add durable agent session and turn bindings so late runtime events stay attached to the Slack session after auth/session switches
- resolve Codex notifications and trace events through those historical bindings before falling back to current mutable session fields
- add regression coverage for state migration, runtime notification routing, and trace recording after session ids change

## Validation
- pnpm test
- pnpm build