### PR TITLE
[codex] Add automatic auth profile switch option

### DIFF
--- a/src/admin-ui/admin-legacy.js
+++ b/src/admin-ui/admin-legacy.js
@@ -185,13 +185,52 @@ export function initAdminPage(options = {}) {
       if (!Number.isFinite(seconds)) return null;
       return Math.max(((seconds * 1000) - Date.now()) / 86400000, 1 / (24 * 60));
     }
+    function msUntilReset(resetsAt) {
+      const seconds = Number(resetsAt);
+      if (!Number.isFinite(seconds)) return null;
+      return Math.max((seconds * 1000) - Date.now(), 60000);
+    }
     function weightedWeeklyQuotaScore(remaining, refreshDays) {
       if (remaining == null) return null;
       return (remaining / 100) / ((refreshDays || 7) / 7);
     }
+    function weightedQuotaWindowScore(remaining, limit, fallbackWindowMins) {
+      if (remaining == null) return null;
+      const windowMins = normalizeWindowDurationMins(limit?.windowDurationMins, fallbackWindowMins);
+      const resetMs = msUntilReset(limit?.resetsAt) || windowMins * 60000;
+      return (remaining / 100) / (resetMs / (windowMins * 60000));
+    }
     function formatWeightedWeeklyQuotaScore(score) {
       if (!Number.isFinite(Number(score))) return "0";
       return Number(score).toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+    }
+    function normalizeWindowDurationMins(value, fallback) {
+      const mins = Number(value);
+      return Number.isFinite(mins) && mins > 0 ? mins : fallback;
+    }
+    function formatWindowDuration(windowMins) {
+      if (windowMins % 1440 === 0) return (windowMins / 1440) + "d";
+      if (windowMins % 60 === 0) return (windowMins / 60) + "h";
+      return windowMins + "m";
+    }
+    function quotaWindowDisplay(limit, fallbackWindowMins) {
+      const remaining = remainingPercent(limit?.usedPercent);
+      if (remaining == null) return null;
+      const windowMins = normalizeWindowDurationMins(limit?.windowDurationMins, fallbackWindowMins);
+      const score = weightedQuotaWindowScore(remaining, limit, windowMins);
+      return formatWindowDuration(windowMins) + " " + Math.round(remaining) + "% / " + formatWeightedWeeklyQuotaScore(score);
+    }
+    function authQuotaDisplay(rateLimits) {
+      const primary = rateLimits?.primary;
+      const primaryRemaining = remainingPercent(primary?.usedPercent);
+      const primaryScore = weightedQuotaWindowScore(primaryRemaining, primary, 300);
+      const shortLabel = Number.isFinite(Number(primaryScore)) && Number(primaryScore) < 0.5
+        ? quotaWindowDisplay(primary, 300)
+        : null;
+      return [
+        quotaWindowDisplay(rateLimits?.secondary, 10080),
+        shortLabel
+      ].filter(Boolean).join(" | ") || null;
     }
     function weeklyQuotaDisplay(limit) {
       const remaining = remainingPercent(limit?.usedPercent);
@@ -219,11 +258,11 @@ export function initAdminPage(options = {}) {
       if (plan === "chatgpt") return "ChatGPT";
       return plan;
     }
-    function profileTooltip(profile, weeklyLabel, secondary) {
+    function profileTooltip(profile, quotaLabel, secondary) {
       return [
         profileAccountLabel(profile),
         profilePlanLabel(profile),
-        weeklyLabel ? "周额度 " + weeklyLabel : "",
+        quotaLabel ? "额度 " + quotaLabel : "",
         secondary ? "周重置 " + formatResetTime(secondary.resetsAt) : "",
         profile.name ? "内部标识 " + profile.name : ""
       ].filter(Boolean).join(" · ");
@@ -234,7 +273,7 @@ export function initAdminPage(options = {}) {
           const rateLimits = profile.rateLimits || {};
           if (rateLimits.ok === false) return null;
           const secondary = rateLimits.rateLimits?.secondary;
-          const label = weeklyQuotaDisplay(secondary);
+          const label = authQuotaDisplay(rateLimits.rateLimits);
           if (!label) return null;
           const remaining = remainingPercent(secondary?.usedPercent);
           const score = weeklyQuotaScore(secondary);
@@ -504,9 +543,9 @@ export function initAdminPage(options = {}) {
       if (!rateLimits || !rateLimits.ok) return '<div class="summary-detail">' + esc(rateLimits?.error || "额度不可用") + '</div>';
       const snapshot = rateLimits.rateLimits || {};
       const secondary = snapshot.secondary;
-      const weeklyLabel = weeklyQuotaDisplay(secondary);
+      const quotaLabel = authQuotaDisplay(snapshot);
       return '<div class="quota-grid">' +
-        '<div class="quota-line"><span>周额度</span><strong>' + esc(weeklyLabel || "--") + '</strong><span>' + esc(secondary ? formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
+        '<div class="quota-line"><span>额度</span><strong>' + esc(quotaLabel || "--") + '</strong><span>' + esc(secondary ? "周 " + formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
       '</div>';
     }
     function renderAuthProfiles(data) {

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -142,7 +142,7 @@
     .auth-profile-label { color: var(--muted); font-size: 10px; white-space: nowrap; }
 
     .session-timeline-panel .mini-body { flex: 1; min-height: 0; overflow: hidden; padding: 0; }
-    .timeline { height: 100%; display: grid; gap: 0; overflow: auto; border: 0; }
+    .timeline { height: 100%; display: grid; grid-auto-rows: max-content; align-content: start; gap: 0; overflow: auto; border: 0; }
     .timeline-event { display: grid; grid-template-columns: 72px 90px minmax(0, 1fr); gap: 6px; align-items: start; padding: 4px 6px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 10px; }
     .timeline-event:last-child { border-bottom: 0; }
     .timeline-main { min-width: 0; }

--- a/src/admin-ui/auth-profile-display.ts
+++ b/src/admin-ui/auth-profile-display.ts
@@ -1,4 +1,4 @@
-import { formatWeeklyQuotaDisplay } from "../auth-profile-quota.js";
+import { formatAuthQuotaDisplay } from "../auth-profile-quota.js";
 
 type AuthProfileRecord = Record<string, any>;
 interface QuotaLabelOptions {
@@ -66,12 +66,12 @@ export function profileQuotaLabel(profile: AuthProfileRecord, options: QuotaLabe
   }
 
   const limits = rateLimits.rateLimits || {};
-  const label = formatWeeklyQuotaDisplay({
-    usedPercent: limits.secondary?.usedPercent,
-    resetsAt: limits.secondary?.resetsAt,
+  const label = formatAuthQuotaDisplay({
+    primary: limits.primary,
+    secondary: limits.secondary,
     now: options.now
   });
-  return label ?? "周额度未知";
+  return label ?? "额度未知";
 }
 
 export function profileWeeklyQuotaLabel(profile: AuthProfileRecord, options: QuotaLabelOptions = {}): string {
@@ -81,11 +81,11 @@ export function profileWeeklyQuotaLabel(profile: AuthProfileRecord, options: Quo
   }
 
   const limits = rateLimits.rateLimits || {};
-  return formatWeeklyQuotaDisplay({
-    usedPercent: limits.secondary?.usedPercent,
-    resetsAt: limits.secondary?.resetsAt,
+  return formatAuthQuotaDisplay({
+    primary: limits.primary,
+    secondary: limits.secondary,
     now: options.now
-  }) ?? "周额度未知";
+  }) ?? "额度未知";
 }
 
 function readString(value: unknown): string | null {

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -40,6 +40,7 @@ type TimelinePayload = {
 } | TimelineEvent[];
 
 const sessionFilters = ["ongoing", "all", "active", "inbound", "jobs", "issues", "usage"];
+const AUTO_AUTH_PROFILE_VALUE = "__auto_auth_profile__";
 
 export function AdminSessionsView(): React.JSX.Element {
   const permalinkSessionKey = readPermalinkSessionKey();
@@ -577,7 +578,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
   readonly currentProfile?: SessionRecord | undefined;
 }): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
-  const [selected, setSelected] = useState(String(session.authProfileName || ""));
+  const [selected, setSelected] = useState(() => initialAuthProfileSelection(session));
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const currentProfile = providedCurrentProfile ?? profiles.find((profile) => profile.name === session.authProfileName);
@@ -588,7 +589,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
   const compactLabel = currentProfile ? profileQuotaLabel(currentProfile) : (blocked ? "账号不可用" : "账号");
 
   useEffect(() => {
-    setSelected(String(session.authProfileName || ""));
+    setSelected(initialAuthProfileSelection(session));
     setMessage(null);
   }, [session.key, session.authProfileName, session.authBlockedAt]);
 
@@ -613,7 +614,8 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
   }
 
   async function switchProfile(): Promise<void> {
-    if (!selected || selected === session.authProfileName) {
+    const autoSelected = selected === AUTO_AUTH_PROFILE_VALUE;
+    if (!autoSelected && (!selected || selected === session.authProfileName)) {
       return;
     }
 
@@ -623,11 +625,11 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
       await requestJson("/admin/api/sessions/" + encodeURIComponent(String(session.key || "")) + "/auth-profile", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ name: selected })
+        body: JSON.stringify(autoSelected ? { mode: "auto" } : { name: selected })
       });
       const timelinePayload = await requestJson(sessionTimelineApiPath(String(session.key || "")));
       publishTimelinePayload(String(session.key || ""), timelinePayload as TimelinePayload);
-      setMessage("已切换，正在恢复待处理消息");
+      setMessage(autoSelected ? "已自动分配，正在恢复待处理消息" : "已切换，正在恢复待处理消息");
     } catch (error) {
       setMessage(error instanceof Error ? error.message : String(error));
     } finally {
@@ -653,7 +655,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
           </div>
           {currentProfile ? (
             <div className="auth-profile-dialog-current">
-              <span>周额度</span>
+              <span>额度</span>
               <strong>{profileQuotaLabel(currentProfile)}</strong>
             </div>
           ) : null}
@@ -671,6 +673,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
               onChange={(event) => setSelected(event.target.value)}
             >
               <option value="">选择账号</option>
+              <option value={AUTO_AUTH_PROFILE_VALUE}>自动分配（按额度规则）</option>
               {profiles.map((profile) => (
                 <option key={profile.name} value={profile.name} disabled={!profileIsSelectable(profile)}>
                   {profileOptionLabel(profile)}
@@ -680,10 +683,10 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
             <button
               type="button"
               className="link-button"
-              disabled={busy || !selected || selected === session.authProfileName}
+              disabled={busy || (selected !== AUTO_AUTH_PROFILE_VALUE && (!selected || selected === session.authProfileName))}
               onClick={() => { void switchProfile(); }}
             >
-              切换并继续处理
+              {selected === AUTO_AUTH_PROFILE_VALUE ? "自动分配并继续处理" : "切换并继续处理"}
             </button>
           </div>
           {message ? <div className="summary-detail">{message}</div> : null}
@@ -694,6 +697,10 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
       </dialog>
     </div>
   );
+}
+
+function initialAuthProfileSelection(session: SessionRecord): string {
+  return session.authBlockedAt ? AUTO_AUTH_PROFILE_VALUE : String(session.authProfileName || "");
 }
 
 function TimelinePayloadView({ payload }: { readonly payload: TimelinePayload }): React.JSX.Element {

--- a/src/auth-profile-quota.ts
+++ b/src/auth-profile-quota.ts
@@ -1,5 +1,9 @@
 export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+export const MS_PER_MINUTE = 60 * 1000;
 export const MIN_REFRESH_DAYS = 1 / (24 * 60);
+export const DEFAULT_SHORT_WINDOW_MINS = 300;
+export const DEFAULT_WEEKLY_WINDOW_MINS = 10_080;
+export const SHORT_WINDOW_DISPLAY_SCORE_THRESHOLD = 0.5;
 
 export function remainingPercent(usedPercent: unknown): number | undefined {
   const used = Number(usedPercent);
@@ -23,6 +27,18 @@ export function daysUntilReset(
   return Math.max(deltaDays, MIN_REFRESH_DAYS);
 }
 
+export function msUntilReset(
+  resetsAt: unknown,
+  now: Date | number | string | undefined = undefined
+): number | undefined {
+  const resetSeconds = Number(resetsAt);
+  if (!Number.isFinite(resetSeconds)) {
+    return undefined;
+  }
+
+  return Math.max(resetSeconds * 1000 - timestampMs(now), MS_PER_MINUTE);
+}
+
 export function weightedWeeklyQuotaScore(
   remaining: number | undefined,
   refreshDays: number | undefined
@@ -33,6 +49,25 @@ export function weightedWeeklyQuotaScore(
 
   const days = refreshDays ?? 7;
   return (remaining / 100) / (days / 7);
+}
+
+export function weightedQuotaWindowScore(options: {
+  readonly remaining: number | undefined;
+  readonly resetsAt?: unknown;
+  readonly windowDurationMins?: unknown;
+  readonly fallbackWindowDurationMins: number;
+  readonly now?: Date | number | string | undefined;
+}): number | undefined {
+  if (options.remaining === undefined) {
+    return undefined;
+  }
+
+  const windowMins = normalizeWindowDurationMins(
+    options.windowDurationMins,
+    options.fallbackWindowDurationMins
+  );
+  const resetMs = msUntilReset(options.resetsAt, options.now) ?? windowMins * MS_PER_MINUTE;
+  return (options.remaining / 100) / (resetMs / (windowMins * MS_PER_MINUTE));
 }
 
 export function formatWeeklyQuotaDisplay(options: {
@@ -47,6 +82,84 @@ export function formatWeeklyQuotaDisplay(options: {
 
   const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(options.resetsAt, options.now));
   return `${Math.round(remaining)}% | ${formatWeightedWeeklyQuotaScore(score)}`;
+}
+
+export function formatQuotaWindowDisplay(options: {
+  readonly usedPercent: unknown;
+  readonly resetsAt?: unknown;
+  readonly windowDurationMins?: unknown;
+  readonly fallbackWindowDurationMins: number;
+  readonly now?: Date | number | string | undefined;
+}): string | null {
+  const remaining = remainingPercent(options.usedPercent);
+  if (remaining === undefined) {
+    return null;
+  }
+
+  const windowMins = normalizeWindowDurationMins(
+    options.windowDurationMins,
+    options.fallbackWindowDurationMins
+  );
+  const score = weightedQuotaWindowScore({
+    remaining,
+    resetsAt: options.resetsAt,
+    windowDurationMins: windowMins,
+    fallbackWindowDurationMins: windowMins,
+    now: options.now
+  });
+  return `${formatWindowDuration(windowMins)} ${Math.round(remaining)}% / ${formatWeightedWeeklyQuotaScore(score)}`;
+}
+
+export function formatAuthQuotaDisplay(options: {
+  readonly primary?: {
+    readonly usedPercent?: unknown;
+    readonly resetsAt?: unknown;
+    readonly windowDurationMins?: unknown;
+  } | null | undefined;
+  readonly secondary?: {
+    readonly usedPercent?: unknown;
+    readonly resetsAt?: unknown;
+    readonly windowDurationMins?: unknown;
+  } | null | undefined;
+  readonly now?: Date | number | string | undefined;
+}): string | null {
+  const weekly = formatQuotaWindowDisplay({
+    usedPercent: options.secondary?.usedPercent,
+    resetsAt: options.secondary?.resetsAt,
+    windowDurationMins: options.secondary?.windowDurationMins,
+    fallbackWindowDurationMins: DEFAULT_WEEKLY_WINDOW_MINS,
+    now: options.now
+  });
+  const short = shouldShowShortWindowQuota(options.primary, options.now)
+    ? formatQuotaWindowDisplay({
+        usedPercent: options.primary?.usedPercent,
+        resetsAt: options.primary?.resetsAt,
+        windowDurationMins: options.primary?.windowDurationMins,
+        fallbackWindowDurationMins: DEFAULT_SHORT_WINDOW_MINS,
+        now: options.now
+      })
+    : null;
+  const parts = [weekly, short].filter(Boolean);
+  return parts.length ? parts.join(" | ") : null;
+}
+
+export function shouldShowShortWindowQuota(
+  limit: {
+    readonly usedPercent?: unknown;
+    readonly resetsAt?: unknown;
+    readonly windowDurationMins?: unknown;
+  } | null | undefined,
+  now?: Date | number | string | undefined
+): boolean {
+  const remaining = remainingPercent(limit?.usedPercent);
+  const score = weightedQuotaWindowScore({
+    remaining,
+    resetsAt: limit?.resetsAt,
+    windowDurationMins: limit?.windowDurationMins,
+    fallbackWindowDurationMins: DEFAULT_SHORT_WINDOW_MINS,
+    now
+  });
+  return Number.isFinite(score) && Number(score) < SHORT_WINDOW_DISPLAY_SCORE_THRESHOLD;
 }
 
 export function formatWeightedWeeklyQuotaScore(score: number | undefined): string {
@@ -72,4 +185,19 @@ export function timestampMs(value: Date | number | string | undefined): number {
     return Number.isFinite(parsed) ? parsed : Date.now();
   }
   return Date.now();
+}
+
+function normalizeWindowDurationMins(value: unknown, fallback: number): number {
+  const mins = Number(value);
+  return Number.isFinite(mins) && mins > 0 ? mins : fallback;
+}
+
+function formatWindowDuration(windowMins: number): string {
+  if (windowMins % (24 * 60) === 0) {
+    return `${windowMins / (24 * 60)}d`;
+  }
+  if (windowMins % 60 === 0) {
+    return `${windowMins / 60}h`;
+  }
+  return `${windowMins}m`;
 }

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -76,11 +76,13 @@ export async function handleAdminRequest(
     }
 
     const name = readString(body.name);
-    if (!name) {
+    const mode = readString(body.mode);
+    const autoMode = mode === "auto";
+    if (!name && !autoMode) {
       respondJson(response, 400, {
         ok: false,
         error: "missing_required_body",
-        required: ["name"]
+        required: ["name", "mode=auto"]
       });
       return true;
     }
@@ -88,7 +90,7 @@ export async function handleAdminRequest(
     await runAdminOperation(response, () =>
       options.adminService.switchSessionAuthProfile({
         sessionKey,
-        name
+        ...(autoMode ? { mode: "auto" as const } : { name })
       })
     );
     return true;

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -23,7 +23,8 @@ import type { RuntimeControl } from "./runtime-control.js";
 import {
   authProfileReasonLabel,
   evaluateAuthProfile,
-  findAuthProfile
+  findAuthProfile,
+  selectBestAuthProfile
 } from "./session-auth-profile-selector.js";
 import type {
   DeployReleaseOptions,
@@ -465,14 +466,23 @@ export class AdminService {
 
   async switchSessionAuthProfile(options: {
     readonly sessionKey: string;
-    readonly name: string;
+    readonly name?: string | undefined;
+    readonly mode?: "auto" | undefined;
   }): Promise<Record<string, unknown>> {
+    const selectionMode = options.mode === "auto" ? "auto" : "manual";
+    const request: JsonLike = selectionMode === "auto"
+      ? {
+          sessionKey: options.sessionKey,
+          mode: "auto"
+        }
+      : {
+          sessionKey: options.sessionKey,
+          mode: "manual",
+          name: options.name ?? ""
+        };
     return await this.#runTrackedOperation(
       "session_auth_profile_switch",
-      {
-        sessionKey: options.sessionKey,
-        name: options.name
-      },
+      request,
       async () => {
         const session = this.options.sessions.getSessionByKey(options.sessionKey);
         if (!session) {
@@ -480,9 +490,14 @@ export class AdminService {
         }
 
         const status = await this.options.authProfiles.listProfilesStatus();
-        const profile = findAuthProfile(status, options.name);
+        const profile = selectionMode === "auto"
+          ? selectBestAuthProfile(status)
+          : (options.name ? findAuthProfile(status, options.name) : null);
         if (!profile) {
-          throw new Error(`Auth profile not found: ${options.name}`);
+          if (selectionMode === "auto") {
+            throw new Error(`No usable auth profile: ${authProfileReasonLabel("no_usable_auth_profiles")}`);
+          }
+          throw new Error(`Auth profile not found: ${options.name ?? ""}`);
         }
 
         const evaluation = evaluateAuthProfile(profile);
@@ -492,10 +507,12 @@ export class AdminService {
 
         await this.options.sessions.resetInflightMessages(session.channelId, session.rootThreadTs);
         const switched = await this.options.sessions.switchSessionAuthProfileAndClearBlock(session.key, profile.name);
-        await this.#appendSessionAuthProfileSwitchTrace(switched, profile.name);
+        await this.#appendSessionAuthProfileSwitchTrace(switched, profile.name, selectionMode);
         const workerResume = await this.#resumeWorkerPendingSession(switched.key);
         return {
           ok: true,
+          selectedMode: selectionMode,
+          selectedProfileName: profile.name,
           session: this.#summarizeSessionByKey(switched.key),
           workerResume
         };
@@ -1227,10 +1244,12 @@ export class AdminService {
 
   async #appendSessionAuthProfileSwitchTrace(
     session: SlackSessionRecord,
-    profileName: string
+    profileName: string,
+    selectionMode: "manual" | "auto"
   ): Promise<void> {
     const now = new Date().toISOString();
     const sequence = this.options.sessions.listAgentTraceEvents(session.key, 10_000).length + 1;
+    const actionLabel = selectionMode === "auto" ? "自动分配到" : "人工切换到";
     await this.options.sessions.upsertAgentTraceEvent({
       id: randomUUID(),
       sessionKey: session.key,
@@ -1239,11 +1258,12 @@ export class AdminService {
       at: now,
       sequence,
       title: "Auth Profile 已切换",
-      summary: `人工切换到 ${profileName}，继续处理待处理消息`,
-      detail: JSON.stringify({ profileName }, null, 2),
+      summary: `${actionLabel} ${profileName}，继续处理待处理消息`,
+      detail: JSON.stringify({ profileName, selectionMode }, null, 2),
       status: "completed",
       metadata: {
-        profileName
+        profileName,
+        selectionMode
       },
       createdAt: now,
       updatedAt: now

--- a/test/admin-auth-profile-display.test.ts
+++ b/test/admin-auth-profile-display.test.ts
@@ -12,63 +12,90 @@ import {
 describe("admin auth profile display", () => {
   it("uses the account identity instead of the internal profile name", () => {
     const now = new Date("2026-05-09T00:00:00.000Z");
+    const fiveHours = Math.floor((now.getTime() + 5 * 60 * 60 * 1000) / 1000);
     const sevenDays = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
     const profile = authProfile({
       name: "575d9997-db66-4b21-979d-4d3b9597b36e",
       email: "hejiachen@toeverything.info",
       planType: "prolite",
       primaryUsed: 4,
+      primaryResetsAt: fiveHours,
       secondaryUsed: 36,
       secondaryResetsAt: sevenDays
     });
 
     expect(profileAccountLabel(profile)).toBe("hejiachen@toeverything.info");
     expect(profileDisplayLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite");
-    expect(profileQuotaLabel(profile, { now })).toBe("64% | 0.64");
-    expect(profileWeeklyQuotaLabel(profile, { now })).toBe("64% | 0.64");
-    expect(profileOptionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 64% | 0.64");
+    expect(profileQuotaLabel(profile, { now })).toBe("7d 64% / 0.64");
+    expect(profileWeeklyQuotaLabel(profile, { now })).toBe("7d 64% / 0.64");
+    expect(profileOptionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 7d 64% / 0.64");
     expect(profileTitle(profile, { now })).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
   });
 
-  it("shows weighted weekly quota normalized by reset time", () => {
+  it("shows weighted quota normalized by each window reset time", () => {
     const now = new Date("2026-05-09T00:00:00.000Z");
     const daysFromNow = (days: number) => Math.floor((now.getTime() + days * 24 * 60 * 60 * 1000) / 1000);
+    const hoursFromNow = (hours: number) => Math.floor((now.getTime() + hours * 60 * 60 * 1000) / 1000);
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "full-week",
       email: "full@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 0,
       secondaryResetsAt: daysFromNow(7)
-    }), { now })).toBe("100% | 1");
+    }), { now })).toBe("7d 100% / 1");
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "half-half-week",
       email: "half@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 50,
       secondaryResetsAt: daysFromNow(3.5)
-    }), { now })).toBe("50% | 1");
+    }), { now })).toBe("7d 50% / 1");
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "full-half-week",
       email: "fast@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 0,
       secondaryResetsAt: daysFromNow(3.5)
-    }), { now })).toBe("100% | 2");
+    }), { now })).toBe("7d 100% / 2");
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "slow",
       email: "slow@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 43,
       secondaryResetsAt: daysFromNow(12)
-    }), { now })).toBe("57% | 0.33");
+    }), { now })).toBe("7d 57% / 0.33");
+
+    expect(profileQuotaLabel(authProfile({
+      name: "short-window-remaining-low-but-reset-soon",
+      email: "short-soon@example.com",
+      planType: "pro",
+      primaryUsed: 70,
+      primaryResetsAt: hoursFromNow(1),
+      secondaryUsed: 50,
+      secondaryResetsAt: daysFromNow(7)
+    }), { now })).toBe("7d 50% / 0.5");
+
+    expect(profileQuotaLabel(authProfile({
+      name: "short-window-pressure",
+      email: "short@example.com",
+      planType: "pro",
+      primaryUsed: 70,
+      primaryResetsAt: hoursFromNow(5),
+      secondaryUsed: 50,
+      secondaryResetsAt: daysFromNow(7)
+    }), { now })).toBe("7d 50% / 0.5 | 5h 30% / 0.3");
   });
 
   it("keeps unusable profiles readable without presenting their UUID as the label", () => {
@@ -94,6 +121,7 @@ function authProfile(options: {
   readonly email: string;
   readonly planType: string;
   readonly primaryUsed: number;
+  readonly primaryResetsAt?: number | undefined;
   readonly secondaryUsed: number;
   readonly secondaryResetsAt?: number | undefined;
 }): Record<string, any> {
@@ -114,7 +142,7 @@ function authProfile(options: {
         primary: {
           usedPercent: options.primaryUsed,
           windowDurationMins: 300,
-          resetsAt: 1_779_000_000
+          resetsAt: options.primaryResetsAt ?? 1_779_000_000
         },
         secondary: {
           usedPercent: options.secondaryUsed,

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -249,6 +249,83 @@ describe("admin control plane e2e", () => {
     });
   });
 
+  it("auto-allocates a blocked session auth profile and asks the worker to resume pending dispatch", async () => {
+    const workerResumePaths: string[] = [];
+    const worker = http.createServer((request, response) => {
+      workerResumePaths.push(request.url ?? "");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, resumedCount: 1 }));
+    });
+    await new Promise<void>((resolve) => worker.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        worker.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    });
+    const address = worker.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start worker fixture");
+    }
+
+    const { baseUrl, sessions } = await startAdminFixture({
+      workerBaseUrl: `http://127.0.0.1:${address.port}`,
+      authProfilesStatus: authProfilesStatusFixture()
+    });
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "old-thread");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "old-turn");
+    session = await sessions.setSessionAuthProfile(session.key, "empty-profile", {
+      boundAt: "2026-05-09T00:00:00.000Z"
+    });
+    await sessions.markSessionAuthBlocked(session.key, {
+      reason: "primary_quota_exhausted",
+      blockedAt: "2026-05-09T01:00:00.000Z"
+    });
+
+    const result = await postJson(
+      `${baseUrl}/admin/api/sessions/${encodeURIComponent(session.key)}/auth-profile`,
+      { mode: "auto" }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      selectedMode: "auto",
+      selectedProfileName: "usable-profile",
+      workerResume: {
+        ok: true,
+        resumedCount: 1
+      },
+      session: {
+        key: session.key,
+        authProfileName: "usable-profile",
+        authBlockedAt: null,
+        agentSessionId: null,
+        activeTurnId: null
+      }
+    });
+    expect(workerResumePaths).toEqual([
+      `/slack/sessions/${encodeURIComponent(session.key)}/resume-pending`
+    ]);
+    expect(sessions.getSessionByKey(session.key)).toMatchObject({
+      authProfileName: "usable-profile",
+      authBlockedAt: undefined,
+      authBlockReason: undefined,
+      agentSessionId: undefined,
+      activeTurnId: undefined
+    });
+    expect(sessions.listAgentTraceEvents(session.key, 10).at(-1)).toMatchObject({
+      title: "Auth Profile 已切换",
+      summary: "自动分配到 usable-profile，继续处理待处理消息",
+      metadata: {
+        profileName: "usable-profile",
+        selectionMode: "auto"
+      }
+    });
+  });
+
   it("exposes a tracked session reset operation and delegates history clearing to the worker", async () => {
     const workerPaths: string[] = [];
     let sessionsRef: SessionManager | undefined;

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -269,6 +269,8 @@ describe("admin routes", () => {
     expect(sessionViewSource).toContain("ongoing");
     expect(adminClientSource).toContain("authProfileQuotaItems");
     expect(adminClientSource).toContain("profileTooltip");
+    expect(sessionViewSource).toContain("自动分配");
+    expect(sessionViewSource).toContain('mode: "auto"');
     expect(adminClientSource).not.toContain("renderAccountChip");
     expect(adminClientSource).not.toContain("refreshButton");
     expect(adminClientSource).not.toContain("lastRefresh");
@@ -284,13 +286,15 @@ describe("admin routes", () => {
     expect(adminCssSource).toContain("text-overflow: ellipsis");
     expect(adminCssSource).toContain("overflow-x: auto");
     expect(adminCssSource).toContain("flex: 0 0 auto");
+    expect(adminCssSource).toContain("grid-auto-rows: max-content");
+    expect(adminCssSource).toContain("align-content: start");
     expect(adminCssSource).toContain("html, body { width: 100%; height: 100%; overflow: hidden; }");
     expect(adminCssSource).toContain(".shell { width: 100%; height: 100dvh;");
     expect(adminCssSource).toContain("grid-template-columns: minmax(320px, 420px)");
     expect(adminCssSource).toContain(".session-detail-panel > .panel-body");
     expect(adminCssSource).toContain(".session-body { flex: 1; min-height: 0; overflow: hidden;");
     expect(adminCssSource).toContain(".session-timeline-panel .mini-body { flex: 1; min-height: 0; overflow: hidden;");
-    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; gap: 0; overflow: auto;");
+    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; grid-auto-rows: max-content; align-content: start;");
     expect(adminCssSource).toContain(".session-card { display: block; overflow: hidden; }");
     expect(adminCssSource).toContain(".session-meta-line { display: flex; gap: 4px; align-items: center; flex-wrap: nowrap;");
     expect(adminCssSource).toContain(".session-meta-pill { min-width: 0; max-width: 100%; flex: 0 1 auto;");
@@ -468,6 +472,44 @@ describe("admin routes", () => {
       {
         slackUserId: "U123",
         githubAuthor: "Alice Example <alice@example.com>"
+      }
+    ]);
+  });
+
+  it("forwards automatic session auth profile switches without requiring a profile name", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      getStatus: async () => ({ ok: true }),
+      addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      deployRelease: async () => ({ ok: true }),
+      rollbackRelease: async () => ({ ok: true }),
+      switchSessionAuthProfile: async (payload: Record<string, unknown>) => {
+        calls.push(payload);
+        return { ok: true };
+      }
+    });
+
+    const response = await fetch(`${baseUrl}/admin/api/sessions/${encodeURIComponent("C123:111.222")}/auth-profile`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        mode: "auto"
+      })
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([
+      {
+        sessionKey: "C123:111.222",
+        mode: "auto"
       }
     ]);
   });

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -307,7 +307,7 @@ describe("admin session row display", () => {
     }, authProfiles, new Map([["C123", "#ops"]]));
     const labels = meta.map((item) => item.label);
 
-    expect(labels).toEqual(["#ops", "64% | 0.64", "Token 5.1K"]);
+    expect(labels).toEqual(["#ops", "7d 64% / 0.64", "Token 5.1K"]);
     expect(labels.join(" ")).not.toContain("hejiachen@toeverything.info");
     expect(labels.join(" ")).not.toContain("Pro Lite");
     expect(shouldShowSessionState({ rank: 10 })).toBe(false);

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -286,7 +286,7 @@ describe("admin token usage e2e", () => {
           <AuthProfilePanel`);
     expect(adminCssSource).toContain(".session-body { flex: 1; min-height: 0; overflow: hidden;");
     expect(adminCssSource).toContain(".session-timeline-panel .mini-body { flex: 1; min-height: 0; overflow: hidden;");
-    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; gap: 0; overflow: auto;");
+    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; grid-auto-rows: max-content; align-content: start;");
     expect(sessionViewSource).not.toContain("SessionHeaderPill");
     expect(sessionViewSource).not.toContain("session-detail-meta-strip");
     expect(adminCssSource).not.toContain(".session-permalink-panel .timeline");


### PR DESCRIPTION
## Summary
- add an automatic allocation mode to the session auth-profile switch endpoint
- reuse the existing weighted quota selector so manual recovery can rebind to the best usable account
- expose 自动分配 in the session account dialog and default blocked sessions to that choice

## Validation
- pnpm build
- pnpm test (final rerun passed 49 files / 261 tests)

## Notes
- an earlier full-suite run hit two unrelated 5s timeout flakes in app-server-process/job-manager; rerunning the suite passed completely.