### PR TITLE
[codex] Allow direct Slack author mappings

### DIFF
--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -24,7 +24,7 @@ Slack broker API usage for this session:
 - Register a broker-managed background job with: {{register_job_command}}
 - Inspect the current session's co-author status with: {{coauthor_status_command}}
 - Configure the current session's co-authors/mappings with: {{coauthor_configure_command}}
-- The co-author configure endpoint accepts current-session contributors by Slack user id, @mention, display name, real name, username, or email, plus optional GitHub author mappings.
+- The co-author configure endpoint accepts current-session contributors by Slack user id, @mention, display name, real name, username, or email; direct `slack_user_id` mapping entries may target any Slack user id or @mention.
 - Prefer absolute file_path values when uploading local artifacts.
 - Registered background jobs receive environment variables including BROKER_JOB_ID, BROKER_JOB_TOKEN, BROKER_API_BASE, BROKER_JOB_HELPER, SLACK_CHANNEL_ID, SLACK_THREAD_TS, SESSION_KEY, SESSION_WORKSPACE, and REPOS_ROOT.
 - Inside a background job script, prefer `node "$BROKER_JOB_HELPER" ...` for heartbeat/event/complete/fail/cancel callbacks instead of hand-writing nested curl JSON payloads.

--- a/src/services/codex/slack-thread-base-instructions.ts
+++ b/src/services/codex/slack-thread-base-instructions.ts
@@ -64,6 +64,10 @@ export async function buildSlackThreadBaseInstructions(
       {
         slack_user: "Alice Example",
         github_author: "Alice Example <alice@example.com>"
+      },
+      {
+        slack_user_id: "<@U12345678>",
+        github_author: "Bot Reviewer <bot@example.com>"
       }
     ]
   });

--- a/src/services/slack/slack-coauthor-service.ts
+++ b/src/services/slack/slack-coauthor-service.ts
@@ -668,12 +668,8 @@ export class SlackCoauthorService {
     readonly githubAuthor: string;
   }> {
     return (mappings ?? []).map((entry) => {
-      const directUserId = entry.slackUserId?.trim();
+      const directUserId = normalizeDirectSlackUserId(entry.slackUserId);
       if (directUserId) {
-        if (!status.candidates.some((candidate) => candidate.userId === directUserId)) {
-          throw new Error(`Unknown co-author candidate: ${entry.slackUserId}`);
-        }
-
         return {
           slackUserId: directUserId,
           githubAuthor: entry.githubAuthor
@@ -857,4 +853,22 @@ function buildGitHubAuthorHint(
 function normalizeUserReference(value: string | undefined): string | undefined {
   const normalized = value?.trim().toLowerCase();
   return normalized || undefined;
+}
+
+function normalizeDirectSlackUserId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const mention = trimmed.match(/^<@([UW][A-Z0-9]+)(?:\|[^>]+)?>$/i);
+  if (mention?.[1]) {
+    return mention[1];
+  }
+
+  if (/^[UW][A-Z0-9]+$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return undefined;
 }

--- a/test/slack-coauthor-service.test.ts
+++ b/test/slack-coauthor-service.test.ts
@@ -454,4 +454,52 @@ describe("SlackCoauthorService", () => {
     expect(mappings.getMapping("U1")).toBeUndefined();
     expect(mappings.getMapping("U2")).toBeUndefined();
   });
+
+  it("allows direct Slack user ids or mentions in configure-session mappings outside the co-author candidates", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-coauthor-sessions-"));
+    tempDirs.push(stateDir, sessionsRoot);
+
+    const sessions = new SessionManager({
+      stateStore: new StateStore(stateDir, sessionsRoot),
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C777", "222.333");
+    const mappings = new GitHubAuthorMappingService({ stateDir });
+    await mappings.load();
+
+    const service = new SlackCoauthorService({
+      sessions,
+      mappings,
+      slackApi: {
+        getUserIdentity: vi.fn(async (userId: string) => ({
+          userId,
+          mention: `<@${userId}>`,
+          realName: userId === "U3720" ? "codex-3720" : userId
+        })),
+        postEphemeral: vi.fn(),
+        openView: vi.fn()
+      } as never
+    });
+
+    await service.configureSessionCoauthors({
+      cwd: session.workspacePath,
+      mappings: [
+        {
+          slackUserId: "<@U3720>",
+          githubAuthor: "3720 Bot <bot@example.com>"
+        }
+      ]
+    });
+
+    expect(mappings.getMapping("U3720")).toMatchObject({
+      slackUserId: "U3720",
+      githubAuthor: "3720 Bot <bot@example.com>",
+      source: "manual",
+      slackIdentity: {
+        realName: "codex-3720"
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow `configure-session` GitHub author mappings to target any direct Slack user id or @mention, not only existing co-author candidates
- normalize direct Slack mentions before storing manual mappings
- document the direct `slack_user_id` mapping path in generated Slack broker instructions

## Tests
- `npm exec --yes pnpm@10.33.0 -- vitest run test/slack-coauthor-service.test.ts test/app-server-client.test.ts`
- `npm exec --yes pnpm@10.33.0 -- build`
- Manual: instantiated the built `SlackCoauthorService` and verified a `<@U3720>` mapping stores as `U3720`
