### PR TITLE
Bind GitHub PR identity to session starter

### DIFF
--- a/docs/session-github-pr-identity.md
+++ b/docs/session-github-pr-identity.md
@@ -1,0 +1,118 @@
+# Session GitHub PR Identity
+
+## Goal
+
+Use the Slack user who starts a broker session as the preferred GitHub identity
+for PR creation from that session.
+
+The session starter is the first human Slack user who causes the broker to create
+the session by mentioning the bot or sending a direct message. Later thread
+participants do not change the session starter.
+
+## Non-Goals
+
+- Do not replace the existing commit co-author system.
+- Do not expose GitHub tokens to the agent prompt, trace, logs, or session UI.
+- Do not make an unbound GitHub account block session startup.
+- Do not silently fall back to the default GitHub account when a bound starter
+  token is revoked or lacks access.
+
+## Current State
+
+The broker already tracks Slack session workspaces and can resolve a workspace
+back to a session. It also has a Slack user to GitHub author mapping for commit
+co-author trailers. That mapping is not a GitHub account credential and cannot
+control the GitHub account used by `gh pr create`.
+
+The PR author is determined by the GitHub token used by the `gh` command. The
+correct control point is therefore broker-managed GitHub credentials, not prompt
+guidance or git commit author configuration.
+
+## Data Model
+
+`SlackSessionRecord` gains:
+
+- `initiatorUserId`: Slack user id that started the session.
+- `initiatorMessageTs`: Slack message timestamp that started the session.
+- `initiatorCapturedAt`: timestamp when the broker recorded the initiator.
+
+GitHub OAuth binding records are keyed by Slack user id:
+
+- `slackUserId`
+- `githubLogin`
+- `githubUserId`
+- `token`
+- `scopes`
+- `createdAt`
+- `updatedAt`
+- `lastValidatedAt`
+- `revokedAt`
+
+The default GitHub PR identity is configured separately and is visible to users
+when a session starter is unbound.
+
+## Session Link Behavior
+
+When the broker posts the session detail link:
+
+- If the starter has a valid GitHub OAuth binding, the link message can stay
+  compact.
+- If the starter is not bound, the link message must say that PRs will use the
+  default GitHub account and include a binding link.
+- This reminder is sent at session startup, not delayed until PR creation.
+- The reminder is sent once with the session link and must not repeat every turn.
+
+Example:
+
+```text
+Session 页面：https://...
+
+当前发起人还没有绑定 GitHub 账号。
+不绑定时，后续创建 PR 会使用默认账号 zzj3720。
+绑定 GitHub：https://.../session/<key>/github/bind
+```
+
+## OAuth Flow
+
+The session page exposes a GitHub identity panel. For an unbound starter it shows
+the starter, the default GitHub account, and a bind action.
+
+Binding uses GitHub device code OAuth:
+
+1. Start device flow.
+2. Show verification URL and user code.
+3. Poll for completion.
+4. Verify the resulting token against GitHub `/user`.
+5. Persist the token under the Slack starter user id.
+6. Refresh the session page state.
+
+## Runtime PR Identity Resolution
+
+The Codex app-server runtime receives a broker-managed `gh` wrapper before the
+real `gh` in `PATH`.
+
+The wrapper:
+
+1. Resolves `cwd` to a Slack session through the broker.
+2. Resolves the session starter's GitHub binding.
+3. Uses the starter token when present and valid.
+4. Uses the default GitHub token only when the starter is unbound.
+5. Blocks when the starter has a binding but that token is invalid or lacks
+   access.
+6. Execs the real `gh` with `GH_TOKEN` set.
+
+The wrapper must never print or log tokens.
+
+## Acceptance Criteria
+
+- A first `@bot` from `U_A` creates a session whose initiator remains `U_A`.
+- A later thread reply from `U_B` does not change the initiator.
+- The session link message includes an unbound GitHub warning and bind link when
+  `U_A` has no binding.
+- The session link message does not include the warning when `U_A` is bound.
+- Device code OAuth can bind `U_A` to a GitHub login.
+- Running `gh` inside the session workspace uses `U_A`'s token when bound.
+- Running `gh` inside the session workspace uses the default token when `U_A` is
+  unbound and the default is available.
+- A revoked or invalid bound token blocks instead of silently using the default.
+- Existing commit co-author behavior continues to work.

--- a/src/admin-index.ts
+++ b/src/admin-index.ts
@@ -11,6 +11,7 @@ import { ReleaseDeploymentService } from "./services/deploy/release-deployment-s
 import {
   configureServiceLogger,
   createGitHubAuthorMappings,
+  createGitHubPrIdentity,
   createSessionServices,
   createSlackApi
 } from "./services/service-components.js";
@@ -28,6 +29,7 @@ export async function startAdminService(): Promise<{
     config
   });
   const githubAuthorMappings = await createGitHubAuthorMappings(config);
+  const githubPrIdentity = await createGitHubPrIdentity(config);
   const deployment = createReleaseDeploymentService(config);
   const runtime = new AuthFileRuntimeControl(config, {
     onRestart: async (reason) => {
@@ -43,6 +45,7 @@ export async function startAdminService(): Promise<{
     runtime,
     authProfiles,
     githubAuthorMappings,
+    githubPrIdentity,
     startedAt,
     deployment,
     slackConversations: createSlackApi(config)

--- a/src/admin-ui/admin-legacy.js
+++ b/src/admin-ui/admin-legacy.js
@@ -185,13 +185,52 @@ export function initAdminPage(options = {}) {
       if (!Number.isFinite(seconds)) return null;
       return Math.max(((seconds * 1000) - Date.now()) / 86400000, 1 / (24 * 60));
     }
+    function msUntilReset(resetsAt) {
+      const seconds = Number(resetsAt);
+      if (!Number.isFinite(seconds)) return null;
+      return Math.max((seconds * 1000) - Date.now(), 60000);
+    }
     function weightedWeeklyQuotaScore(remaining, refreshDays) {
       if (remaining == null) return null;
       return (remaining / 100) / ((refreshDays || 7) / 7);
     }
+    function weightedQuotaWindowScore(remaining, limit, fallbackWindowMins) {
+      if (remaining == null) return null;
+      const windowMins = normalizeWindowDurationMins(limit?.windowDurationMins, fallbackWindowMins);
+      const resetMs = msUntilReset(limit?.resetsAt) || windowMins * 60000;
+      return (remaining / 100) / (resetMs / (windowMins * 60000));
+    }
     function formatWeightedWeeklyQuotaScore(score) {
       if (!Number.isFinite(Number(score))) return "0";
       return Number(score).toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1");
+    }
+    function normalizeWindowDurationMins(value, fallback) {
+      const mins = Number(value);
+      return Number.isFinite(mins) && mins > 0 ? mins : fallback;
+    }
+    function formatWindowDuration(windowMins) {
+      if (windowMins % 1440 === 0) return (windowMins / 1440) + "d";
+      if (windowMins % 60 === 0) return (windowMins / 60) + "h";
+      return windowMins + "m";
+    }
+    function quotaWindowDisplay(limit, fallbackWindowMins) {
+      const remaining = remainingPercent(limit?.usedPercent);
+      if (remaining == null) return null;
+      const windowMins = normalizeWindowDurationMins(limit?.windowDurationMins, fallbackWindowMins);
+      const score = weightedQuotaWindowScore(remaining, limit, windowMins);
+      return formatWindowDuration(windowMins) + " " + Math.round(remaining) + "% / " + formatWeightedWeeklyQuotaScore(score);
+    }
+    function authQuotaDisplay(rateLimits) {
+      const primary = rateLimits?.primary;
+      const primaryRemaining = remainingPercent(primary?.usedPercent);
+      const primaryScore = weightedQuotaWindowScore(primaryRemaining, primary, 300);
+      const shortLabel = Number.isFinite(Number(primaryScore)) && Number(primaryScore) < 0.5
+        ? quotaWindowDisplay(primary, 300)
+        : null;
+      return [
+        quotaWindowDisplay(rateLimits?.secondary, 10080),
+        shortLabel
+      ].filter(Boolean).join(" | ") || null;
     }
     function weeklyQuotaDisplay(limit) {
       const remaining = remainingPercent(limit?.usedPercent);
@@ -219,11 +258,11 @@ export function initAdminPage(options = {}) {
       if (plan === "chatgpt") return "ChatGPT";
       return plan;
     }
-    function profileTooltip(profile, weeklyLabel, secondary) {
+    function profileTooltip(profile, quotaLabel, secondary) {
       return [
         profileAccountLabel(profile),
         profilePlanLabel(profile),
-        weeklyLabel ? "周额度 " + weeklyLabel : "",
+        quotaLabel ? "额度 " + quotaLabel : "",
         secondary ? "周重置 " + formatResetTime(secondary.resetsAt) : "",
         profile.name ? "内部标识 " + profile.name : ""
       ].filter(Boolean).join(" · ");
@@ -234,7 +273,7 @@ export function initAdminPage(options = {}) {
           const rateLimits = profile.rateLimits || {};
           if (rateLimits.ok === false) return null;
           const secondary = rateLimits.rateLimits?.secondary;
-          const label = weeklyQuotaDisplay(secondary);
+          const label = authQuotaDisplay(rateLimits.rateLimits);
           if (!label) return null;
           const remaining = remainingPercent(secondary?.usedPercent);
           const score = weeklyQuotaScore(secondary);
@@ -504,9 +543,9 @@ export function initAdminPage(options = {}) {
       if (!rateLimits || !rateLimits.ok) return '<div class="summary-detail">' + esc(rateLimits?.error || "额度不可用") + '</div>';
       const snapshot = rateLimits.rateLimits || {};
       const secondary = snapshot.secondary;
-      const weeklyLabel = weeklyQuotaDisplay(secondary);
+      const quotaLabel = authQuotaDisplay(snapshot);
       return '<div class="quota-grid">' +
-        '<div class="quota-line"><span>周额度</span><strong>' + esc(weeklyLabel || "--") + '</strong><span>' + esc(secondary ? formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
+        '<div class="quota-line"><span>额度</span><strong>' + esc(quotaLabel || "--") + '</strong><span>' + esc(secondary ? "周 " + formatResetTime(secondary.resetsAt) : "不可用") + '</span></div>' +
       '</div>';
     }
     function renderAuthProfiles(data) {

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -130,6 +130,10 @@
     .meta-line.warn strong { color: var(--amber); }
     .meta-line.danger strong { color: var(--red); }
     .auth-profile-panel { display: grid; gap: 6px; min-width: 0; }
+    .github-identity-panel { display: grid; gap: 5px; min-width: 0; }
+    .github-bind-button { justify-content: center; width: 100%; min-width: 0; }
+    .github-identity-panel .device-code-panel { padding: 6px; }
+    .github-identity-panel .device-code-panel .link-button { justify-content: center; }
     .auth-profile-compact-button { display: inline-flex; justify-content: center; align-items: center; min-width: 76px; padding: 2px 7px; border-color: var(--cyan); background: transparent; color: var(--cyan); font-weight: 700; white-space: nowrap; }
     .session-side-column .auth-profile-compact-button { width: 100%; }
     .auth-profile-compact-button.danger { border-color: var(--red); color: var(--red); }

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -142,7 +142,7 @@
     .auth-profile-label { color: var(--muted); font-size: 10px; white-space: nowrap; }
 
     .session-timeline-panel .mini-body { flex: 1; min-height: 0; overflow: hidden; padding: 0; }
-    .timeline { height: 100%; display: grid; gap: 0; overflow: auto; border: 0; }
+    .timeline { height: 100%; display: grid; grid-auto-rows: max-content; align-content: start; gap: 0; overflow: auto; border: 0; }
     .timeline-event { display: grid; grid-template-columns: 72px 90px minmax(0, 1fr); gap: 6px; align-items: start; padding: 4px 6px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 10px; }
     .timeline-event:last-child { border-bottom: 0; }
     .timeline-main { min-width: 0; }

--- a/src/admin-ui/auth-profile-display.ts
+++ b/src/admin-ui/auth-profile-display.ts
@@ -1,4 +1,4 @@
-import { formatWeeklyQuotaDisplay } from "../auth-profile-quota.js";
+import { formatAuthQuotaDisplay } from "../auth-profile-quota.js";
 
 type AuthProfileRecord = Record<string, any>;
 interface QuotaLabelOptions {
@@ -66,12 +66,12 @@ export function profileQuotaLabel(profile: AuthProfileRecord, options: QuotaLabe
   }
 
   const limits = rateLimits.rateLimits || {};
-  const label = formatWeeklyQuotaDisplay({
-    usedPercent: limits.secondary?.usedPercent,
-    resetsAt: limits.secondary?.resetsAt,
+  const label = formatAuthQuotaDisplay({
+    primary: limits.primary,
+    secondary: limits.secondary,
     now: options.now
   });
-  return label ?? "周额度未知";
+  return label ?? "额度未知";
 }
 
 export function profileWeeklyQuotaLabel(profile: AuthProfileRecord, options: QuotaLabelOptions = {}): string {
@@ -81,11 +81,11 @@ export function profileWeeklyQuotaLabel(profile: AuthProfileRecord, options: Quo
   }
 
   const limits = rateLimits.rateLimits || {};
-  return formatWeeklyQuotaDisplay({
-    usedPercent: limits.secondary?.usedPercent,
-    resetsAt: limits.secondary?.resetsAt,
+  return formatAuthQuotaDisplay({
+    primary: limits.primary,
+    secondary: limits.secondary,
     now: options.now
-  }) ?? "周额度未知";
+  }) ?? "额度未知";
 }
 
 function readString(value: unknown): string | null {

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -363,6 +363,7 @@ function SessionActions({ session, profiles, currentProfile, isPermalink }: {
   return (
     <div className="side-action-stack">
       <AuthProfilePanel session={session} profiles={profiles} currentProfile={currentProfile} />
+      <GitHubIdentityPanel session={session} />
       <SessionResetButton session={session} />
       <div className="side-link-grid">
         {!isPermalink ? (
@@ -374,6 +375,156 @@ function SessionActions({ session, profiles, currentProfile, isPermalink }: {
           <a className="link-button" href={session.threadUrl} target="_blank" rel="noreferrer">打开 Slack Thread</a>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function GitHubIdentityPanel({ session }: {
+  readonly session: SessionRecord;
+}): React.JSX.Element {
+  const sessionKey = String(session.key || "");
+  const [identity, setIdentity] = useState<Record<string, any> | null>(null);
+  const [device, setDevice] = useState<Record<string, any> | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const autoStartRef = useRef(false);
+  const shouldAutoStart = typeof window !== "undefined" && window.location.pathname.endsWith("/github/bind");
+  const binding = identity?.binding || {};
+  const defaultAccount = identity?.defaultAccount || {};
+
+  async function refreshIdentity(): Promise<Record<string, any> | null> {
+    if (!sessionKey) {
+      return null;
+    }
+    const payload = await requestJson(githubIdentityApiPath(sessionKey)) as Record<string, any>;
+    const nextIdentity = payload.identity as Record<string, any>;
+    setIdentity(nextIdentity);
+    return nextIdentity;
+  }
+
+  async function startDeviceAuthorization(): Promise<void> {
+    if (!sessionKey || busy) {
+      return;
+    }
+    setBusy(true);
+    setMessage(null);
+    try {
+      const payload = await requestJson(githubDeviceStartApiPath(sessionKey), {
+        method: "POST"
+      }) as Record<string, any>;
+      setDevice(payload.device as Record<string, any>);
+      setMessage("打开 GitHub 设备码页面，输入下面的代码完成绑定。");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    setIdentity(null);
+    setDevice(null);
+    setMessage(null);
+    autoStartRef.current = false;
+    void refreshIdentity()
+      .catch((error: unknown) => {
+        if (!cancelled) setMessage(error instanceof Error ? error.message : String(error));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionKey]);
+
+  useEffect(() => {
+    if (!shouldAutoStart || autoStartRef.current || !identity || binding.state !== "unbound") {
+      return;
+    }
+    autoStartRef.current = true;
+    void startDeviceAuthorization();
+  }, [shouldAutoStart, identity, binding.state]);
+
+  useEffect(() => {
+    if (!device?.id) {
+      return;
+    }
+    let cancelled = false;
+    let timeout: number | undefined;
+    async function poll(): Promise<void> {
+      try {
+        const payload = await requestJson(githubDevicePollApiPath(String(device.id))) as Record<string, any>;
+        const result = payload.result as Record<string, any>;
+        if (cancelled) return;
+        if (result.status === "completed") {
+          setDevice(null);
+          setMessage("GitHub 账号已绑定。");
+          await refreshIdentity();
+          return;
+        }
+        if (result.status === "expired") {
+          setMessage("设备码已过期，请重新发起绑定。");
+          setDevice(null);
+          return;
+        }
+        if (result.status === "failed") {
+          setMessage(String(result.error || "绑定失败"));
+          setDevice(null);
+          return;
+        }
+        timeout = window.setTimeout(
+          () => { void poll(); },
+          Math.max(1, Number(result.retryAfterSeconds || device.intervalSeconds || 5)) * 1000
+        );
+      } catch (error) {
+        if (!cancelled) setMessage(error instanceof Error ? error.message : String(error));
+      }
+    }
+    timeout = window.setTimeout(() => { void poll(); }, 800);
+    return () => {
+      cancelled = true;
+      if (timeout !== undefined) window.clearTimeout(timeout);
+    };
+  }, [device?.id]);
+
+  return (
+    <div className="github-identity-panel">
+      {identity ? (
+        <div className="meta-list">
+          {binding.state === "bound" ? (
+            <MetaLine label="PR 账号" value={String(binding.githubLogin || "--")} tone="good" />
+          ) : binding.state === "revoked" ? (
+            <MetaLine label="PR 账号" value="绑定失效" detail={String(binding.githubLogin || "")} tone="danger" />
+          ) : binding.state === "unbound" && defaultAccount.available ? (
+            <MetaLine label="PR 默认" value={String(defaultAccount.githubLogin || "--")} detail="发起人未绑定" tone="warn" />
+          ) : binding.state === "unbound" ? (
+            <MetaLine label="PR 账号" value="未绑定" detail="没有默认账号" tone="danger" />
+          ) : (
+            <MetaLine label="PR 账号" value="未记录发起人" tone="danger" />
+          )}
+        </div>
+      ) : (
+        <div className="summary-detail">GitHub 绑定状态加载中</div>
+      )}
+      {binding.state === "unbound" || binding.state === "revoked" ? (
+        <button
+          type="button"
+          className="link-button github-bind-button"
+          disabled={busy || !sessionKey}
+          onClick={() => { void startDeviceAuthorization(); }}
+        >
+          {busy ? "正在发起绑定" : "绑定发起人的 GitHub"}
+        </button>
+      ) : null}
+      {device ? (
+        <div className="device-code-panel">
+          <div className="device-code-label">GitHub 设备码</div>
+          <div className="code-block">{String(device.userCode || "")}</div>
+          <a className="link-button" href={String(device.verificationUriComplete || device.verificationUri || "https://github.com/login/device")} target="_blank" rel="noreferrer">
+            打开 GitHub 验证页
+          </a>
+        </div>
+      ) : null}
+      {message ? <div className="summary-detail">{message}</div> : null}
     </div>
   );
 }
@@ -1032,6 +1183,18 @@ async function requestJson(path: string, init?: RequestInit): Promise<unknown> {
 
 function sessionTimelineApiPath(sessionKey: string): string {
   return "/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/timeline";
+}
+
+function githubIdentityApiPath(sessionKey: string): string {
+  return "/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/github-identity";
+}
+
+function githubDeviceStartApiPath(sessionKey: string): string {
+  return "/admin/api/sessions/" + encodeURIComponent(sessionKey) + "/github-oauth/device/start";
+}
+
+function githubDevicePollApiPath(deviceAuthorizationId: string): string {
+  return "/admin/api/github-oauth/device/" + encodeURIComponent(deviceAuthorizationId);
 }
 
 function adminSessionPath(sessionKey: string): string {

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -40,6 +40,7 @@ type TimelinePayload = {
 } | TimelineEvent[];
 
 const sessionFilters = ["ongoing", "all", "active", "inbound", "jobs", "issues", "usage"];
+const AUTO_AUTH_PROFILE_VALUE = "__auto_auth_profile__";
 
 export function AdminSessionsView(): React.JSX.Element {
   const permalinkSessionKey = readPermalinkSessionKey();
@@ -577,7 +578,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
   readonly currentProfile?: SessionRecord | undefined;
 }): React.JSX.Element {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
-  const [selected, setSelected] = useState(String(session.authProfileName || ""));
+  const [selected, setSelected] = useState(() => initialAuthProfileSelection(session));
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const currentProfile = providedCurrentProfile ?? profiles.find((profile) => profile.name === session.authProfileName);
@@ -588,7 +589,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
   const compactLabel = currentProfile ? profileQuotaLabel(currentProfile) : (blocked ? "账号不可用" : "账号");
 
   useEffect(() => {
-    setSelected(String(session.authProfileName || ""));
+    setSelected(initialAuthProfileSelection(session));
     setMessage(null);
   }, [session.key, session.authProfileName, session.authBlockedAt]);
 
@@ -613,7 +614,8 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
   }
 
   async function switchProfile(): Promise<void> {
-    if (!selected || selected === session.authProfileName) {
+    const autoSelected = selected === AUTO_AUTH_PROFILE_VALUE;
+    if (!autoSelected && (!selected || selected === session.authProfileName)) {
       return;
     }
 
@@ -623,11 +625,11 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
       await requestJson("/admin/api/sessions/" + encodeURIComponent(String(session.key || "")) + "/auth-profile", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ name: selected })
+        body: JSON.stringify(autoSelected ? { mode: "auto" } : { name: selected })
       });
       const timelinePayload = await requestJson(sessionTimelineApiPath(String(session.key || "")));
       publishTimelinePayload(String(session.key || ""), timelinePayload as TimelinePayload);
-      setMessage("已切换，正在恢复待处理消息");
+      setMessage(autoSelected ? "已自动分配，正在恢复待处理消息" : "已切换，正在恢复待处理消息");
     } catch (error) {
       setMessage(error instanceof Error ? error.message : String(error));
     } finally {
@@ -653,7 +655,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
           </div>
           {currentProfile ? (
             <div className="auth-profile-dialog-current">
-              <span>周额度</span>
+              <span>额度</span>
               <strong>{profileQuotaLabel(currentProfile)}</strong>
             </div>
           ) : null}
@@ -671,6 +673,7 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
               onChange={(event) => setSelected(event.target.value)}
             >
               <option value="">选择账号</option>
+              <option value={AUTO_AUTH_PROFILE_VALUE}>自动分配（按额度规则）</option>
               {profiles.map((profile) => (
                 <option key={profile.name} value={profile.name} disabled={!profileIsSelectable(profile)}>
                   {profileOptionLabel(profile)}
@@ -680,10 +683,10 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
             <button
               type="button"
               className="link-button"
-              disabled={busy || !selected || selected === session.authProfileName}
+              disabled={busy || (selected !== AUTO_AUTH_PROFILE_VALUE && (!selected || selected === session.authProfileName))}
               onClick={() => { void switchProfile(); }}
             >
-              切换并继续处理
+              {selected === AUTO_AUTH_PROFILE_VALUE ? "自动分配并继续处理" : "切换并继续处理"}
             </button>
           </div>
           {message ? <div className="summary-detail">{message}</div> : null}
@@ -694,6 +697,10 @@ function AuthProfilePanel({ session, profiles, currentProfile: providedCurrentPr
       </dialog>
     </div>
   );
+}
+
+function initialAuthProfileSelection(session: SessionRecord): string {
+  return session.authBlockedAt ? AUTO_AUTH_PROFILE_VALUE : String(session.authProfileName || "");
 }
 
 function TimelinePayloadView({ payload }: { readonly payload: TimelinePayload }): React.JSX.Element {

--- a/src/auth-profile-quota.ts
+++ b/src/auth-profile-quota.ts
@@ -1,5 +1,9 @@
 export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+export const MS_PER_MINUTE = 60 * 1000;
 export const MIN_REFRESH_DAYS = 1 / (24 * 60);
+export const DEFAULT_SHORT_WINDOW_MINS = 300;
+export const DEFAULT_WEEKLY_WINDOW_MINS = 10_080;
+export const SHORT_WINDOW_DISPLAY_SCORE_THRESHOLD = 0.5;
 
 export function remainingPercent(usedPercent: unknown): number | undefined {
   const used = Number(usedPercent);
@@ -23,6 +27,18 @@ export function daysUntilReset(
   return Math.max(deltaDays, MIN_REFRESH_DAYS);
 }
 
+export function msUntilReset(
+  resetsAt: unknown,
+  now: Date | number | string | undefined = undefined
+): number | undefined {
+  const resetSeconds = Number(resetsAt);
+  if (!Number.isFinite(resetSeconds)) {
+    return undefined;
+  }
+
+  return Math.max(resetSeconds * 1000 - timestampMs(now), MS_PER_MINUTE);
+}
+
 export function weightedWeeklyQuotaScore(
   remaining: number | undefined,
   refreshDays: number | undefined
@@ -33,6 +49,25 @@ export function weightedWeeklyQuotaScore(
 
   const days = refreshDays ?? 7;
   return (remaining / 100) / (days / 7);
+}
+
+export function weightedQuotaWindowScore(options: {
+  readonly remaining: number | undefined;
+  readonly resetsAt?: unknown;
+  readonly windowDurationMins?: unknown;
+  readonly fallbackWindowDurationMins: number;
+  readonly now?: Date | number | string | undefined;
+}): number | undefined {
+  if (options.remaining === undefined) {
+    return undefined;
+  }
+
+  const windowMins = normalizeWindowDurationMins(
+    options.windowDurationMins,
+    options.fallbackWindowDurationMins
+  );
+  const resetMs = msUntilReset(options.resetsAt, options.now) ?? windowMins * MS_PER_MINUTE;
+  return (options.remaining / 100) / (resetMs / (windowMins * MS_PER_MINUTE));
 }
 
 export function formatWeeklyQuotaDisplay(options: {
@@ -47,6 +82,84 @@ export function formatWeeklyQuotaDisplay(options: {
 
   const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(options.resetsAt, options.now));
   return `${Math.round(remaining)}% | ${formatWeightedWeeklyQuotaScore(score)}`;
+}
+
+export function formatQuotaWindowDisplay(options: {
+  readonly usedPercent: unknown;
+  readonly resetsAt?: unknown;
+  readonly windowDurationMins?: unknown;
+  readonly fallbackWindowDurationMins: number;
+  readonly now?: Date | number | string | undefined;
+}): string | null {
+  const remaining = remainingPercent(options.usedPercent);
+  if (remaining === undefined) {
+    return null;
+  }
+
+  const windowMins = normalizeWindowDurationMins(
+    options.windowDurationMins,
+    options.fallbackWindowDurationMins
+  );
+  const score = weightedQuotaWindowScore({
+    remaining,
+    resetsAt: options.resetsAt,
+    windowDurationMins: windowMins,
+    fallbackWindowDurationMins: windowMins,
+    now: options.now
+  });
+  return `${formatWindowDuration(windowMins)} ${Math.round(remaining)}% / ${formatWeightedWeeklyQuotaScore(score)}`;
+}
+
+export function formatAuthQuotaDisplay(options: {
+  readonly primary?: {
+    readonly usedPercent?: unknown;
+    readonly resetsAt?: unknown;
+    readonly windowDurationMins?: unknown;
+  } | null | undefined;
+  readonly secondary?: {
+    readonly usedPercent?: unknown;
+    readonly resetsAt?: unknown;
+    readonly windowDurationMins?: unknown;
+  } | null | undefined;
+  readonly now?: Date | number | string | undefined;
+}): string | null {
+  const weekly = formatQuotaWindowDisplay({
+    usedPercent: options.secondary?.usedPercent,
+    resetsAt: options.secondary?.resetsAt,
+    windowDurationMins: options.secondary?.windowDurationMins,
+    fallbackWindowDurationMins: DEFAULT_WEEKLY_WINDOW_MINS,
+    now: options.now
+  });
+  const short = shouldShowShortWindowQuota(options.primary, options.now)
+    ? formatQuotaWindowDisplay({
+        usedPercent: options.primary?.usedPercent,
+        resetsAt: options.primary?.resetsAt,
+        windowDurationMins: options.primary?.windowDurationMins,
+        fallbackWindowDurationMins: DEFAULT_SHORT_WINDOW_MINS,
+        now: options.now
+      })
+    : null;
+  const parts = [weekly, short].filter(Boolean);
+  return parts.length ? parts.join(" | ") : null;
+}
+
+export function shouldShowShortWindowQuota(
+  limit: {
+    readonly usedPercent?: unknown;
+    readonly resetsAt?: unknown;
+    readonly windowDurationMins?: unknown;
+  } | null | undefined,
+  now?: Date | number | string | undefined
+): boolean {
+  const remaining = remainingPercent(limit?.usedPercent);
+  const score = weightedQuotaWindowScore({
+    remaining,
+    resetsAt: limit?.resetsAt,
+    windowDurationMins: limit?.windowDurationMins,
+    fallbackWindowDurationMins: DEFAULT_SHORT_WINDOW_MINS,
+    now
+  });
+  return Number.isFinite(score) && Number(score) < SHORT_WINDOW_DISPLAY_SCORE_THRESHOLD;
 }
 
 export function formatWeightedWeeklyQuotaScore(score: number | undefined): string {
@@ -72,4 +185,19 @@ export function timestampMs(value: Date | number | string | undefined): number {
     return Number.isFinite(parsed) ? parsed : Date.now();
   }
   return Date.now();
+}
+
+function normalizeWindowDurationMins(value: unknown, fallback: number): number {
+  const mins = Number(value);
+  return Number.isFinite(mins) && mins > 0 ? mins : fallback;
+}
+
+function formatWindowDuration(windowMins: number): string {
+  if (windowMins % (24 * 60) === 0) {
+    return `${windowMins / (24 * 60)}d`;
+  }
+  if (windowMins % 60 === 0) {
+    return `${windowMins / 60}h`;
+  }
+  return `${windowMins}m`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,12 @@ export interface AppConfig {
   readonly codexAppServerPort: number;
   readonly codexOpenAiApiKey?: string | undefined;
   readonly tempadLinkServiceUrl?: string | undefined;
+  readonly githubOAuthClientId?: string | undefined;
+  readonly githubOAuthBaseUrl: string;
+  readonly githubApiBaseUrl: string;
+  readonly githubOAuthScopes: string[];
+  readonly defaultGitHubLogin?: string | undefined;
+  readonly defaultGitHubToken?: string | undefined;
   readonly port: number;
   readonly adminBaseUrl: string;
   readonly workerPort: number;
@@ -196,6 +202,14 @@ export function loadConfig(env = process.env): AppConfig {
     codexAppServerPort: getNumber(env, "CODEX_APP_SERVER_PORT", 4590),
     codexOpenAiApiKey: getOptional(env, "OPENAI_API_KEY"),
     tempadLinkServiceUrl: getOptional(env, "TEMPAD_LINK_SERVICE_URL"),
+    githubOAuthClientId: getOptional(env, "GITHUB_OAUTH_CLIENT_ID"),
+    githubOAuthBaseUrl: env.GITHUB_OAUTH_BASE_URL ?? "https://github.com/login/oauth",
+    githubApiBaseUrl: env.GITHUB_API_BASE_URL ?? "https://api.github.com",
+    githubOAuthScopes: getCsvList(env, "GITHUB_OAUTH_SCOPES").length > 0
+      ? getCsvList(env, "GITHUB_OAUTH_SCOPES")
+      : ["repo", "read:user"],
+    defaultGitHubLogin: getOptional(env, "BROKER_DEFAULT_GITHUB_LOGIN"),
+    defaultGitHubToken: getOptional(env, "BROKER_DEFAULT_GITHUB_TOKEN"),
     port,
     workerPort,
     workerBindHost,

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -61,6 +61,51 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "GET" && url.pathname.startsWith("/admin/api/sessions/") && url.pathname.endsWith("/github-identity")) {
+    const sessionKey = decodeURIComponent(url.pathname.slice(
+      "/admin/api/sessions/".length,
+      -"/github-identity".length
+    ));
+    if (!sessionKey || sessionKey.includes("/")) {
+      return false;
+    }
+
+    const result = await options.adminService.getSessionGitHubIdentity(sessionKey);
+    respondJson(response, result.ok === false ? 404 : 200, result);
+    return true;
+  }
+
+  if (
+    method === "POST" &&
+    url.pathname.startsWith("/admin/api/sessions/") &&
+    url.pathname.endsWith("/github-oauth/device/start")
+  ) {
+    const sessionKey = decodeURIComponent(url.pathname.slice(
+      "/admin/api/sessions/".length,
+      -"/github-oauth/device/start".length
+    ));
+    if (!sessionKey || sessionKey.includes("/")) {
+      return false;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.startSessionGitHubDeviceAuthorization(sessionKey)
+    );
+    return true;
+  }
+
+  if (method === "GET" && url.pathname.startsWith("/admin/api/github-oauth/device/")) {
+    const deviceAuthorizationId = decodeURIComponent(url.pathname.slice("/admin/api/github-oauth/device/".length));
+    if (!deviceAuthorizationId || deviceAuthorizationId.includes("/")) {
+      return false;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.pollGitHubDeviceAuthorization(deviceAuthorizationId)
+    );
+    return true;
+  }
+
   if (method === "POST" && url.pathname.startsWith("/admin/api/sessions/") && url.pathname.endsWith("/auth-profile")) {
     const sessionKey = decodeURIComponent(url.pathname.slice(
       "/admin/api/sessions/".length,

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -76,11 +76,13 @@ export async function handleAdminRequest(
     }
 
     const name = readString(body.name);
-    if (!name) {
+    const mode = readString(body.mode);
+    const autoMode = mode === "auto";
+    if (!name && !autoMode) {
       respondJson(response, 400, {
         ok: false,
         error: "missing_required_body",
-        required: ["name"]
+        required: ["name", "mode=auto"]
       });
       return true;
     }
@@ -88,7 +90,7 @@ export async function handleAdminRequest(
     await runAdminOperation(response, () =>
       options.adminService.switchSessionAuthProfile({
         sessionKey,
-        name
+        ...(autoMode ? { mode: "auto" as const } : { name })
       })
     );
     return true;

--- a/src/http/slack-routes.ts
+++ b/src/http/slack-routes.ts
@@ -74,6 +74,11 @@ export async function handleSlackRequest(
     return true;
   }
 
+  if (method === "POST" && url.pathname === "/slack/github-token/resolve") {
+    await handleResolveGitHubTokenRequest(request, response, options);
+    return true;
+  }
+
   return false;
 }
 
@@ -488,6 +493,39 @@ async function handleResolveCommitCoauthorsRequest(
       ok: true,
       ...result
     });
+  } catch (error) {
+    respondJson(response, 500, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+async function handleResolveGitHubTokenRequest(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  options: {
+    readonly bridge: SlackAgentBridge;
+  }
+): Promise<void> {
+  try {
+    const body = await readJsonBody(request);
+    const cwd = readString(body.cwd);
+    const command = normalizeStringArray(body.command) ?? [];
+    if (!cwd) {
+      respondJson(response, 400, {
+        ok: false,
+        error: "missing_required_body",
+        required: ["cwd"]
+      });
+      return;
+    }
+
+    const result = await options.bridge.resolveGitHubPrToken({
+      cwd,
+      command
+    });
+    respondJson(response, result.ok ? 200 : 409, result);
   } catch (error) {
     respondJson(response, 500, {
       ok: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   createCodexBroker,
   createDiskPressureCleanup,
   createGitHubAuthorMappings,
+  createGitHubPrIdentity,
   createIsolatedMcpService,
   createJobManager,
   createSessionServices,
@@ -27,6 +28,7 @@ export async function startService(): Promise<{
   configureServiceLogger(config);
   const { sessions: sessionManager } = createSessionServices(config);
   const githubAuthorMappings = await createGitHubAuthorMappings(config);
+  const githubPrIdentity = await createGitHubPrIdentity(config);
   const authProfiles = new AuthProfileService({
     config
   });
@@ -41,7 +43,8 @@ export async function startService(): Promise<{
     config,
     sessions: sessionManager,
     agentRuntime,
-    mappings: githubAuthorMappings
+    mappings: githubAuthorMappings,
+    githubPrIdentity
   });
   const isolatedMcp = createIsolatedMcpService(config);
   const jobManager = createJobManager({
@@ -60,6 +63,7 @@ export async function startService(): Promise<{
     runtime: new CodexRuntimeControl(codexBroker),
     authProfiles,
     githubAuthorMappings,
+    githubPrIdentity,
     startedAt,
     slackConversations: createSlackApi(config)
   });

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -19,6 +19,7 @@ import type {
 import type { SessionManager } from "./session-manager.js";
 import type { AuthProfileService } from "./auth-profile-service.js";
 import type { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
+import type { GitHubPrIdentityService } from "./github-pr-identity-service.js";
 import type { RuntimeControl } from "./runtime-control.js";
 import {
   authProfileReasonLabel,
@@ -70,6 +71,10 @@ interface RuntimeStatus {
   readonly githubAuthorMappings: {
     readonly count: number;
     readonly mappings: readonly unknown[];
+  };
+  readonly githubPrIdentities: {
+    readonly count: number;
+    readonly bindings: readonly unknown[];
   };
 }
 
@@ -144,6 +149,7 @@ export class AdminService {
       readonly runtime: RuntimeControl;
       readonly authProfiles: AuthProfileService;
       readonly githubAuthorMappings: GitHubAuthorMappingService;
+      readonly githubPrIdentity?: GitHubPrIdentityService | undefined;
       readonly startedAt: Date;
       readonly deployment?: ReleaseDeploymentService | undefined;
       readonly slackConversations?: SlackConversationLookup | undefined;
@@ -185,6 +191,7 @@ export class AdminService {
       },
       authProfiles: runtime.authProfiles,
       githubAuthorMappings: runtime.githubAuthorMappings,
+      githubPrIdentities: runtime.githubPrIdentities,
       account: runtime.account,
       rateLimits: runtime.rateLimits,
       deployment: runtime.deployment,
@@ -211,6 +218,7 @@ export class AdminService {
       service: this.#serviceInfo(),
       authProfiles: runtime.authProfiles,
       githubAuthorMappings: runtime.githubAuthorMappings,
+      githubPrIdentities: runtime.githubPrIdentities,
       account: runtime.account,
       rateLimits: runtime.rateLimits,
       deployment: runtime.deployment,
@@ -641,8 +649,81 @@ export class AdminService {
     );
   }
 
+  async getSessionGitHubIdentity(sessionKey: string): Promise<Record<string, unknown>> {
+    const githubPrIdentity = this.options.githubPrIdentity;
+    if (!githubPrIdentity) {
+      return {
+        ok: false,
+        error: "github_pr_identity_not_configured"
+      };
+    }
+    await githubPrIdentity.load();
+    const session = this.options.sessions.getSessionByKey(sessionKey);
+    if (!session) {
+      return {
+        ok: false,
+        error: "session_not_found"
+      };
+    }
+
+    return {
+      ok: true,
+      sessionKey,
+      initiatorUserId: session.initiatorUserId ?? null,
+      identity: githubPrIdentity.getSessionIdentityStatus(session)
+    };
+  }
+
+  async startSessionGitHubDeviceAuthorization(sessionKey: string): Promise<Record<string, unknown>> {
+    const githubPrIdentity = this.options.githubPrIdentity;
+    if (!githubPrIdentity) {
+      return {
+        ok: false,
+        error: "github_pr_identity_not_configured"
+      };
+    }
+    await githubPrIdentity.load();
+    const session = this.options.sessions.getSessionByKey(sessionKey);
+    if (!session) {
+      return {
+        ok: false,
+        error: "session_not_found"
+      };
+    }
+    if (!session.initiatorUserId) {
+      return {
+        ok: false,
+        error: "missing_session_initiator"
+      };
+    }
+
+    const device = await githubPrIdentity.startDeviceAuthorization({
+      slackUserId: session.initiatorUserId
+    });
+    return {
+      ok: true,
+      device
+    };
+  }
+
+  async pollGitHubDeviceAuthorization(deviceAuthorizationId: string): Promise<Record<string, unknown>> {
+    const githubPrIdentity = this.options.githubPrIdentity;
+    if (!githubPrIdentity) {
+      return {
+        ok: false,
+        error: "github_pr_identity_not_configured"
+      };
+    }
+    const result = await githubPrIdentity.pollDeviceAuthorization(deviceAuthorizationId);
+    return {
+      ok: true,
+      result
+    };
+  }
+
   async #readRuntimeStatus(): Promise<RuntimeStatus> {
     await this.options.githubAuthorMappings.load();
+    await this.options.githubPrIdentity?.load();
     const [account, rateLimits, deployment] = await Promise.all([
       this.#readAccountSummary(),
       this.#readAccountRateLimits(),
@@ -650,6 +731,7 @@ export class AdminService {
     ]);
     const authProfiles = await this.options.authProfiles.listProfilesStatus();
     const mappings = this.options.githubAuthorMappings.listMappings();
+    const prBindings = this.options.githubPrIdentity?.listBindings() ?? [];
     return {
       account,
       rateLimits,
@@ -658,6 +740,19 @@ export class AdminService {
       githubAuthorMappings: {
         count: mappings.length,
         mappings
+      },
+      githubPrIdentities: {
+        count: prBindings.length,
+        bindings: prBindings.map((binding) => ({
+          slackUserId: binding.slackUserId,
+          githubLogin: binding.githubLogin,
+          githubUserId: binding.githubUserId,
+          scopes: binding.scopes,
+          createdAt: binding.createdAt,
+          updatedAt: binding.updatedAt,
+          lastValidatedAt: binding.lastValidatedAt ?? null,
+          revokedAt: binding.revokedAt ?? null
+        }))
       }
     };
   }

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -23,7 +23,8 @@ import type { RuntimeControl } from "./runtime-control.js";
 import {
   authProfileReasonLabel,
   evaluateAuthProfile,
-  findAuthProfile
+  findAuthProfile,
+  selectBestAuthProfile
 } from "./session-auth-profile-selector.js";
 import type {
   DeployReleaseOptions,
@@ -465,14 +466,23 @@ export class AdminService {
 
   async switchSessionAuthProfile(options: {
     readonly sessionKey: string;
-    readonly name: string;
+    readonly name?: string | undefined;
+    readonly mode?: "auto" | undefined;
   }): Promise<Record<string, unknown>> {
+    const selectionMode = options.mode === "auto" ? "auto" : "manual";
+    const request: JsonLike = selectionMode === "auto"
+      ? {
+          sessionKey: options.sessionKey,
+          mode: "auto"
+        }
+      : {
+          sessionKey: options.sessionKey,
+          mode: "manual",
+          name: options.name ?? ""
+        };
     return await this.#runTrackedOperation(
       "session_auth_profile_switch",
-      {
-        sessionKey: options.sessionKey,
-        name: options.name
-      },
+      request,
       async () => {
         const session = this.options.sessions.getSessionByKey(options.sessionKey);
         if (!session) {
@@ -480,9 +490,14 @@ export class AdminService {
         }
 
         const status = await this.options.authProfiles.listProfilesStatus();
-        const profile = findAuthProfile(status, options.name);
+        const profile = selectionMode === "auto"
+          ? selectBestAuthProfile(status)
+          : (options.name ? findAuthProfile(status, options.name) : null);
         if (!profile) {
-          throw new Error(`Auth profile not found: ${options.name}`);
+          if (selectionMode === "auto") {
+            throw new Error(`No usable auth profile: ${authProfileReasonLabel("no_usable_auth_profiles")}`);
+          }
+          throw new Error(`Auth profile not found: ${options.name ?? ""}`);
         }
 
         const evaluation = evaluateAuthProfile(profile);
@@ -492,10 +507,12 @@ export class AdminService {
 
         await this.options.sessions.resetInflightMessages(session.channelId, session.rootThreadTs);
         const switched = await this.options.sessions.switchSessionAuthProfileAndClearBlock(session.key, profile.name);
-        await this.#appendSessionAuthProfileSwitchTrace(switched, profile.name);
+        await this.#appendSessionAuthProfileSwitchTrace(switched, profile.name, selectionMode);
         const workerResume = await this.#resumeWorkerPendingSession(switched.key);
         return {
           ok: true,
+          selectedMode: selectionMode,
+          selectedProfileName: profile.name,
           session: this.#summarizeSessionByKey(switched.key),
           workerResume
         };
@@ -1227,10 +1244,12 @@ export class AdminService {
 
   async #appendSessionAuthProfileSwitchTrace(
     session: SlackSessionRecord,
-    profileName: string
+    profileName: string,
+    selectionMode: "manual" | "auto"
   ): Promise<void> {
     const now = new Date().toISOString();
     const sequence = this.options.sessions.listAgentTraceEvents(session.key, 10_000).length + 1;
+    const actionLabel = selectionMode === "auto" ? "自动分配到" : "人工切换到";
     await this.options.sessions.upsertAgentTraceEvent({
       id: randomUUID(),
       sessionKey: session.key,
@@ -1239,11 +1258,12 @@ export class AdminService {
       at: now,
       sequence,
       title: "Auth Profile 已切换",
-      summary: `人工切换到 ${profileName}，继续处理待处理消息`,
-      detail: JSON.stringify({ profileName }, null, 2),
+      summary: `${actionLabel} ${profileName}，继续处理待处理消息`,
+      detail: JSON.stringify({ profileName, selectionMode }, null, 2),
       status: "completed",
       metadata: {
-        profileName
+        profileName,
+        selectionMode
       },
       createdAt: now,
       updatedAt: now

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -71,6 +72,7 @@ export class AppServerProcess {
     await this.#bootstrapAuth();
     await this.#disableConfiguredMcpServers();
     await this.#ensureGitCommitHook();
+    const githubCliWrapper = await this.#ensureGitHubCliWrapper();
     const tempadLinkServiceUrl = await this.#resolveTempadLinkServiceUrl();
 
     const env: NodeJS.ProcessEnv = {
@@ -78,11 +80,16 @@ export class AppServerProcess {
       CODEX_HOME: this.#codexHome,
       HOME: this.#runtimeHome,
       BROKER_API_BASE: this.#brokerHttpBaseUrl,
+      BROKER_GH_HELPER:
+        process.env.BROKER_GH_HELPER?.trim() || resolveRuntimeToolPath("gh.js"),
+      BROKER_REAL_GH_PATH:
+        process.env.BROKER_REAL_GH_PATH?.trim() || githubCliWrapper.realGhPath || "",
       TEMPAD_LINK_SERVICE_URL: tempadLinkServiceUrl,
       BROKER_GIT_COAUTHOR_HELPER:
         process.env.BROKER_GIT_COAUTHOR_HELPER?.trim() || resolveRuntimeToolPath("git-coauthor.js"),
       BROKER_GEMINI_UI_HELPER:
-        process.env.BROKER_GEMINI_UI_HELPER?.trim() || resolveRuntimeToolPath("gemini-ui.js")
+        process.env.BROKER_GEMINI_UI_HELPER?.trim() || resolveRuntimeToolPath("gemini-ui.js"),
+      PATH: `${githubCliWrapper.binDir}:${process.env.PATH ?? ""}`
     };
 
     if (this.#geminiHttpProxy) {
@@ -222,6 +229,30 @@ export class AppServerProcess {
     await fs.writeFile(hookPath, `${hookScript}\n`, { mode: 0o755 });
     await fs.chmod(hookPath, 0o755);
     await this.#runGit(["config", "--global", "core.hooksPath", hooksDir]);
+  }
+
+  async #ensureGitHubCliWrapper(): Promise<{
+    readonly binDir: string;
+    readonly realGhPath?: string | undefined;
+  }> {
+    const binDir = path.join(this.#runtimeHome, ".local", "broker-bin");
+    await ensureDir(binDir);
+    const wrapperPath = path.join(binDir, "gh");
+    const wrapperScript = [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "if [ -z \"${BROKER_GH_HELPER:-}\" ]; then",
+      "  printf '%s\\n' 'BROKER_GH_HELPER is required for broker gh wrapper.' >&2",
+      "  exit 1",
+      "fi",
+      "exec node \"$BROKER_GH_HELPER\" \"$@\""
+    ].join("\n");
+    await fs.writeFile(wrapperPath, `${wrapperScript}\n`, { mode: 0o755 });
+    await fs.chmod(wrapperPath, 0o755);
+    return {
+      binDir,
+      realGhPath: process.env.BROKER_REAL_GH_PATH?.trim() || await findExecutableOnPath("gh", process.env.PATH)
+    };
   }
 
   async #disableConfiguredMcpServers(): Promise<void> {
@@ -644,4 +675,17 @@ async function isHealthyHttpService(baseUrl: string): Promise<boolean> {
 
 function uniqueStrings(values: readonly (string | undefined)[]): string[] {
   return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
+async function findExecutableOnPath(command: string, pathValue: string | undefined): Promise<string | undefined> {
+  for (const dir of (pathValue ?? "").split(path.delimiter).filter(Boolean)) {
+    const candidate = path.join(dir, command);
+    try {
+      await fs.access(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      // Keep searching PATH.
+    }
+  }
+  return undefined;
 }

--- a/src/services/github-pr-identity-service.ts
+++ b/src/services/github-pr-identity-service.ts
@@ -1,0 +1,608 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { SlackSessionRecord } from "../types.js";
+import { ensureDir } from "../utils/fs.js";
+
+export interface GitHubPrBindingRecord {
+  readonly slackUserId: string;
+  readonly githubLogin: string;
+  readonly githubUserId: number;
+  readonly token: string;
+  readonly scopes: readonly string[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly lastValidatedAt?: string | undefined;
+  readonly revokedAt?: string | undefined;
+}
+
+export type GitHubPrTokenResolution =
+  | {
+      readonly ok: true;
+      readonly mode: "initiator";
+      readonly slackUserId: string;
+      readonly githubLogin: string;
+      readonly token: string;
+    }
+  | {
+      readonly ok: true;
+      readonly mode: "default";
+      readonly githubLogin: string;
+      readonly token: string;
+      readonly reason: "missing_initiator" | "initiator_unbound";
+    }
+  | {
+      readonly ok: false;
+      readonly mode: "blocked";
+      readonly reason:
+        | "session_not_found"
+        | "missing_initiator"
+        | "initiator_unbound"
+        | "initiator_token_invalid"
+        | "default_account_unavailable";
+      readonly message: string;
+      readonly slackUserId?: string | undefined;
+      readonly githubLogin?: string | undefined;
+    };
+
+export interface GitHubPrIdentityStatus {
+  readonly initiatorUserId?: string | undefined;
+  readonly binding:
+    | {
+        readonly state: "bound";
+        readonly githubLogin: string;
+        readonly githubUserId: number;
+        readonly scopes: readonly string[];
+        readonly updatedAt: string;
+        readonly lastValidatedAt?: string | undefined;
+      }
+    | {
+        readonly state: "revoked";
+        readonly githubLogin: string;
+        readonly githubUserId: number;
+        readonly revokedAt: string;
+      }
+    | {
+        readonly state: "unbound";
+      }
+    | {
+        readonly state: "missing_initiator";
+      };
+  readonly defaultAccount:
+    | {
+        readonly available: true;
+        readonly githubLogin: string;
+      }
+    | {
+        readonly available: false;
+      };
+}
+
+interface StoredDeviceAuthorization {
+  readonly id: string;
+  readonly slackUserId: string;
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string | undefined;
+  readonly expiresAt: number;
+  intervalSeconds: number;
+}
+
+export class GitHubPrIdentityService {
+  readonly #rootDir: string;
+  readonly #bindingsDir: string;
+  readonly #defaultGitHubLogin: string | undefined;
+  readonly #defaultGitHubToken: string | undefined;
+  readonly #githubOAuthClientId: string | undefined;
+  readonly #githubOAuthBaseUrl: string;
+  readonly #githubApiBaseUrl: string;
+  readonly #githubOAuthScopes: readonly string[];
+  readonly #bindings = new Map<string, GitHubPrBindingRecord>();
+  readonly #deviceAuthorizations = new Map<string, StoredDeviceAuthorization>();
+
+  constructor(options: {
+    readonly stateDir: string;
+    readonly defaultGitHubLogin?: string | undefined;
+    readonly defaultGitHubToken?: string | undefined;
+    readonly githubOAuthClientId?: string | undefined;
+    readonly githubOAuthBaseUrl?: string | undefined;
+    readonly githubApiBaseUrl?: string | undefined;
+    readonly githubOAuthScopes?: readonly string[] | undefined;
+  }) {
+    this.#rootDir = path.join(options.stateDir, "github-pr-identities");
+    this.#bindingsDir = path.join(this.#rootDir, "bindings");
+    this.#defaultGitHubLogin = normalizeString(options.defaultGitHubLogin);
+    this.#defaultGitHubToken = normalizeString(options.defaultGitHubToken);
+    this.#githubOAuthClientId = normalizeString(options.githubOAuthClientId);
+    this.#githubOAuthBaseUrl = normalizeString(options.githubOAuthBaseUrl) ?? "https://github.com/login/oauth";
+    this.#githubApiBaseUrl = normalizeString(options.githubApiBaseUrl) ?? "https://api.github.com";
+    this.#githubOAuthScopes = options.githubOAuthScopes?.length ? options.githubOAuthScopes : ["repo", "read:user"];
+  }
+
+  async load(): Promise<void> {
+    await ensureDir(this.#bindingsDir);
+    this.#bindings.clear();
+
+    const entries = await fs.readdir(this.#bindingsDir, { withFileTypes: true }).catch((error: unknown) => {
+      if (isNodeErrno(error, "ENOENT")) {
+        return [];
+      }
+      throw error;
+    });
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) {
+        continue;
+      }
+
+      const filePath = path.join(this.#bindingsDir, entry.name);
+      const raw = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+      const record = normalizeBinding(raw);
+      if (record) {
+        this.#bindings.set(record.slackUserId, record);
+      }
+    }
+  }
+
+  async upsertBinding(options: {
+    readonly slackUserId: string;
+    readonly githubLogin: string;
+    readonly githubUserId: number;
+    readonly token: string;
+    readonly scopes: readonly string[];
+    readonly lastValidatedAt?: string | undefined;
+    readonly revokedAt?: string | undefined;
+  }): Promise<GitHubPrBindingRecord> {
+    const slackUserId = requiredString(options.slackUserId, "slackUserId");
+    const githubLogin = requiredString(options.githubLogin, "githubLogin");
+    const token = requiredString(options.token, "token");
+    if (!Number.isInteger(options.githubUserId) || options.githubUserId <= 0) {
+      throw new Error("githubUserId must be a positive integer.");
+    }
+
+    const now = new Date().toISOString();
+    const existing = this.#bindings.get(slackUserId);
+    const record: GitHubPrBindingRecord = {
+      slackUserId,
+      githubLogin,
+      githubUserId: options.githubUserId,
+      token,
+      scopes: [...new Set(options.scopes.map((scope) => scope.trim()).filter(Boolean))],
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      ...(options.lastValidatedAt ? { lastValidatedAt: options.lastValidatedAt } : {}),
+      ...(options.revokedAt ? { revokedAt: options.revokedAt } : {})
+    };
+
+    await ensureDir(this.#bindingsDir);
+    await fs.writeFile(this.#bindingPath(slackUserId), `${JSON.stringify(record, null, 2)}\n`, {
+      mode: 0o600
+    });
+    this.#bindings.set(slackUserId, record);
+    return record;
+  }
+
+  async getBinding(slackUserId: string): Promise<GitHubPrBindingRecord | undefined> {
+    await this.load();
+    return this.#bindings.get(slackUserId);
+  }
+
+  listBindings(): readonly GitHubPrBindingRecord[] {
+    return [...this.#bindings.values()].sort((left, right) => left.slackUserId.localeCompare(right.slackUserId));
+  }
+
+  getSessionIdentityStatus(session: SlackSessionRecord): GitHubPrIdentityStatus {
+    const initiatorUserId = normalizeString(session.initiatorUserId);
+    const defaultAccount = this.#defaultGitHubLogin && this.#defaultGitHubToken
+      ? {
+          available: true as const,
+          githubLogin: this.#defaultGitHubLogin
+        }
+      : {
+          available: false as const
+        };
+
+    if (!initiatorUserId) {
+      return {
+        defaultAccount,
+        binding: {
+          state: "missing_initiator"
+        }
+      };
+    }
+
+    const binding = this.#bindings.get(initiatorUserId);
+    if (!binding) {
+      return {
+        initiatorUserId,
+        defaultAccount,
+        binding: {
+          state: "unbound"
+        }
+      };
+    }
+
+    if (binding.revokedAt) {
+      return {
+        initiatorUserId,
+        defaultAccount,
+        binding: {
+          state: "revoked",
+          githubLogin: binding.githubLogin,
+          githubUserId: binding.githubUserId,
+          revokedAt: binding.revokedAt
+        }
+      };
+    }
+
+    return {
+      initiatorUserId,
+      defaultAccount,
+      binding: {
+        state: "bound",
+        githubLogin: binding.githubLogin,
+        githubUserId: binding.githubUserId,
+        scopes: binding.scopes,
+        updatedAt: binding.updatedAt,
+        ...(binding.lastValidatedAt ? { lastValidatedAt: binding.lastValidatedAt } : {})
+      }
+    };
+  }
+
+  async resolveTokenForSession(options: {
+    readonly session: SlackSessionRecord;
+    readonly command: readonly string[];
+  }): Promise<GitHubPrTokenResolution> {
+    await this.load();
+    const initiatorUserId = normalizeString(options.session.initiatorUserId);
+    if (!initiatorUserId) {
+      return this.#resolveDefault("missing_initiator");
+    }
+
+    const binding = this.#bindings.get(initiatorUserId);
+    if (!binding) {
+      return this.#resolveDefault("initiator_unbound", initiatorUserId);
+    }
+
+    if (binding.revokedAt) {
+      return {
+        ok: false,
+        mode: "blocked",
+        reason: "initiator_token_invalid",
+        slackUserId: initiatorUserId,
+        githubLogin: binding.githubLogin,
+        message: `GitHub token for ${binding.githubLogin} is invalid. Open the session page and rebind GitHub before running gh ${options.command.join(" ")}.`
+      };
+    }
+
+    return {
+      ok: true,
+      mode: "initiator",
+      slackUserId: initiatorUserId,
+      githubLogin: binding.githubLogin,
+      token: binding.token
+    };
+  }
+
+  async startDeviceAuthorization(options: {
+    readonly slackUserId: string;
+  }): Promise<{
+    readonly id: string;
+    readonly slackUserId: string;
+    readonly userCode: string;
+    readonly verificationUri: string;
+    readonly verificationUriComplete?: string | undefined;
+    readonly expiresAt: string;
+    readonly intervalSeconds: number;
+  }> {
+    const slackUserId = requiredString(options.slackUserId, "slackUserId");
+    if (!this.#githubOAuthClientId) {
+      throw new Error("GitHub OAuth client id is not configured.");
+    }
+
+    const body = new URLSearchParams({
+      client_id: this.#githubOAuthClientId,
+      scope: this.#githubOAuthScopes.join(" ")
+    });
+    const response = await fetch(joinOAuthUrl(this.#githubOAuthBaseUrl, "../device/code"), {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded"
+      },
+      body
+    });
+    const raw = await readJsonResponse(response);
+    const parsed = parseDeviceCodeResponse(raw);
+    const id = randomUUID();
+    const expiresAt = Date.now() + parsed.expiresInSeconds * 1000;
+    this.#deviceAuthorizations.set(id, {
+      id,
+      slackUserId,
+      deviceCode: parsed.deviceCode,
+      userCode: parsed.userCode,
+      verificationUri: parsed.verificationUri,
+      verificationUriComplete: parsed.verificationUriComplete,
+      expiresAt,
+      intervalSeconds: parsed.intervalSeconds
+    });
+
+    return {
+      id,
+      slackUserId,
+      userCode: parsed.userCode,
+      verificationUri: parsed.verificationUri,
+      ...(parsed.verificationUriComplete ? { verificationUriComplete: parsed.verificationUriComplete } : {}),
+      expiresAt: new Date(expiresAt).toISOString(),
+      intervalSeconds: parsed.intervalSeconds
+    };
+  }
+
+  async pollDeviceAuthorization(id: string): Promise<
+    | {
+        readonly status: "pending";
+        readonly retryAfterSeconds: number;
+      }
+    | {
+        readonly status: "expired";
+      }
+    | {
+        readonly status: "failed";
+        readonly error: string;
+      }
+    | {
+        readonly status: "completed";
+        readonly binding: GitHubPrBindingRecord;
+      }
+  > {
+    if (!this.#githubOAuthClientId) {
+      throw new Error("GitHub OAuth client id is not configured.");
+    }
+
+    const pending = this.#deviceAuthorizations.get(id);
+    if (!pending) {
+      return {
+        status: "failed",
+        error: "unknown_device_authorization"
+      };
+    }
+    if (Date.now() >= pending.expiresAt) {
+      this.#deviceAuthorizations.delete(id);
+      return {
+        status: "expired"
+      };
+    }
+
+    const body = new URLSearchParams({
+      client_id: this.#githubOAuthClientId,
+      device_code: pending.deviceCode,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code"
+    });
+    const response = await fetch(joinOAuthUrl(this.#githubOAuthBaseUrl, "access_token"), {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded"
+      },
+      body
+    });
+    const raw = await readJsonResponse(response);
+    if (isRecord(raw) && typeof raw.error === "string") {
+      if (raw.error === "authorization_pending") {
+        return {
+          status: "pending",
+          retryAfterSeconds: pending.intervalSeconds
+        };
+      }
+      if (raw.error === "slow_down") {
+        pending.intervalSeconds += 5;
+        return {
+          status: "pending",
+          retryAfterSeconds: pending.intervalSeconds
+        };
+      }
+      return {
+        status: "failed",
+        error: raw.error
+      };
+    }
+
+    const token = isRecord(raw) && typeof raw.access_token === "string" ? raw.access_token.trim() : "";
+    if (!token) {
+      return {
+        status: "failed",
+        error: "missing_access_token"
+      };
+    }
+
+    const user = await this.#fetchGitHubUser(token);
+    const scopes = parseScopes(isRecord(raw) && typeof raw.scope === "string" ? raw.scope : "");
+    const validatedAt = new Date().toISOString();
+    const binding = await this.upsertBinding({
+      slackUserId: pending.slackUserId,
+      githubLogin: user.login,
+      githubUserId: user.id,
+      token,
+      scopes,
+      lastValidatedAt: validatedAt
+    });
+    this.#deviceAuthorizations.delete(id);
+    return {
+      status: "completed",
+      binding
+    };
+  }
+
+  async #fetchGitHubUser(token: string): Promise<{
+    readonly id: number;
+    readonly login: string;
+  }> {
+    const response = await fetch(joinUrl(this.#githubApiBaseUrl, "/user"), {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "user-agent": "slack-codex-broker"
+      }
+    });
+    const raw = await readJsonResponse(response);
+    if (!isRecord(raw) || typeof raw.login !== "string" || typeof raw.id !== "number" || !Number.isInteger(raw.id)) {
+      throw new Error("GitHub user response did not include login and id.");
+    }
+    return {
+      login: raw.login,
+      id: raw.id
+    };
+  }
+
+  #resolveDefault(
+    reason: "missing_initiator" | "initiator_unbound",
+    slackUserId?: string | undefined
+  ): GitHubPrTokenResolution {
+    if (this.#defaultGitHubLogin && this.#defaultGitHubToken) {
+      return {
+        ok: true,
+        mode: "default",
+        githubLogin: this.#defaultGitHubLogin,
+        token: this.#defaultGitHubToken,
+        reason
+      };
+    }
+
+    return {
+      ok: false,
+      mode: "blocked",
+      reason: this.#defaultGitHubLogin || this.#defaultGitHubToken ? reason : "default_account_unavailable",
+      ...(slackUserId ? { slackUserId } : {}),
+      message: "No GitHub account is bound to this Slack session initiator, and no default GitHub account is configured."
+    };
+  }
+
+  #bindingPath(slackUserId: string): string {
+    return path.join(this.#bindingsDir, `${encodePathPart(slackUserId)}.json`);
+  }
+}
+
+function parseDeviceCodeResponse(raw: unknown): {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string | undefined;
+  readonly expiresInSeconds: number;
+  readonly intervalSeconds: number;
+} {
+  if (!isRecord(raw)) {
+    throw new Error("GitHub device code response must be an object.");
+  }
+
+  const deviceCode = requiredString(raw.device_code, "device_code");
+  const userCode = requiredString(raw.user_code, "user_code");
+  const verificationUri = requiredString(raw.verification_uri, "verification_uri");
+  const expiresInSeconds = readPositiveNumber(raw.expires_in, "expires_in");
+  const intervalSeconds = typeof raw.interval === "number" && raw.interval > 0 ? raw.interval : 5;
+  const verificationUriComplete = normalizeString(raw.verification_uri_complete);
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    ...(verificationUriComplete ? { verificationUriComplete } : {}),
+    expiresInSeconds,
+    intervalSeconds
+  };
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  const parsed = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const error = isRecord(parsed) && typeof parsed.error === "string" ? parsed.error : response.statusText;
+    throw new Error(`GitHub request failed (${response.status}): ${error}`);
+  }
+  return parsed;
+}
+
+function normalizeBinding(raw: unknown): GitHubPrBindingRecord | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const slackUserId = normalizeString(raw.slackUserId);
+  const githubLogin = normalizeString(raw.githubLogin);
+  const githubUserId = typeof raw.githubUserId === "number" && Number.isInteger(raw.githubUserId)
+    ? raw.githubUserId
+    : 0;
+  const token = normalizeString(raw.token);
+  const createdAt = normalizeString(raw.createdAt);
+  const updatedAt = normalizeString(raw.updatedAt);
+  if (!slackUserId || !githubLogin || githubUserId <= 0 || !token || !createdAt || !updatedAt) {
+    return null;
+  }
+
+  const scopes = Array.isArray(raw.scopes)
+    ? raw.scopes.map((entry) => normalizeString(entry)).filter((entry): entry is string => Boolean(entry))
+    : [];
+  const lastValidatedAt = normalizeString(raw.lastValidatedAt);
+  const revokedAt = normalizeString(raw.revokedAt);
+  return {
+    slackUserId,
+    githubLogin,
+    githubUserId,
+    token,
+    scopes,
+    createdAt,
+    updatedAt,
+    ...(lastValidatedAt ? { lastValidatedAt } : {}),
+    ...(revokedAt ? { revokedAt } : {})
+  };
+}
+
+function joinUrl(baseUrl: string, pathName: string): string {
+  return new URL(pathName.replace(/^\/+/, ""), `${baseUrl.replace(/\/+$/, "")}/`).toString();
+}
+
+function joinOAuthUrl(baseUrl: string, pathName: string): string {
+  return new URL(pathName, `${baseUrl.replace(/\/+$/, "")}/`).toString();
+}
+
+function parseScopes(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function requiredString(value: unknown, name: string): string {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    throw new Error(`${name} is required.`);
+  }
+  return normalized;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readPositiveNumber(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number.`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNodeErrno(error: unknown, code: string): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
+}
+
+function encodePathPart(value: string): string {
+  return encodeURIComponent(value).replace(/%/g, "_");
+}

--- a/src/services/service-components.ts
+++ b/src/services/service-components.ts
@@ -9,6 +9,7 @@ import { CodexBroker } from "./codex/codex-broker.js";
 import { IsolatedMcpService } from "./codex/isolated-mcp-service.js";
 import { DiskPressureCleanupService } from "./disk-pressure-cleanup-service.js";
 import { GitHubAuthorMappingService } from "./github-author-mapping-service.js";
+import { GitHubPrIdentityService } from "./github-pr-identity-service.js";
 import { JobManager } from "./job-manager.js";
 import { SessionManager } from "./session-manager.js";
 import { SlackApi } from "./slack/slack-api.js";
@@ -57,6 +58,20 @@ export async function createGitHubAuthorMappings(config: AppConfig): Promise<Git
   return mappings;
 }
 
+export async function createGitHubPrIdentity(config: AppConfig): Promise<GitHubPrIdentityService> {
+  const identities = new GitHubPrIdentityService({
+    stateDir: config.stateDir,
+    defaultGitHubLogin: config.defaultGitHubLogin,
+    defaultGitHubToken: config.defaultGitHubToken,
+    githubOAuthClientId: config.githubOAuthClientId,
+    githubOAuthBaseUrl: config.githubOAuthBaseUrl,
+    githubApiBaseUrl: config.githubApiBaseUrl,
+    githubOAuthScopes: config.githubOAuthScopes
+  });
+  await identities.load();
+  return identities;
+}
+
 export function createCodexBroker(config: AppConfig): CodexBroker {
   return new CodexBroker({
     serviceName: config.serviceName,
@@ -102,12 +117,14 @@ export function createSlackBridge(options: {
   readonly sessions: SessionManager;
   readonly agentRuntime: AgentRuntime;
   readonly mappings: GitHubAuthorMappingService;
+  readonly githubPrIdentity: GitHubPrIdentityService;
 }): SlackAgentBridge {
   return new SlackAgentBridge({
     config: options.config,
     sessions: options.sessions,
     agentRuntime: options.agentRuntime,
-    mappings: options.mappings
+    mappings: options.mappings,
+    githubPrIdentity: options.githubPrIdentity
   });
 }
 

--- a/src/services/session-manager.ts
+++ b/src/services/session-manager.ts
@@ -24,6 +24,13 @@ export interface SessionChannelMetadata {
   readonly channelType?: string | undefined;
 }
 
+export interface SessionInitiatorMetadata {
+  readonly initiatorUserId?: string | undefined;
+  readonly initiatorMessageTs?: string | undefined;
+}
+
+export type EnsureSessionMetadata = SessionChannelMetadata & SessionInitiatorMetadata;
+
 export class SessionManager {
   readonly #stateStore: StateStore;
   readonly #sessionsRoot: string;
@@ -93,7 +100,7 @@ export class SessionManager {
   async ensureSession(
     channelId: string,
     rootThreadTs: string,
-    metadata?: SessionChannelMetadata | undefined
+    metadata?: EnsureSessionMetadata | undefined
   ): Promise<SlackSessionRecord> {
     const existing = this.getSession(channelId, rootThreadTs);
     if (existing) {
@@ -108,6 +115,7 @@ export class SessionManager {
       key: SessionManager.createKey(channelId, rootThreadTs),
       channelId,
       ...normalizeChannelMetadata(metadata),
+      ...normalizeSessionInitiator(metadata),
       rootThreadTs,
       workspacePath,
       createdAt: new Date().toISOString(),
@@ -608,6 +616,22 @@ function normalizeChannelMetadata(
   return {
     channelName: normalizeNonEmptyString(metadata?.channelName),
     channelType: normalizeNonEmptyString(metadata?.channelType)
+  };
+}
+
+function normalizeSessionInitiator(
+  metadata?: SessionInitiatorMetadata | undefined
+): Pick<SlackSessionRecord, "initiatorUserId" | "initiatorMessageTs" | "initiatorCapturedAt"> {
+  const initiatorUserId = normalizeNonEmptyString(metadata?.initiatorUserId);
+  const initiatorMessageTs = normalizeNonEmptyString(metadata?.initiatorMessageTs);
+  if (!initiatorUserId) {
+    return {};
+  }
+
+  return {
+    initiatorUserId,
+    initiatorMessageTs,
+    initiatorCapturedAt: new Date().toISOString()
   };
 }
 

--- a/src/services/slack/slack-agent-bridge.ts
+++ b/src/services/slack/slack-agent-bridge.ts
@@ -10,6 +10,10 @@ import type {
 } from "../../types.js";
 import type { AgentRuntime } from "../agent-runtime/types.js";
 import { GitHubAuthorMappingService } from "../github-author-mapping-service.js";
+import type {
+  GitHubPrIdentityService,
+  GitHubPrTokenResolution
+} from "../github-pr-identity-service.js";
 import { SessionManager } from "../session-manager.js";
 import type { SessionChannelMetadata } from "../session-manager.js";
 import {
@@ -31,6 +35,7 @@ export class SlackAgentBridge {
   readonly #slackSocket: SlackSocketModeClient;
   readonly #selfMessageFilter = new SlackSelfMessageFilter();
   readonly #coauthors: SlackCoauthorService;
+  readonly #githubPrIdentity: GitHubPrIdentityService;
   readonly #conversations: SlackConversationService;
   #botUserId = "";
   #botIdentity: SlackUserIdentity | null = null;
@@ -43,6 +48,7 @@ export class SlackAgentBridge {
     readonly sessions: SessionManager;
     readonly agentRuntime: AgentRuntime;
     readonly mappings: GitHubAuthorMappingService;
+    readonly githubPrIdentity: GitHubPrIdentityService;
   }) {
     this.#config = options.config;
     this.#sessions = options.sessions;
@@ -61,13 +67,15 @@ export class SlackAgentBridge {
       slackApi: this.#slackApi,
       mappings: options.mappings
     });
+    this.#githubPrIdentity = options.githubPrIdentity;
     this.#conversations = new SlackConversationService({
       config: this.#config,
       sessions: this.#sessions,
       agentRuntime: this.#agentRuntime,
       slackApi: this.#slackApi,
       selfMessageFilter: this.#selfMessageFilter,
-      coauthors: this.#coauthors
+      coauthors: this.#coauthors,
+      githubPrIdentity: this.#githubPrIdentity
     });
   }
 
@@ -222,6 +230,26 @@ export class SlackAgentBridge {
     readonly primaryAuthorEmail?: string | undefined;
   }) {
     return await this.#coauthors.resolveCommitCoauthors(options);
+  }
+
+  async resolveGitHubPrToken(options: {
+    readonly cwd: string;
+    readonly command: readonly string[];
+  }): Promise<GitHubPrTokenResolution> {
+    const session = this.#sessions.findSessionByWorkspace(options.cwd);
+    if (!session) {
+      return {
+        ok: false,
+        mode: "blocked",
+        reason: "session_not_found",
+        message: `No Slack session is associated with ${options.cwd}.`
+      };
+    }
+
+    return await this.#githubPrIdentity.resolveTokenForSession({
+      session,
+      command: options.command
+    });
   }
 
   async #acceptEventsApi(payload: {
@@ -571,7 +599,15 @@ export class SlackAgentBridge {
   ): Promise<void> {
     const existing = this.#sessions.getSession(parsed.channelId, parsed.rootThreadTs);
     let session = options.createSession
-      ? await this.#sessions.ensureSession(parsed.channelId, parsed.rootThreadTs, options.channelMetadata)
+      ? await this.#sessions.ensureSession(parsed.channelId, parsed.rootThreadTs, {
+          ...options.channelMetadata,
+          ...(parsed.input.senderKind === "user"
+            ? {
+                initiatorUserId: parsed.input.userId,
+                initiatorMessageTs: parsed.messageTs
+              }
+            : {})
+        })
       : existing;
 
     if (!session) {

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -57,6 +57,7 @@ import {
 import { markdownishToMrkdwn } from "./slack-mrkdwn.js";
 import { SlackSelfMessageFilter } from "./slack-self-filter.js";
 import { SlackCoauthorService } from "./slack-coauthor-service.js";
+import type { GitHubPrIdentityService } from "../github-pr-identity-service.js";
 import { planCompletedTurnDisposition } from "./slack-turn-disposition.js";
 import { SlackTurnReconciler } from "./slack-turn-reconciler.js";
 import { SlackTurnRunner } from "./slack-turn-runner.js";
@@ -93,6 +94,7 @@ export class SlackConversationService {
       item: SlackInputMessage
     ) => Promise<SlackSessionRecord>;
   };
+  readonly #githubPrIdentity: GitHubPrIdentityService | undefined;
   readonly #runtimeSessions = new Map<string, RuntimeSessionState>();
   readonly #statusControllers = new Map<string, SlackAssistantStatusController>();
   readonly #inboundStore: SlackInboundStore;
@@ -111,6 +113,7 @@ export class SlackConversationService {
     readonly slackApi: SlackApi;
     readonly selfMessageFilter: SlackSelfMessageFilter;
     readonly coauthors?: SlackCoauthorService | undefined;
+    readonly githubPrIdentity?: GitHubPrIdentityService | undefined;
   }) {
     this.#config = options.config;
     this.#sessions = options.sessions;
@@ -120,6 +123,7 @@ export class SlackConversationService {
     this.#coauthors = options.coauthors ?? {
       noteIncomingSlackInput: async (session) => session
     };
+    this.#githubPrIdentity = options.githubPrIdentity;
     this.#inboundStore = new SlackInboundStore({
       sessions: this.#sessions,
       slackApi: this.#slackApi
@@ -862,7 +866,7 @@ export class SlackConversationService {
       await this.#postBotThreadMessage(
         session.channelId,
         session.rootThreadTs,
-        `<${url}|查看会话活动时间线>`,
+        this.#formatSessionPageLinkMessage(session, url),
         { alreadyFormatted: true }
       );
       return await this.#sessions.setSessionPageLinkPostedAt(
@@ -878,6 +882,19 @@ export class SlackConversationService {
       });
       return session;
     }
+  }
+
+  #formatSessionPageLinkMessage(session: SlackSessionRecord, url: string): string {
+    const lines = [`<${url}|查看会话活动时间线>`];
+    const identity = this.#githubPrIdentity?.getSessionIdentityStatus(session);
+    if (identity?.binding.state === "unbound" && identity.defaultAccount.available) {
+      lines.push(
+        "",
+        `当前发起人还没有绑定 GitHub 账号。不绑定时，后续创建 PR 会使用默认账号 ${identity.defaultAccount.githubLogin}。`,
+        `<${url}/github/bind|绑定 GitHub>`
+      );
+    }
+    return lines.join("\n");
   }
 
   async #recordStopSignal(

--- a/src/store/state-store.ts
+++ b/src/store/state-store.ts
@@ -19,7 +19,7 @@ import type {
 import { ensureDir } from "../utils/fs.js";
 
 export const STATE_DATABASE_FILENAME = "broker.sqlite";
-export const CURRENT_STATE_SCHEMA_VERSION = 12;
+export const CURRENT_STATE_SCHEMA_VERSION = 13;
 export const STATE_STORE_BUSY_TIMEOUT_MS = 5_000;
 const ADMIN_EVENT_RETENTION_LIMIT = 20_000;
 
@@ -45,6 +45,9 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
           channel_type TEXT,
           root_thread_ts TEXT NOT NULL,
           workspace_path TEXT NOT NULL,
+          initiator_user_id TEXT,
+          initiator_message_ts TEXT,
+          initiator_captured_at TEXT,
           created_at TEXT NOT NULL,
           updated_at TEXT NOT NULL,
           agent_session_id TEXT,
@@ -303,6 +306,13 @@ const STATE_MIGRATIONS: readonly StateMigration[] = [
     up(database) {
       createAgentActivityBindingSchema(database);
     }
+  },
+  {
+    version: 13,
+    name: "session_initiator",
+    up(database) {
+      repairSessionInitiatorSchema(database);
+    }
   }
 ];
 
@@ -399,6 +409,23 @@ function repairSessionPageLinkAnnouncementSchema(database: DatabaseSync): void {
   const columns = tableColumns(database, "sessions");
   if (!columns.has("session_page_link_posted_at")) {
     database.exec("ALTER TABLE sessions ADD COLUMN session_page_link_posted_at TEXT");
+  }
+}
+
+function repairSessionInitiatorSchema(database: DatabaseSync): void {
+  if (!tableExists(database, "sessions")) {
+    return;
+  }
+
+  const columns = tableColumns(database, "sessions");
+  if (!columns.has("initiator_user_id")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN initiator_user_id TEXT");
+  }
+  if (!columns.has("initiator_message_ts")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN initiator_message_ts TEXT");
+  }
+  if (!columns.has("initiator_captured_at")) {
+    database.exec("ALTER TABLE sessions ADD COLUMN initiator_captured_at TEXT");
   }
 }
 
@@ -1167,6 +1194,7 @@ export class StateStore {
     this.#databaseRequired().prepare(`
       INSERT INTO sessions (
         key, channel_id, channel_name, channel_type, root_thread_ts, workspace_path, created_at, updated_at,
+        initiator_user_id, initiator_message_ts, initiator_captured_at,
         agent_session_id, active_turn_id, active_turn_started_at,
         last_observed_message_ts, last_delivered_message_ts, last_slack_reply_at, session_page_link_posted_at,
         auth_profile_name, auth_profile_bound_at, auth_blocked_at, auth_block_reason, auth_blocked_notice_posted_at,
@@ -1174,7 +1202,7 @@ export class StateStore {
         co_author_candidate_user_ids, co_author_candidate_revision,
         co_author_confirmed_user_ids, co_author_confirmed_revision,
         co_author_ignore_missing_revision, co_author_prompt_revision, co_author_prompted_at
-      ) VALUES (${placeholders(31)})
+      ) VALUES (${placeholders(34)})
       ON CONFLICT(key) DO UPDATE SET
         channel_id = excluded.channel_id,
         channel_name = excluded.channel_name,
@@ -1183,6 +1211,9 @@ export class StateStore {
         workspace_path = excluded.workspace_path,
         created_at = excluded.created_at,
         updated_at = excluded.updated_at,
+        initiator_user_id = excluded.initiator_user_id,
+        initiator_message_ts = excluded.initiator_message_ts,
+        initiator_captured_at = excluded.initiator_captured_at,
         agent_session_id = excluded.agent_session_id,
         active_turn_id = excluded.active_turn_id,
         active_turn_started_at = excluded.active_turn_started_at,
@@ -1215,6 +1246,9 @@ export class StateStore {
       record.workspacePath,
       record.createdAt,
       record.updatedAt,
+      record.initiatorUserId ?? null,
+      record.initiatorMessageTs ?? null,
+      record.initiatorCapturedAt ?? null,
       record.agentSessionId ?? null,
       record.activeTurnId ?? null,
       record.activeTurnStartedAt ?? null,
@@ -1626,6 +1660,9 @@ export class StateStore {
       channelType: optionalStringColumn(row, "channel_type"),
       rootThreadTs: stringColumn(row, "root_thread_ts"),
       workspacePath: stringColumn(row, "workspace_path"),
+      initiatorUserId: optionalStringColumn(row, "initiator_user_id"),
+      initiatorMessageTs: optionalStringColumn(row, "initiator_message_ts"),
+      initiatorCapturedAt: optionalStringColumn(row, "initiator_captured_at"),
       createdAt: stringColumn(row, "created_at"),
       updatedAt: stringColumn(row, "updated_at"),
       agentSessionId: optionalStringColumn(row, "agent_session_id"),
@@ -1823,6 +1860,9 @@ export class StateStore {
       channelType: optionalNonEmptyString(session.channelType),
       rootThreadTs: String(session.rootThreadTs),
       workspacePath,
+      initiatorUserId: optionalNonEmptyString(session.initiatorUserId),
+      initiatorMessageTs: optionalNonEmptyString(session.initiatorMessageTs),
+      initiatorCapturedAt: optionalNonEmptyString(session.initiatorCapturedAt),
       createdAt: String(session.createdAt),
       updatedAt: String(session.updatedAt),
       agentSessionId: session.agentSessionId,

--- a/src/tools/gh.ts
+++ b/src/tools/gh.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export interface GhWrapperOptions {
+  readonly brokerApiBase: string;
+  readonly realGhPath: string;
+  readonly cwd: string;
+  readonly argv: readonly string[];
+  readonly env: NodeJS.ProcessEnv;
+}
+
+export interface GhWrapperResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export async function runGhWrapper(options: GhWrapperOptions): Promise<GhWrapperResult> {
+  const resolution = await resolveGitHubToken(options);
+  if (!resolution.ok) {
+    return {
+      status: 1,
+      stdout: "",
+      stderr: `${resolution.message ?? "GitHub identity resolution blocked."}\n`
+    };
+  }
+
+  return await runRealGh({
+    ...options,
+    token: resolution.token
+  });
+}
+
+async function resolveGitHubToken(options: GhWrapperOptions): Promise<
+  | {
+      readonly ok: true;
+      readonly token: string;
+    }
+  | {
+      readonly ok: false;
+      readonly message?: string | undefined;
+    }
+> {
+  const response = await fetch(new URL("/slack/github-token/resolve", normalizeBaseUrl(options.brokerApiBase)), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      cwd: options.cwd,
+      command: options.argv
+    })
+  });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) as Record<string, unknown> : {};
+  if (!response.ok || body.ok !== true) {
+    return {
+      ok: false,
+      message: typeof body.message === "string"
+        ? body.message
+        : typeof body.error === "string"
+          ? body.error
+          : `GitHub identity resolution failed (${response.status}).`
+    };
+  }
+
+  if (typeof body.token !== "string" || !body.token.trim()) {
+    return {
+      ok: false,
+      message: "GitHub identity resolution did not return a token."
+    };
+  }
+
+  return {
+    ok: true,
+    token: body.token
+  };
+}
+
+function runRealGh(options: GhWrapperOptions & {
+  readonly token: string;
+}): Promise<GhWrapperResult> {
+  return new Promise<GhWrapperResult>((resolve) => {
+    const child = spawn(options.realGhPath, [...options.argv], {
+      cwd: options.cwd,
+      env: {
+        ...options.env,
+        GH_TOKEN: options.token
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({
+        status: 1,
+        stdout,
+        stderr: `${stderr}${error instanceof Error ? error.message : String(error)}\n`
+      });
+    });
+    child.on("close", (code) => {
+      resolve({
+        status: code ?? 1,
+        stdout,
+        stderr
+      });
+    });
+  });
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const brokerApiBase = process.env.BROKER_API_BASE?.trim();
+  const realGhPath = process.env.BROKER_REAL_GH_PATH?.trim();
+  if (!brokerApiBase || !realGhPath) {
+    process.stderr.write("BROKER_API_BASE and BROKER_REAL_GH_PATH are required for broker gh wrapper.\n");
+    process.exitCode = 1;
+  } else {
+    const result = await runGhWrapper({
+      brokerApiBase,
+      realGhPath,
+      cwd: process.cwd(),
+      argv: process.argv.slice(2),
+      env: process.env
+    });
+    process.stdout.write(result.stdout);
+    process.stderr.write(result.stderr);
+    process.exitCode = result.status;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ export interface SlackSessionRecord {
   readonly channelType?: string | undefined;
   readonly rootThreadTs: string;
   readonly workspacePath: string;
+  readonly initiatorUserId?: string | undefined;
+  readonly initiatorMessageTs?: string | undefined;
+  readonly initiatorCapturedAt?: string | undefined;
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly agentSessionId?: string | undefined;

--- a/src/worker-index.ts
+++ b/src/worker-index.ts
@@ -10,6 +10,7 @@ import {
   createCodexBroker,
   createDiskPressureCleanup,
   createGitHubAuthorMappings,
+  createGitHubPrIdentity,
   createIsolatedMcpService,
   createJobManager,
   createSessionServices,
@@ -24,6 +25,7 @@ export async function startWorkerService(): Promise<{
 
   const { sessions: sessionManager } = createSessionServices(config);
   const githubAuthorMappings = await createGitHubAuthorMappings(config);
+  const githubPrIdentity = await createGitHubPrIdentity(config);
   const authProfiles = new AuthProfileService({
     config
   });
@@ -38,7 +40,8 @@ export async function startWorkerService(): Promise<{
     config,
     sessions: sessionManager,
     agentRuntime,
-    mappings: githubAuthorMappings
+    mappings: githubAuthorMappings,
+    githubPrIdentity
   });
   const isolatedMcp = createIsolatedMcpService(config);
   const jobManager = createJobManager({

--- a/test/admin-auth-profile-display.test.ts
+++ b/test/admin-auth-profile-display.test.ts
@@ -12,63 +12,90 @@ import {
 describe("admin auth profile display", () => {
   it("uses the account identity instead of the internal profile name", () => {
     const now = new Date("2026-05-09T00:00:00.000Z");
+    const fiveHours = Math.floor((now.getTime() + 5 * 60 * 60 * 1000) / 1000);
     const sevenDays = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
     const profile = authProfile({
       name: "575d9997-db66-4b21-979d-4d3b9597b36e",
       email: "hejiachen@toeverything.info",
       planType: "prolite",
       primaryUsed: 4,
+      primaryResetsAt: fiveHours,
       secondaryUsed: 36,
       secondaryResetsAt: sevenDays
     });
 
     expect(profileAccountLabel(profile)).toBe("hejiachen@toeverything.info");
     expect(profileDisplayLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite");
-    expect(profileQuotaLabel(profile, { now })).toBe("64% | 0.64");
-    expect(profileWeeklyQuotaLabel(profile, { now })).toBe("64% | 0.64");
-    expect(profileOptionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 64% | 0.64");
+    expect(profileQuotaLabel(profile, { now })).toBe("7d 64% / 0.64");
+    expect(profileWeeklyQuotaLabel(profile, { now })).toBe("7d 64% / 0.64");
+    expect(profileOptionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 7d 64% / 0.64");
     expect(profileTitle(profile, { now })).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
   });
 
-  it("shows weighted weekly quota normalized by reset time", () => {
+  it("shows weighted quota normalized by each window reset time", () => {
     const now = new Date("2026-05-09T00:00:00.000Z");
     const daysFromNow = (days: number) => Math.floor((now.getTime() + days * 24 * 60 * 60 * 1000) / 1000);
+    const hoursFromNow = (hours: number) => Math.floor((now.getTime() + hours * 60 * 60 * 1000) / 1000);
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "full-week",
       email: "full@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 0,
       secondaryResetsAt: daysFromNow(7)
-    }), { now })).toBe("100% | 1");
+    }), { now })).toBe("7d 100% / 1");
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "half-half-week",
       email: "half@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 50,
       secondaryResetsAt: daysFromNow(3.5)
-    }), { now })).toBe("50% | 1");
+    }), { now })).toBe("7d 50% / 1");
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "full-half-week",
       email: "fast@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 0,
       secondaryResetsAt: daysFromNow(3.5)
-    }), { now })).toBe("100% | 2");
+    }), { now })).toBe("7d 100% / 2");
 
     expect(profileWeeklyQuotaLabel(authProfile({
       name: "slow",
       email: "slow@example.com",
       planType: "pro",
       primaryUsed: 0,
+      primaryResetsAt: hoursFromNow(5),
       secondaryUsed: 43,
       secondaryResetsAt: daysFromNow(12)
-    }), { now })).toBe("57% | 0.33");
+    }), { now })).toBe("7d 57% / 0.33");
+
+    expect(profileQuotaLabel(authProfile({
+      name: "short-window-remaining-low-but-reset-soon",
+      email: "short-soon@example.com",
+      planType: "pro",
+      primaryUsed: 70,
+      primaryResetsAt: hoursFromNow(1),
+      secondaryUsed: 50,
+      secondaryResetsAt: daysFromNow(7)
+    }), { now })).toBe("7d 50% / 0.5");
+
+    expect(profileQuotaLabel(authProfile({
+      name: "short-window-pressure",
+      email: "short@example.com",
+      planType: "pro",
+      primaryUsed: 70,
+      primaryResetsAt: hoursFromNow(5),
+      secondaryUsed: 50,
+      secondaryResetsAt: daysFromNow(7)
+    }), { now })).toBe("7d 50% / 0.5 | 5h 30% / 0.3");
   });
 
   it("keeps unusable profiles readable without presenting their UUID as the label", () => {
@@ -94,6 +121,7 @@ function authProfile(options: {
   readonly email: string;
   readonly planType: string;
   readonly primaryUsed: number;
+  readonly primaryResetsAt?: number | undefined;
   readonly secondaryUsed: number;
   readonly secondaryResetsAt?: number | undefined;
 }): Record<string, any> {
@@ -114,7 +142,7 @@ function authProfile(options: {
         primary: {
           usedPercent: options.primaryUsed,
           windowDurationMins: 300,
-          resetsAt: 1_779_000_000
+          resetsAt: options.primaryResetsAt ?? 1_779_000_000
         },
         secondary: {
           usedPercent: options.secondaryUsed,

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -249,6 +249,83 @@ describe("admin control plane e2e", () => {
     });
   });
 
+  it("auto-allocates a blocked session auth profile and asks the worker to resume pending dispatch", async () => {
+    const workerResumePaths: string[] = [];
+    const worker = http.createServer((request, response) => {
+      workerResumePaths.push(request.url ?? "");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, resumedCount: 1 }));
+    });
+    await new Promise<void>((resolve) => worker.listen(0, "127.0.0.1", resolve));
+    cleanups.push(async () => {
+      await new Promise<void>((resolve, reject) => {
+        worker.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    });
+    const address = worker.address();
+    if (!address || typeof address === "string") {
+      throw new Error("failed to start worker fixture");
+    }
+
+    const { baseUrl, sessions } = await startAdminFixture({
+      workerBaseUrl: `http://127.0.0.1:${address.port}`,
+      authProfilesStatus: authProfilesStatusFixture()
+    });
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "old-thread");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "old-turn");
+    session = await sessions.setSessionAuthProfile(session.key, "empty-profile", {
+      boundAt: "2026-05-09T00:00:00.000Z"
+    });
+    await sessions.markSessionAuthBlocked(session.key, {
+      reason: "primary_quota_exhausted",
+      blockedAt: "2026-05-09T01:00:00.000Z"
+    });
+
+    const result = await postJson(
+      `${baseUrl}/admin/api/sessions/${encodeURIComponent(session.key)}/auth-profile`,
+      { mode: "auto" }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      selectedMode: "auto",
+      selectedProfileName: "usable-profile",
+      workerResume: {
+        ok: true,
+        resumedCount: 1
+      },
+      session: {
+        key: session.key,
+        authProfileName: "usable-profile",
+        authBlockedAt: null,
+        agentSessionId: null,
+        activeTurnId: null
+      }
+    });
+    expect(workerResumePaths).toEqual([
+      `/slack/sessions/${encodeURIComponent(session.key)}/resume-pending`
+    ]);
+    expect(sessions.getSessionByKey(session.key)).toMatchObject({
+      authProfileName: "usable-profile",
+      authBlockedAt: undefined,
+      authBlockReason: undefined,
+      agentSessionId: undefined,
+      activeTurnId: undefined
+    });
+    expect(sessions.listAgentTraceEvents(session.key, 10).at(-1)).toMatchObject({
+      title: "Auth Profile 已切换",
+      summary: "自动分配到 usable-profile，继续处理待处理消息",
+      metadata: {
+        profileName: "usable-profile",
+        selectionMode: "auto"
+      }
+    });
+  });
+
   it("exposes a tracked session reset operation and delegates history clearing to the worker", async () => {
     const workerPaths: string[] = [];
     let sessionsRef: SessionManager | undefined;

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -226,6 +226,82 @@ describe("admin routes", () => {
     expect(sessionViewSource).toContain("/admin/api/sessions/\" + encodeURIComponent(sessionKey) + \"/timeline");
   });
 
+  it("serves the GitHub bind session deep link and routes device OAuth api calls", async () => {
+    const calls: string[] = [];
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      getSessionGitHubIdentity: async (sessionKey: string) => {
+        calls.push(`identity:${sessionKey}`);
+        return {
+          ok: true,
+          sessionKey,
+          identity: {
+            binding: { state: "unbound" },
+            defaultAccount: { available: true, githubLogin: "default-bot" }
+          }
+        };
+      },
+      startSessionGitHubDeviceAuthorization: async (sessionKey: string) => {
+        calls.push(`start:${sessionKey}`);
+        return {
+          ok: true,
+          device: {
+            id: "device-1",
+            userCode: "ABCD-EFGH"
+          }
+        };
+      },
+      pollGitHubDeviceAuthorization: async (deviceAuthorizationId: string) => {
+        calls.push(`poll:${deviceAuthorizationId}`);
+        return {
+          ok: true,
+          result: { status: "pending" }
+        };
+      }
+    });
+    const sessionKey = "C123:111.222";
+
+    const page = await fetch(`${baseUrl}/admin/sessions/${encodeURIComponent(sessionKey)}/github/bind`);
+    expect(page.status).toBe(200);
+    await expect(page.text()).resolves.toContain('id="admin-root"');
+
+    const identity = await fetch(`${baseUrl}/admin/api/sessions/${encodeURIComponent(sessionKey)}/github-identity`);
+    expect(identity.status).toBe(200);
+    await expect(identity.json()).resolves.toMatchObject({
+      ok: true,
+      identity: {
+        binding: { state: "unbound" },
+        defaultAccount: { githubLogin: "default-bot" }
+      }
+    });
+
+    const started = await fetch(`${baseUrl}/admin/api/sessions/${encodeURIComponent(sessionKey)}/github-oauth/device/start`, {
+      method: "POST"
+    });
+    expect(started.status).toBe(200);
+    await expect(started.json()).resolves.toMatchObject({
+      ok: true,
+      device: {
+        id: "device-1",
+        userCode: "ABCD-EFGH"
+      }
+    });
+
+    const polled = await fetch(`${baseUrl}/admin/api/github-oauth/device/device-1`);
+    expect(polled.status).toBe(200);
+    await expect(polled.json()).resolves.toMatchObject({
+      ok: true,
+      result: { status: "pending" }
+    });
+    expect(calls).toEqual([
+      "identity:C123:111.222",
+      "start:C123:111.222",
+      "poll:device-1"
+    ]);
+  });
+
   it("persists session ui state in the admin page script", async () => {
     const baseUrl = await startAdminServer({
       SLACK_APP_TOKEN: "xapp-test",

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -269,6 +269,8 @@ describe("admin routes", () => {
     expect(sessionViewSource).toContain("ongoing");
     expect(adminClientSource).toContain("authProfileQuotaItems");
     expect(adminClientSource).toContain("profileTooltip");
+    expect(sessionViewSource).toContain("自动分配");
+    expect(sessionViewSource).toContain('mode: "auto"');
     expect(adminClientSource).not.toContain("renderAccountChip");
     expect(adminClientSource).not.toContain("refreshButton");
     expect(adminClientSource).not.toContain("lastRefresh");
@@ -284,13 +286,15 @@ describe("admin routes", () => {
     expect(adminCssSource).toContain("text-overflow: ellipsis");
     expect(adminCssSource).toContain("overflow-x: auto");
     expect(adminCssSource).toContain("flex: 0 0 auto");
+    expect(adminCssSource).toContain("grid-auto-rows: max-content");
+    expect(adminCssSource).toContain("align-content: start");
     expect(adminCssSource).toContain("html, body { width: 100%; height: 100%; overflow: hidden; }");
     expect(adminCssSource).toContain(".shell { width: 100%; height: 100dvh;");
     expect(adminCssSource).toContain("grid-template-columns: minmax(320px, 420px)");
     expect(adminCssSource).toContain(".session-detail-panel > .panel-body");
     expect(adminCssSource).toContain(".session-body { flex: 1; min-height: 0; overflow: hidden;");
     expect(adminCssSource).toContain(".session-timeline-panel .mini-body { flex: 1; min-height: 0; overflow: hidden;");
-    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; gap: 0; overflow: auto;");
+    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; grid-auto-rows: max-content; align-content: start;");
     expect(adminCssSource).toContain(".session-card { display: block; overflow: hidden; }");
     expect(adminCssSource).toContain(".session-meta-line { display: flex; gap: 4px; align-items: center; flex-wrap: nowrap;");
     expect(adminCssSource).toContain(".session-meta-pill { min-width: 0; max-width: 100%; flex: 0 1 auto;");
@@ -468,6 +472,44 @@ describe("admin routes", () => {
       {
         slackUserId: "U123",
         githubAuthor: "Alice Example <alice@example.com>"
+      }
+    ]);
+  });
+
+  it("forwards automatic session auth profile switches without requiring a profile name", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      getStatus: async () => ({ ok: true }),
+      addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      deployRelease: async () => ({ ok: true }),
+      rollbackRelease: async () => ({ ok: true }),
+      switchSessionAuthProfile: async (payload: Record<string, unknown>) => {
+        calls.push(payload);
+        return { ok: true };
+      }
+    });
+
+    const response = await fetch(`${baseUrl}/admin/api/sessions/${encodeURIComponent("C123:111.222")}/auth-profile`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        mode: "auto"
+      })
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([
+      {
+        sessionKey: "C123:111.222",
+        mode: "auto"
       }
     ]);
   });

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -307,7 +307,7 @@ describe("admin session row display", () => {
     }, authProfiles, new Map([["C123", "#ops"]]));
     const labels = meta.map((item) => item.label);
 
-    expect(labels).toEqual(["#ops", "64% | 0.64", "Token 5.1K"]);
+    expect(labels).toEqual(["#ops", "7d 64% / 0.64", "Token 5.1K"]);
     expect(labels.join(" ")).not.toContain("hejiachen@toeverything.info");
     expect(labels.join(" ")).not.toContain("Pro Lite");
     expect(shouldShowSessionState({ rank: 10 })).toBe(false);

--- a/test/admin-token-usage.e2e.test.ts
+++ b/test/admin-token-usage.e2e.test.ts
@@ -286,7 +286,7 @@ describe("admin token usage e2e", () => {
           <AuthProfilePanel`);
     expect(adminCssSource).toContain(".session-body { flex: 1; min-height: 0; overflow: hidden;");
     expect(adminCssSource).toContain(".session-timeline-panel .mini-body { flex: 1; min-height: 0; overflow: hidden;");
-    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; gap: 0; overflow: auto;");
+    expect(adminCssSource).toContain(".timeline { height: 100%; display: grid; grid-auto-rows: max-content; align-content: start;");
     expect(sessionViewSource).not.toContain("SessionHeaderPill");
     expect(sessionViewSource).not.toContain("session-detail-meta-strip");
     expect(adminCssSource).not.toContain(".session-permalink-panel .timeline");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -45,6 +45,12 @@ describe("loadConfig", () => {
     expect(config.isolatedMcpServers).toEqual(["linear", "notion"]);
     expect(config.codexDisabledMcpServers).toEqual(["*", "linear", "notion"]);
     expect(config.tempadLinkServiceUrl).toBeUndefined();
+    expect(config.githubOAuthClientId).toBeUndefined();
+    expect(config.githubOAuthBaseUrl).toBe("https://github.com/login/oauth");
+    expect(config.githubApiBaseUrl).toBe("https://api.github.com");
+    expect(config.githubOAuthScopes).toEqual(["repo", "read:user"]);
+    expect(config.defaultGitHubLogin).toBeUndefined();
+    expect(config.defaultGitHubToken).toBeUndefined();
     expect(config.adminBaseUrl).toBe("http://127.0.0.1:3000");
   });
 
@@ -132,6 +138,26 @@ describe("loadConfig", () => {
     } as NodeJS.ProcessEnv);
 
     expect(config.brokerAdminToken).toBe("secret-admin-token");
+  });
+
+  it("loads GitHub PR identity configuration", () => {
+    const config = loadConfig({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      GITHUB_OAUTH_CLIENT_ID: "github-client",
+      GITHUB_OAUTH_BASE_URL: "https://github.enterprise.test/login/oauth",
+      GITHUB_API_BASE_URL: "https://github.enterprise.test/api/v3",
+      GITHUB_OAUTH_SCOPES: "repo, read:user, workflow",
+      BROKER_DEFAULT_GITHUB_LOGIN: "default-bot",
+      BROKER_DEFAULT_GITHUB_TOKEN: "default-token"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.githubOAuthClientId).toBe("github-client");
+    expect(config.githubOAuthBaseUrl).toBe("https://github.enterprise.test/login/oauth");
+    expect(config.githubApiBaseUrl).toBe("https://github.enterprise.test/api/v3");
+    expect(config.githubOAuthScopes).toEqual(["repo", "read:user", "workflow"]);
+    expect(config.defaultGitHubLogin).toBe("default-bot");
+    expect(config.defaultGitHubToken).toBe("default-token");
   });
 
   it("parses disk cleanup configuration", () => {

--- a/test/e2e-broker.test.ts
+++ b/test/e2e-broker.test.ts
@@ -187,6 +187,82 @@ describe.sequential("slack-codex-broker e2e", () => {
     });
   }, 60_000);
 
+  it("records the session starter and warns about default GitHub PR fallback in the session link", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
+    cleanups.push(async () => {
+      await removeTempRoot(tempRoot);
+    });
+
+    const brokerPort = await getFreePort();
+    const mockSlack = new MockSlackServer("UBOT", {
+      botId: "BBOT",
+      appId: "AAPP"
+    });
+    const mockCodex = new MockCodexAppServer();
+    const slackPort = await mockSlack.start();
+    const codexUrl = await mockCodex.start();
+    cleanups.push(async () => {
+      await mockCodex.stop();
+      await mockSlack.stop();
+    });
+
+    const broker = await startBrokerProcess({
+      port: brokerPort,
+      slackPort,
+      codexUrl,
+      tempRoot,
+      extraEnv: {
+        ADMIN_BASE_URL: "https://admin.example.test",
+        BROKER_DEFAULT_GITHUB_LOGIN: "default-bot",
+        BROKER_DEFAULT_GITHUB_TOKEN: "default-token"
+      }
+    });
+    cleanups.push(() => broker.stop());
+
+    await mockSlack.sendEvent("evt-session-github-starter", {
+      type: "app_mention",
+      user: "U_STARTER",
+      channel: "C123",
+      thread_ts: "992.220",
+      ts: "992.221",
+      text: "<@UBOT> open a PR"
+    });
+
+    await waitFor(() => mockCodex.turnsStarted.length >= 1, "first turn start");
+    await waitFor(
+      () => mockSlack.postedMessages.some((message) =>
+        message.threadTs === "992.220" &&
+          message.text.includes("查看会话活动时间线") &&
+          message.text.includes("当前发起人还没有绑定 GitHub 账号") &&
+          message.text.includes("默认账号 default-bot") &&
+          message.text.includes("https://admin.example.test/admin/sessions/C123%3A992.220/github/bind")
+      ),
+      "session permalink GitHub fallback message"
+    );
+    await waitForSessionIdle(tempRoot, "C123:992.220");
+    await expect(readSessionRecord(tempRoot, "C123:992.220")).resolves.toMatchObject({
+      initiatorUserId: "U_STARTER",
+      initiatorMessageTs: "992.221",
+      initiatorCapturedAt: expect.any(String)
+    });
+
+    await mockSlack.sendEvent("evt-session-github-later", {
+      type: "message",
+      user: "U_LATER",
+      channel: "C123",
+      thread_ts: "992.220",
+      ts: "992.222",
+      text: "follow-up"
+    });
+
+    await waitFor(() => mockCodex.turnsStarted.length >= 2, "second turn start");
+    await waitForSessionIdle(tempRoot, "C123:992.220");
+    await expect(readSessionRecord(tempRoot, "C123:992.220")).resolves.toMatchObject({
+      initiatorUserId: "U_STARTER",
+      initiatorMessageTs: "992.221"
+    });
+  }, 60_000);
+
   it("falls back to an eyes reaction when Slack assistant status is unavailable", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-broker-e2e-"));
     cleanups.push(async () => {

--- a/test/gh-wrapper.test.ts
+++ b/test/gh-wrapper.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runGhWrapper } from "../src/tools/gh.js";
+
+describe("broker gh wrapper", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("asks the broker for the current session token and execs the real gh with GH_TOKEN", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-gh-wrapper-"));
+    cleanups.push(async () => fs.rm(tempRoot, { recursive: true, force: true }));
+    const capturePath = path.join(tempRoot, "capture.json");
+    const realGhPath = path.join(tempRoot, "real-gh.mjs");
+    await fs.writeFile(realGhPath, [
+      "#!/usr/bin/env node",
+      "import fs from 'node:fs/promises';",
+      "await fs.writeFile(process.env.CAPTURE_PATH, JSON.stringify({",
+      "  argv: process.argv.slice(2),",
+      "  ghToken: process.env.GH_TOKEN,",
+      "  cwd: process.cwd()",
+      "}));"
+    ].join("\n"));
+    await fs.chmod(realGhPath, 0o755);
+
+    let resolveRequest: Record<string, unknown> | undefined;
+    const server = http.createServer(async (request, response) => {
+      if (request.method !== "POST" || request.url !== "/slack/github-token/resolve") {
+        response.writeHead(404);
+        response.end();
+        return;
+      }
+      let body = "";
+      for await (const chunk of request) {
+        body += chunk;
+      }
+      resolveRequest = JSON.parse(body) as Record<string, unknown>;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        ok: true,
+        mode: "initiator",
+        githubLogin: "alice",
+        token: "starter-token"
+      }));
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+
+    const result = await runGhWrapper({
+      brokerApiBase: `http://127.0.0.1:${(server.address() as { port: number }).port}`,
+      realGhPath,
+      cwd: tempRoot,
+      argv: ["pr", "create", "--fill"],
+      env: {
+        ...process.env,
+        CAPTURE_PATH: capturePath
+      }
+    });
+
+    expect(result.status).toBe(0);
+    expect(resolveRequest).toMatchObject({
+      cwd: tempRoot,
+      command: ["pr", "create", "--fill"]
+    });
+    const realTempRoot = await fs.realpath(tempRoot);
+    await expect(fs.readFile(capturePath, "utf8").then(JSON.parse)).resolves.toMatchObject({
+      argv: ["pr", "create", "--fill"],
+      ghToken: "starter-token",
+      cwd: realTempRoot
+    });
+  });
+
+  it("does not call the real gh when broker token resolution blocks", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-gh-wrapper-"));
+    cleanups.push(async () => fs.rm(tempRoot, { recursive: true, force: true }));
+    const realGhPath = path.join(tempRoot, "real-gh.mjs");
+    await fs.writeFile(realGhPath, [
+      "#!/usr/bin/env node",
+      "throw new Error('real gh should not run');"
+    ].join("\n"));
+    await fs.chmod(realGhPath, 0o755);
+
+    const server = http.createServer((request, response) => {
+      if (request.method !== "POST" || request.url !== "/slack/github-token/resolve") {
+        response.writeHead(404);
+        response.end();
+        return;
+      }
+      response.writeHead(409, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        ok: false,
+        mode: "blocked",
+        reason: "initiator_token_invalid",
+        message: "GitHub token for alice is invalid."
+      }));
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+
+    const result = await runGhWrapper({
+      brokerApiBase: `http://127.0.0.1:${(server.address() as { port: number }).port}`,
+      realGhPath,
+      cwd: tempRoot,
+      argv: ["pr", "create"],
+      env: process.env
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("GitHub token for alice is invalid.");
+  });
+});

--- a/test/github-pr-identity-service.test.ts
+++ b/test/github-pr-identity-service.test.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GitHubPrIdentityService } from "../src/services/github-pr-identity-service.js";
+import type { SlackSessionRecord } from "../src/types.js";
+
+describe("GitHubPrIdentityService", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("resolves session PR identity from the bound initiator before falling back to the default account", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-pr-identity-"));
+    cleanups.push(async () => fs.rm(stateDir, { recursive: true, force: true }));
+    const service = new GitHubPrIdentityService({
+      stateDir,
+      defaultGitHubLogin: "default-bot",
+      defaultGitHubToken: "default-token"
+    });
+    await service.load();
+
+    await service.upsertBinding({
+      slackUserId: "U_STARTER",
+      githubLogin: "alice",
+      githubUserId: 101,
+      token: "alice-token",
+      scopes: ["repo"]
+    });
+
+    await expect(service.resolveTokenForSession({
+      session: session({ initiatorUserId: "U_STARTER" }),
+      command: ["pr", "create"]
+    })).resolves.toMatchObject({
+      ok: true,
+      mode: "initiator",
+      slackUserId: "U_STARTER",
+      githubLogin: "alice",
+      token: "alice-token"
+    });
+
+    await expect(service.resolveTokenForSession({
+      session: session({ initiatorUserId: "U_UNBOUND" }),
+      command: ["pr", "create"]
+    })).resolves.toMatchObject({
+      ok: true,
+      mode: "default",
+      githubLogin: "default-bot",
+      token: "default-token",
+      reason: "initiator_unbound"
+    });
+  });
+
+  it("blocks instead of silently falling back when the initiator binding is revoked", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-pr-identity-"));
+    cleanups.push(async () => fs.rm(stateDir, { recursive: true, force: true }));
+    const service = new GitHubPrIdentityService({
+      stateDir,
+      defaultGitHubLogin: "default-bot",
+      defaultGitHubToken: "default-token"
+    });
+    await service.load();
+
+    await service.upsertBinding({
+      slackUserId: "U_STARTER",
+      githubLogin: "alice",
+      githubUserId: 101,
+      token: "alice-token",
+      scopes: ["repo"],
+      revokedAt: "2026-05-13T00:00:00.000Z"
+    });
+
+    await expect(service.resolveTokenForSession({
+      session: session({ initiatorUserId: "U_STARTER" }),
+      command: ["pr", "create"]
+    })).resolves.toMatchObject({
+      ok: false,
+      mode: "blocked",
+      reason: "initiator_token_invalid",
+      githubLogin: "alice"
+    });
+  });
+
+  it("binds a Slack user through GitHub device code OAuth", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-pr-identity-"));
+    cleanups.push(async () => fs.rm(stateDir, { recursive: true, force: true }));
+    let accessPollCount = 0;
+    const server = http.createServer((request, response) => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "POST" && url.pathname === "/login/device/code") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({
+          device_code: "device-1",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://github.com/login/device",
+          expires_in: 900,
+          interval: 1
+        }));
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/login/oauth/access_token") {
+        accessPollCount += 1;
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(accessPollCount === 1
+          ? JSON.stringify({ error: "authorization_pending" })
+          : JSON.stringify({ access_token: "user-token", scope: "repo,read:user", token_type: "bearer" }));
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/user") {
+        expect(request.headers.authorization).toBe("Bearer user-token");
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ id: 42, login: "alice" }));
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    cleanups.push(async () => new Promise<void>((resolve) => server.close(() => resolve())));
+    const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    const service = new GitHubPrIdentityService({
+      stateDir,
+      githubOAuthClientId: "client-1",
+      githubOAuthBaseUrl: `${baseUrl}/login/oauth`,
+      githubApiBaseUrl: baseUrl
+    });
+    await service.load();
+
+    const started = await service.startDeviceAuthorization({
+      slackUserId: "U_STARTER"
+    });
+    expect(started).toMatchObject({
+      userCode: "ABCD-EFGH",
+      verificationUri: "https://github.com/login/device"
+    });
+
+    await expect(service.pollDeviceAuthorization(started.id)).resolves.toMatchObject({
+      status: "pending"
+    });
+    await expect(service.pollDeviceAuthorization(started.id)).resolves.toMatchObject({
+      status: "completed",
+      binding: {
+        slackUserId: "U_STARTER",
+        githubLogin: "alice",
+        githubUserId: 42
+      }
+    });
+    await expect(service.getBinding("U_STARTER")).resolves.toMatchObject({
+      token: "user-token",
+      scopes: ["repo", "read:user"]
+    });
+  });
+});
+
+function session(patch: Partial<SlackSessionRecord>): SlackSessionRecord {
+  return {
+    key: "C123:111.222",
+    channelId: "C123",
+    rootThreadTs: "111.222",
+    workspacePath: "/tmp/session",
+    createdAt: "2026-05-13T00:00:00.000Z",
+    updatedAt: "2026-05-13T00:00:00.000Z",
+    ...patch
+  };
+}

--- a/test/session-manager.test.ts
+++ b/test/session-manager.test.ts
@@ -48,6 +48,56 @@ describe("SessionManager", () => {
     });
   });
 
+  it("records the session initiator once and never replaces it with later input", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));
+    const store = new StateStore(stateDir, sessionsRoot);
+    const manager = new SessionManager({
+      stateStore: store,
+      sessionsRoot
+    });
+
+    await manager.load();
+    const created = await manager.ensureSession("C123", "111.222", {
+      channelName: "deep-review",
+      channelType: "channel",
+      initiatorUserId: "U_STARTER",
+      initiatorMessageTs: "111.223"
+    });
+
+    expect(created).toMatchObject({
+      initiatorUserId: "U_STARTER",
+      initiatorMessageTs: "111.223",
+      initiatorCapturedAt: expect.any(String)
+    });
+
+    const existing = await manager.ensureSession("C123", "111.222", {
+      channelName: "renamed",
+      initiatorUserId: "U_LATER",
+      initiatorMessageTs: "111.224"
+    });
+
+    expect(existing).toMatchObject({
+      channelName: "renamed",
+      initiatorUserId: "U_STARTER",
+      initiatorMessageTs: "111.223",
+      initiatorCapturedAt: created.initiatorCapturedAt
+    });
+
+    const reloadedStore = new StateStore(stateDir, sessionsRoot);
+    const reloadedManager = new SessionManager({
+      stateStore: reloadedStore,
+      sessionsRoot
+    });
+    await reloadedManager.load();
+
+    expect(reloadedManager.getSession("C123", "111.222")).toMatchObject({
+      initiatorUserId: "U_STARTER",
+      initiatorMessageTs: "111.223",
+      initiatorCapturedAt: created.initiatorCapturedAt
+    });
+  });
+
   it("updates codex thread and active turn metadata", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
     const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));

--- a/test/slack-routes.test.ts
+++ b/test/slack-routes.test.ts
@@ -93,4 +93,79 @@ describe("handleSlackRequest", () => {
     });
     expect(response.statusCode).toBe(200);
   });
+
+  it("resolves GitHub PR tokens through the bridge", async () => {
+    const resolveGitHubPrToken = vi.fn(async () => ({
+      ok: true,
+      mode: "initiator",
+      slackUserId: "U_STARTER",
+      githubLogin: "alice",
+      token: "alice-token"
+    }));
+    const request = createJsonRequest({
+      cwd: "/tmp/session/workspace",
+      command: ["pr", "create", "--fill"]
+    });
+    const response = createResponse();
+
+    const handled = await handleSlackRequest(
+      "POST",
+      new URL("http://localhost/slack/github-token/resolve"),
+      request as never,
+      response as never,
+      {
+        bridge: {
+          resolveGitHubPrToken
+        } as never,
+        config: {} as never
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(resolveGitHubPrToken).toHaveBeenCalledWith({
+      cwd: "/tmp/session/workspace",
+      command: ["pr", "create", "--fill"]
+    });
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.bodyText || "{}")).toMatchObject({
+      ok: true,
+      githubLogin: "alice",
+      token: "alice-token"
+    });
+  });
+
+  it("returns a blocking status when GitHub PR token resolution is blocked", async () => {
+    const resolveGitHubPrToken = vi.fn(async () => ({
+      ok: false,
+      mode: "blocked",
+      reason: "initiator_token_invalid",
+      message: "GitHub token for alice is invalid."
+    }));
+    const request = createJsonRequest({
+      cwd: "/tmp/session/workspace",
+      command: ["pr", "create"]
+    });
+    const response = createResponse();
+
+    const handled = await handleSlackRequest(
+      "POST",
+      new URL("http://localhost/slack/github-token/resolve"),
+      request as never,
+      response as never,
+      {
+        bridge: {
+          resolveGitHubPrToken
+        } as never,
+        config: {} as never
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(response.statusCode).toBe(409);
+    expect(JSON.parse(response.bodyText || "{}")).toMatchObject({
+      ok: false,
+      reason: "initiator_token_invalid",
+      message: "GitHub token for alice is invalid."
+    });
+  });
 });

--- a/test/state-store.test.ts
+++ b/test/state-store.test.ts
@@ -411,8 +411,12 @@ describe("StateStore", () => {
           name: "session_auth_profile_binding"
         },
         {
-          version: CURRENT_STATE_SCHEMA_VERSION,
+          version: 12,
           name: "agent_activity_bindings"
+        },
+        {
+          version: CURRENT_STATE_SCHEMA_VERSION,
+          name: "session_initiator"
         }
       ]);
     } finally {


### PR DESCRIPTION
## Summary
- record the Slack user who starts a session and keep that initiator stable
- add GitHub PR identity bindings via device-code OAuth and expose session bind links
- route session-local gh commands through the broker so PRs use the initiator token or the configured default account

## Tests
- pnpm test
- pnpm build