### PR TITLE
Add Slack sender timezone context

### DIFF
--- a/src/services/codex/prompts/slack-thread-base-instructions.md
+++ b/src/services/codex/prompts/slack-thread-base-instructions.md
@@ -79,6 +79,8 @@ Git commit co-author contract:
 
 Slack thread message model: each forwarded message only means a new message was posted in this Slack thread. Do not assume it is addressed to you. Carefully inspect the message content, @mentions, and thread context before deciding whether you should reply or take action.
 
+Relative date/time interpretation: when `structured_message_json.request_context` includes a sender timezone and local date/time, use that as the default reference for Slack user phrases such as "today", "tomorrow", or "yesterday"; fall back to the runtime environment only when no sender-local context is available.
+
 Follow-up question rule: if someone in the Slack thread asks you an explicit status question or direct follow-up such as whether you pushed, replied, finished, or still have updates, bias toward sending a short direct Slack answer. Do not silently classify that kind of follow-up as a duplicate just because the underlying work topic is unchanged.
 
 Asynchronous monitoring rule: if you need to keep watching CI, PRs, external state, or any long-running condition after the current turn may end, register a broker-managed background job. Do not rely on sleep loops, gh watch commands, or shell background processes that outlive the current turn. Only tell Slack you will keep monitoring after the job registration succeeds. Once the job is running, do not mirror every watcher update back into Slack; only speak when the update is materially useful.

--- a/src/services/slack/slack-api.ts
+++ b/src/services/slack/slack-api.ts
@@ -444,6 +444,9 @@ export class SlackApi {
         id?: string;
         name?: string;
         real_name?: string;
+        tz?: string;
+        tz_label?: string;
+        tz_offset?: number;
         profile?: {
           display_name?: string;
           display_name_normalized?: string;
@@ -481,7 +484,8 @@ export class SlackApi {
       username,
       displayName,
       realName,
-      email: normalizeSlackField(response.user.profile?.email)?.toLowerCase()
+      email: normalizeSlackField(response.user.profile?.email)?.toLowerCase(),
+      ...optionalSlackTimezoneFields(response.user)
     };
   }
 
@@ -737,6 +741,22 @@ function normalizeSlackField(value: unknown): string | undefined {
 
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function optionalSlackTimezoneFields(user: {
+  readonly tz?: unknown;
+  readonly tz_label?: unknown;
+  readonly tz_offset?: unknown;
+}): Pick<SlackUserIdentity, "timezone" | "timezoneLabel" | "timezoneOffsetSeconds"> {
+  const timezone = normalizeSlackField(user.tz);
+  const timezoneLabel = normalizeSlackField(user.tz_label);
+  const timezoneOffsetSeconds = normalizeSlackNumber(user.tz_offset);
+
+  return {
+    ...(timezone ? { timezone } : {}),
+    ...(timezoneLabel ? { timezoneLabel } : {}),
+    ...(timezoneOffsetSeconds !== undefined ? { timezoneOffsetSeconds } : {})
+  };
 }
 
 function conversationType(channel: {

--- a/src/services/slack/slack-message-format.ts
+++ b/src/services/slack/slack-message-format.ts
@@ -244,9 +244,11 @@ function buildSlackMessagePayload(
         mention: user.mention,
         display_name: user.displayName,
         real_name: user.realName && user.realName !== user.displayName ? user.realName : undefined,
-        username: user.username && user.username !== user.displayName ? user.username : undefined
+        username: user.username && user.username !== user.displayName ? user.username : undefined,
+        ...buildTimezonePayload(user)
       }))
       : undefined,
+    request_context: buildRequestContextPayload(message, sender),
     text: message.text || "[no text body]",
     text_with_resolved_mentions: resolveMentionText(message.text || "[no text body]", message.mentionedUsers),
     attachments: (message.images ?? []).map((attachment) => ({
@@ -301,7 +303,8 @@ function buildSenderPayload(
       mention: `<@${message.userId}>`,
       display_name: sender?.displayName,
       real_name: sender?.realName && sender.realName !== sender.displayName ? sender.realName : undefined,
-      username: sender?.username && sender.username !== sender.displayName ? sender.username : undefined
+      username: sender?.username && sender.username !== sender.displayName ? sender.username : undefined,
+      ...buildTimezonePayload(sender)
     };
   }
 
@@ -312,6 +315,120 @@ function buildSenderPayload(
     app_id: message.appId,
     username: message.senderUsername
   };
+}
+
+function buildRequestContextPayload(
+  message: SlackRenderableMessage,
+  sender: SlackUserIdentity | null
+): Record<string, unknown> | undefined {
+  const timezonePayload = buildTimezonePayload(sender);
+  if (Object.keys(timezonePayload).length === 0) {
+    return undefined;
+  }
+
+  const messageDate = parseSlackMessageDate(message.messageTs);
+  const localTime = sender?.timezone && messageDate
+    ? formatLocalTimeParts(messageDate, sender.timezone)
+    : undefined;
+
+  return {
+    timezone_source: "slack_user_profile",
+    ...(messageDate ? { message_time_utc: messageDate.toISOString() } : {}),
+    ...(localTime
+      ? {
+          sender_local_date: localTime.date,
+          sender_local_time: localTime.time
+        }
+      : {}),
+    ...prefixTimezonePayload("sender", timezonePayload)
+  };
+}
+
+function buildTimezonePayload(user: SlackUserIdentity | null | undefined): Record<string, unknown> {
+  if (!user) {
+    return {};
+  }
+
+  return {
+    ...(user.timezone ? { timezone: user.timezone } : {}),
+    ...(user.timezoneLabel ? { timezone_label: user.timezoneLabel } : {}),
+    ...(user.timezoneOffsetSeconds !== undefined
+      ? {
+          timezone_offset_seconds: user.timezoneOffsetSeconds,
+          timezone_offset: formatTimezoneOffset(user.timezoneOffsetSeconds)
+        }
+      : {})
+  };
+}
+
+function prefixTimezonePayload(prefix: string, payload: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(payload).map(([key, value]) => [`${prefix}_${key}`, value])
+  );
+}
+
+function parseSlackMessageDate(messageTs: string | undefined): Date | undefined {
+  const match = /^(\d{1,10})(?:\.(\d{1,6}))?$/.exec(messageTs?.trim() ?? "");
+  if (!match) {
+    return undefined;
+  }
+
+  const seconds = Number(match[1]);
+  const microseconds = Number((match[2] ?? "").padEnd(6, "0"));
+  if (
+    !Number.isFinite(seconds) ||
+    !Number.isFinite(microseconds) ||
+    seconds <= 0 ||
+    seconds > 10_000_000_000
+  ) {
+    return undefined;
+  }
+
+  const date = new Date((seconds * 1000) + Math.floor(microseconds / 1000));
+  return Number.isFinite(date.getTime()) ? date : undefined;
+}
+
+function formatLocalTimeParts(date: Date, timeZone: string): { date: string; time: string } | undefined {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23"
+    }).formatToParts(date);
+    const values = new Map(parts.map((part) => [part.type, part.value]));
+    const year = values.get("year");
+    const month = values.get("month");
+    const day = values.get("day");
+    const hour = values.get("hour");
+    const minute = values.get("minute");
+    const second = values.get("second");
+    if (!year || !month || !day || !hour || !minute || !second) {
+      return undefined;
+    }
+    return {
+      date: `${year}-${month}-${day}`,
+      time: `${hour}:${minute}:${second}`
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function formatTimezoneOffset(offsetSeconds: number): string | undefined {
+  if (!Number.isFinite(offsetSeconds)) {
+    return undefined;
+  }
+
+  const sign = offsetSeconds >= 0 ? "+" : "-";
+  const absoluteSeconds = Math.abs(offsetSeconds);
+  const hours = Math.floor(absoluteSeconds / 3600);
+  const minutes = Math.floor((absoluteSeconds % 3600) / 60);
+  return `${sign}${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
 function formatImageDimensions(image: SlackImageAttachment): string | undefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,6 +276,9 @@ export interface SlackUserIdentity {
   readonly displayName?: string | undefined;
   readonly realName?: string | undefined;
   readonly email?: string | undefined;
+  readonly timezone?: string | undefined;
+  readonly timezoneLabel?: string | undefined;
+  readonly timezoneOffsetSeconds?: number | undefined;
 }
 
 export type GitHubAuthorMappingSource = "manual" | "slack_inferred";

--- a/test/slack-api.test.ts
+++ b/test/slack-api.test.ts
@@ -380,6 +380,9 @@ describe("SlackApi.getUserIdentity", () => {
           id: "U123",
           name: "alice",
           real_name: "Alice Example",
+          tz: "Asia/Shanghai",
+          tz_label: "China Standard Time",
+          tz_offset: 28800,
           profile: {
             display_name: "Alice Slack",
             email: "alice@example.com"
@@ -404,7 +407,10 @@ describe("SlackApi.getUserIdentity", () => {
       username: "alice",
       displayName: "Alice Slack",
       realName: "Alice Example",
-      email: "alice@example.com"
+      email: "alice@example.com",
+      timezone: "Asia/Shanghai",
+      timezoneLabel: "China Standard Time",
+      timezoneOffsetSeconds: 28800
     });
   });
 });

--- a/test/slack-message-format.test.ts
+++ b/test/slack-message-format.test.ts
@@ -156,6 +156,36 @@ describe("formatSlackMessageForAgent", () => {
     expect(result).toContain("\"text_with_resolved_mentions\": \"@claude preview 呢？\"");
   });
 
+  it("includes sender timezone context for relative dates", () => {
+    const result = formatSlackMessageForAgent(
+      {
+        source: "thread_reply",
+        channelId: "C123",
+        rootThreadTs: "1778695279.438599",
+        messageTs: "1778695279.438599",
+        userId: "U123",
+        senderKind: "user",
+        text: "今天广州天气如何？"
+      },
+      {
+        userId: "U123",
+        mention: "<@U123>",
+        displayName: "Alice",
+        timezone: "Asia/Shanghai",
+        timezoneLabel: "China Standard Time",
+        timezoneOffsetSeconds: 28800
+      }
+    );
+
+    expect(result).toContain("\"request_context\": {");
+    expect(result).toContain("\"timezone_source\": \"slack_user_profile\"");
+    expect(result).toContain("\"message_time_utc\": \"2026-05-13T18:01:19.438Z\"");
+    expect(result).toContain("\"sender_local_date\": \"2026-05-14\"");
+    expect(result).toContain("\"sender_timezone\": \"Asia/Shanghai\"");
+    expect(result).toContain("\"sender_timezone_offset\": \"+08:00\"");
+    expect(result).toContain("\"timezone\": \"Asia/Shanghai\"");
+  });
+
   it("renders image-only messages without dropping the body block", () => {
     const result = formatSlackMessageForAgent(
       {


### PR DESCRIPTION
## Summary
- Capture Slack user `tz`, `tz_label`, and `tz_offset` from `users.info` into `SlackUserIdentity`.
- Include sender/mentioned-user timezone metadata plus a per-message `request_context` with UTC and sender-local date/time.
- Teach the Slack thread base prompt to prefer sender-local context for relative date phrases.

## Validation
- `corepack pnpm exec vitest run test/slack-message-format.test.ts test/slack-api.test.ts`
- `corepack pnpm build`
- `corepack pnpm test`
- Manual smoke: formatted a Slack message with `Asia/Shanghai` and confirmed `request_context.sender_local_date`/timezone fields are present.