### PR TITLE
[codex] Add npm package release deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,17 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Pack release artifact
-        run: pnpm pack --pack-destination artifacts
+      - name: Stage release packages
+        run: pnpm release:stage
+
+      - name: Pack admin release artifact
+        run: npm pack artifacts/npm-packages/admin --pack-destination artifacts
+
+      - name: Pack worker release artifact
+        run: npm pack artifacts/npm-packages/worker --pack-destination artifacts
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-session-broker-npm-package
+          name: agent-session-broker-npm-packages
           path: artifacts/*.tgz

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,16 +41,33 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Pack release artifact
-        run: pnpm pack --pack-destination artifacts
+      - name: Stage release packages
+        run: pnpm release:stage
 
-      - name: Upload release artifact
+      - name: Pack admin release artifact
+        run: npm pack artifacts/npm-packages/admin --pack-destination artifacts
+
+      - name: Pack worker release artifact
+        run: npm pack artifacts/npm-packages/worker --pack-destination artifacts
+
+      - name: Upload admin release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agent-session-broker-npm-package
-          path: artifacts/*.tgz
+          name: agent-session-broker-admin-npm-package
+          path: artifacts/agent-session-broker-admin-*.tgz
 
-      - name: Publish to npm
-        run: npm publish --access public --provenance
+      - name: Upload worker release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-session-broker-worker-npm-package
+          path: artifacts/agent-session-broker-worker-*.tgz
+
+      - name: Publish admin to npm
+        run: npm publish artifacts/npm-packages/admin --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish worker to npm
+        run: npm publish artifacts/npm-packages/worker --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,19 +1,20 @@
-name: CI
+name: Publish NPM Package
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  test:
-    name: Build and test
+  publish:
+    name: Build, test, pack, and publish
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -29,6 +30,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,3 +49,8 @@ jobs:
         with:
           name: agent-session-broker-npm-package
           path: artifacts/*.tgz
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+artifacts/
 
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -156,21 +156,24 @@ pnpm ops:ui:real
 
 The preferred macOS deployment model is package-first:
 
-- build and publish/pack the npm package outside the VM
+- build and publish/pack the admin and worker npm packages outside the VM
 - run the bootstrap script with the package version to install
 - upload `auth.json` later through the admin page
-- do all later deploy / rollback operations from the admin page by package version
+- do all later deploy / rollback operations from the admin page by target and
+  package version
 
 There is no host-side code sync or production build step in the normal path.
 
 ### First bootstrap on the VM
 
 ```bash
-npm install -g agent-session-broker@0.1.0
+npm install -g @agent-session-broker/admin@0.1.0
 agent-session-broker-macos-bootstrap --service-root ~/services/slack-codex-broker --package-version 0.1.0 --start-worker
 ```
 
-The bootstrap script installs `agent-session-broker@<version>` into the service root and points launchd at the installed package through the `current` symlink.
+The bootstrap script installs `@agent-session-broker/admin@<version>` and
+`@agent-session-broker/worker@<version>` into the service root. Admin launchd
+runs through `current-admin`; worker launchd runs through `current-worker`.
 
 Before running it, make sure the Slack app credentials are available through one of these sources:
 
@@ -179,8 +182,9 @@ Before running it, make sure the Slack app credentials are available through one
 
 What it prepares:
 
-- `releases/npm-<version>/` package installs for admin and worker releases
-- `current`, `previous`, and `failed` release links
+- `releases/admin/npm-<version>/` and `releases/worker/npm-<version>/` package installs
+- `current-admin`, `previous-admin`, `failed-admin` release links
+- `current-worker`, `previous-worker`, `failed-worker` release links
 - shared runtime state under `.data/`
 - support homes under `runtime-support/`
 - launchd agents for:
@@ -195,37 +199,44 @@ What it does not do:
 
 ### Runtime layout on the VM
 
-The npm package is the release unit. Runtime services execute code through the `current` release link, not from a source checkout.
+The npm packages are the release units. Runtime services execute code through
+their target-specific current release links, not from a source checkout.
 
 - `<service-root>/`:
   - release manager and shared runtime root
-- `<service-root>/releases/npm-<version>/`:
-  - npm install root for one package version
-- `<service-root>/current`:
-  - symlink to the active installed package root
-- `<service-root>/previous`:
-  - symlink to the last good admin/worker release
-- `<service-root>/failed`:
-  - symlink to the most recent failed cutover
+- `<service-root>/releases/admin/npm-<version>/`:
+  - npm install root for one admin package version
+- `<service-root>/releases/worker/npm-<version>/`:
+  - npm install root for one worker package version
+- `<service-root>/current-admin` and `<service-root>/current-worker`:
+  - symlinks to the active installed package roots
+- `<service-root>/previous-admin` and `<service-root>/previous-worker`:
+  - symlinks to the last good release for each target
+- `<service-root>/failed-admin` and `<service-root>/failed-worker`:
+  - symlinks to the most recent failed cutover for each target
 - `<service-root>/.data/`:
   - shared broker state, sessions, jobs, logs, repos, auth profiles, codex home
 
 ### Deploy and rollback
 
-The admin service deploys a selected npm package version into a new release directory. Both launchd agents are written to execute through `current`; the deploy operation switches `current`, restarts the worker immediately, then schedules the admin launchd restart after the API response so the request is not killed mid-flight.
+The admin service deploys a selected target and npm package version into a new
+release directory. Admin and worker are independent release targets: an admin
+deploy switches only `current-admin` and schedules only the admin restart; a
+worker deploy switches only `current-worker`, restarts the worker immediately,
+and waits for worker readiness.
 
 - deploy:
-  - read package versions from the npm registry
-  - install the selected package under `releases/npm-<version>`
-  - switch `current` to the new release
-  - restart the worker launchd service
+  - read package versions from the selected target's npm registry entry
+  - install the selected package under `releases/<target>/npm-<version>`
+  - switch that target's current symlink
+  - for worker deploys, restart the worker launchd service
   - run worker health + Codex-ready checks with a 90s startup window, because worker startup can spend tens of seconds reconciling Slack thread state before `/readyz` answers
-  - schedule the admin launchd service restart from the same `current` release
+  - for admin deploys, schedule the admin launchd service restart from `current-admin`
   - auto-rollback on failed cutover
 - rollback:
-  - switch `current` back to `previous`, or to an explicitly selected installed package version
-  - restart the worker and schedule the admin restart
-  - run the same health checks
+  - switch the requested target back to `previous-*`, or to an explicitly selected installed package version
+  - restart only that target's launchd service
+  - run worker health checks only for worker rollback
 
 Because old releases stay on disk, rollback is a pointer switch. It does not fetch source or build a missing version.
 

--- a/README.md
+++ b/README.md
@@ -154,24 +154,23 @@ pnpm ops:ui:real
 
 ## Run On a macOS VM
 
-The preferred macOS deployment model is now GitHub-first:
+The preferred macOS deployment model is package-first:
 
-- clone this repository directly on the VM
-- run the bootstrap script from inside that clone
+- build and publish/pack the npm package outside the VM
+- run the bootstrap script with the package version to install
 - upload `auth.json` later through the admin page
-- do all later deploy / rollback operations from the admin page by Git ref
+- do all later deploy / rollback operations from the admin page by package version
 
-There is no host-side code sync step in the normal path anymore.
+There is no host-side code sync or production build step in the normal path.
 
 ### First bootstrap on the VM
 
 ```bash
-git clone https://github.com/zzj3720/slack-codex-broker.git ~/services/slack-codex-broker
-cd ~/services/slack-codex-broker
-node scripts/ops/macos-bootstrap.mjs --start-worker
+npm install -g agent-session-broker@0.1.0
+agent-session-broker-macos-bootstrap --service-root ~/services/slack-codex-broker --package-version 0.1.0 --start-worker
 ```
 
-The bootstrap script expects to run inside the VM's long-lived clone and uses that clone as the stable admin/control repo.
+The bootstrap script installs `agent-session-broker@<version>` into the service root and points launchd at the installed package through the `current` symlink.
 
 Before running it, make sure the Slack app credentials are available through one of these sources:
 
@@ -180,31 +179,30 @@ Before running it, make sure the Slack app credentials are available through one
 
 What it prepares:
 
-- `releases/<sha>` worktrees for admin and worker releases
+- `releases/npm-<version>/` package installs for admin and worker releases
 - `current`, `previous`, and `failed` release links
 - shared runtime state under `.data/`
 - support homes under `runtime-support/`
 - launchd agents for:
-  - `com.zzj3720.slack-codex-broker` (admin/control plane)
-  - `com.zzj3720.slack-codex-broker.worker` (Slack/Codex worker)
+  - `io.github.hoolc.agent-session-broker` (admin/control plane)
+  - `io.github.hoolc.agent-session-broker.worker` (Slack/Codex worker)
 
 What it does not do:
 
 - it does not copy `auth.json`; import auth profiles later through `/admin`
 - it does not copy historical sessions, logs, jobs, or repo caches from another machine
-- it does not require `pnpm` to already be installed globally; it uses Corepack and the repo-pinned pnpm version
+- it does not run `pnpm install` or `pnpm build` on the VM
 
 ### Runtime layout on the VM
 
-The fixed clone is the Git source of truth for release worktrees. Runtime services execute code through the `current` release link, not directly from the fixed clone.
+The npm package is the release unit. Runtime services execute code through the `current` release link, not from a source checkout.
 
 - `<service-root>/`:
-  - long-lived git clone
   - release manager and shared runtime root
-- `<service-root>/releases/<sha>/`:
-  - admin and worker build for a specific commit
+- `<service-root>/releases/npm-<version>/`:
+  - npm install root for one package version
 - `<service-root>/current`:
-  - symlink to the active admin/worker release
+  - symlink to the active installed package root
 - `<service-root>/previous`:
   - symlink to the last good admin/worker release
 - `<service-root>/failed`:
@@ -214,24 +212,22 @@ The fixed clone is the Git source of truth for release worktrees. Runtime servic
 
 ### Deploy and rollback
 
-The admin service fetches from the VM's local Git clone and deploys a selected ref into a new release directory. Both launchd agents are written to execute through `current`; the deploy operation switches `current`, restarts the worker immediately, then schedules the admin launchd restart after the API response so the request is not killed mid-flight.
+The admin service deploys a selected npm package version into a new release directory. Both launchd agents are written to execute through `current`; the deploy operation switches `current`, restarts the worker immediately, then schedules the admin launchd restart after the API response so the request is not killed mid-flight.
 
 - deploy:
-  - `git fetch origin`
-  - resolve commit / branch / tag
-  - create or reuse `releases/<sha>`
-  - build there
+  - read package versions from the npm registry
+  - install the selected package under `releases/npm-<version>`
   - switch `current` to the new release
   - restart the worker launchd service
   - run worker health + Codex-ready checks with a 90s startup window, because worker startup can spend tens of seconds reconciling Slack thread state before `/readyz` answers
   - schedule the admin launchd service restart from the same `current` release
   - auto-rollback on failed cutover
 - rollback:
-  - switch `current` back to `previous`, or to an explicitly selected ref
+  - switch `current` back to `previous`, or to an explicitly selected installed package version
   - restart the worker and schedule the admin restart
   - run the same health checks
 
-Because old releases stay on disk, rollback is a pointer switch instead of a rebuild.
+Because old releases stay on disk, rollback is a pointer switch. It does not fetch source or build a missing version.
 
 ### Admin surface
 
@@ -253,7 +249,7 @@ Typical first-run flow:
 1. Open `/admin`.
 2. Upload one or more `auth.json` files into Auth Profiles.
 3. Activate the profile you want the worker to use.
-4. Later, deploy a commit / branch / tag from the Deploy panel.
+4. Later, deploy a package version from the Deploy panel.
 5. Roll back from the same panel when needed.
 
 The same admin page also exposes a `GitHub Authors` panel for manually maintaining `Slack user -> GitHub author` mappings. Manual entries override Slack-inferred mappings.

--- a/docs/admin-react-ui.md
+++ b/docs/admin-react-ui.md
@@ -53,6 +53,9 @@ Status data flows through a React hook backed by `admin-status-store`:
 - `/admin/api/overview` is loaded after the session index, with bounded runtime
   probes, so account quota, auth profile, GitHub, or deploy status reads cannot
   keep the whole admin page blank;
+- the browser-side session and overview request budgets must be long enough for
+  the real production data reads used by preview/admin. They stay bounded, but
+  the UI must not give up before session and account data arrive;
 - `/admin/api/overview` must not scan the full inbound-message history; Slack
   account rows are composed in React from the already loaded session summaries
   plus OAuth bindings;
@@ -109,8 +112,25 @@ be React state and refs, not global DOM lookup.
 
 The operations page must preserve existing behavior:
 
-- publish and rollback show deployment status and run preflight confirmation;
+- operation modules are first-class sections with stronger boundaries than
+  their internal rows. The page uses dedicated operations layout and panel
+  classes so publish, audit records, account pool, GitHub accounts, logs, and
+  service status read as separate modules without adding table-like separators
+  inside each module;
+- admin pages do not expose free-text search boxes. Session navigation uses
+  explicit status filters, and account panels show their full bounded lists;
+- publish uses a package-version selector instead of a free-form text field.
+  Candidates are recent npm package versions reported by the deployment service.
+  Rollback is not a parallel top-level input; each recent installed package
+  release row exposes its own rollback action. Publish and rollback still show
+  deployment status and run preflight confirmation;
 - auth profiles list current accounts, quota, and deletion;
+- auth profile rows render as structured account cards: identity and plan first,
+  then weekly remaining, weighted score, reset time, and any short-window pressure.
+  They avoid redundant dark sub-containers, repeated generic account copy, and
+  table-like internal separator lines; hierarchy comes from spacing, type, and
+  color only.
+  Deletion is a secondary danger action, not the main visual weight of the row;
 - adding auth profiles prefers device-code OAuth and keeps auth.json as the
   fallback;
 - operation records and audit records remain visible;
@@ -130,7 +150,11 @@ After the React migration, GitHub account work continues in React:
   and default PR account flag;
 - the old manual commit-author editing path is not shown; rows bind existing
   Slack users to GitHub OAuth identities;
-- setting the default PR account only accepts a bound non-revoked OAuth account.
+- setting the default PR account only accepts a bound non-revoked OAuth account;
+- the default PR control shows account identity only in the selector. Surrounding
+  text is limited to the field label and action state, so the same identity is
+  not repeated as summary, selected option, and action text. The label, selector,
+  and switch action stay on one row as a single form control group.
 
 ## Acceptance Criteria
 
@@ -140,6 +164,8 @@ After the React migration, GitHub account work continues in React:
 - `admin-shell` exports React components, not an HTML string renderer.
 - Business UI files do not use `getElementById`, `querySelector`, or
   `innerHTML` for rendering or event binding.
+- Admin business UI does not render `type="search"` inputs or keep free-text
+  search state such as `sessionSearch`.
 - `/admin` still serves one app shell and the production Vite assets.
 - `/admin/sessions/:key` still deep links into the session React view.
 - `/admin/sessions/:key/github/bind` renders a dedicated GitHub binding page
@@ -177,4 +203,10 @@ After the React migration, GitHub account work continues in React:
   failed, and already-cancelled jobs do not show a cancel action.
 - The session detail operation panel displays the selected auth profile with
   account identity, plan, and quota. Dense quota labels elsewhere remain compact.
+- The operations page account pool uses structured account cards with separate
+  quota metrics while the top quota strip remains compact.
+- The GitHub default PR account control shows account identity only once, in the
+  selector, and lays out label, selector, and action on one row.
+- The publish control uses a select for package versions and does not render a
+  free-form `提交 / 分支 / 标签` input or Git ref selector.
 - `pnpm test` and `pnpm build` pass.

--- a/docs/admin-react-ui.md
+++ b/docs/admin-react-ui.md
@@ -119,8 +119,9 @@ The operations page must preserve existing behavior:
   inside each module;
 - admin pages do not expose free-text search boxes. Session navigation uses
   explicit status filters, and account panels show their full bounded lists;
-- publish uses a package-version selector instead of a free-form text field.
-  Candidates are recent npm package versions reported by the deployment service.
+- publish uses target and package-version selectors instead of a free-form text
+  field. Candidates are recent npm package versions reported by the deployment
+  service for the selected admin or worker target.
   Rollback is not a parallel top-level input; each recent installed package
   release row exposes its own rollback action. Publish and rollback still show
   deployment status and run preflight confirmation;
@@ -207,6 +208,6 @@ After the React migration, GitHub account work continues in React:
   quota metrics while the top quota strip remains compact.
 - The GitHub default PR account control shows account identity only once, in the
   selector, and lays out label, selector, and action on one row.
-- The publish control uses a select for package versions and does not render a
-  free-form `提交 / 分支 / 标签` input or Git ref selector.
+- The publish control uses selects for target and package versions and does not
+  render a free-form `提交 / 分支 / 标签` input or Git ref selector.
 - `pnpm test` and `pnpm build` pass.

--- a/docs/npm-package-deployment.md
+++ b/docs/npm-package-deployment.md
@@ -2,73 +2,89 @@
 
 ## Goal
 
-Ship broker releases as built npm packages, then let admin deploy and roll back
-installed package versions.
+Ship broker releases as built npm packages, with separate admin and worker
+release units.
 
 Production must not be a build machine. CI or a release workstation builds the
-TypeScript and admin assets, packs the npm artifact, and publishes or stores that
-artifact. The live admin process only chooses a package version, installs that
-version into a versioned release directory, switches the `current` symlink, and
-restarts the launchd services.
+TypeScript and admin assets, stages runtime-only package directories, and
+publishes versioned npm artifacts. The live admin process only chooses a package
+target and version, installs that version into a versioned release directory,
+switches that target's `current` symlink, and restarts only the affected launchd
+service.
 
 ## Current State
 
-The current release path is Git based:
+The old release path was Git based:
 
-- the live machine keeps a repository clone;
-- admin fetches refs from that clone;
-- deploy creates a Git worktree under `releases/<sha>`;
-- deploy runs `pnpm install`, `pnpm build`, then `pnpm install --prod` on the
+- the live machine kept a repository clone;
+- admin fetched refs from that clone;
+- deploy created a Git worktree under `releases/<sha>`;
+- deploy ran `pnpm install`, `pnpm build`, then `pnpm install --prod` on the
   live machine;
-- rollback can resolve an arbitrary Git ref and build it if that release is not
-  already present.
+- rollback could resolve an arbitrary Git ref and build it if that release was
+  not already present.
 
-That couples live deploy safety to Git/network/build behavior on the production
-host. It also makes the public package boundary unclear because deployment relies
-on a whole checkout instead of a runtime artifact.
+The first npm refactor still used one package as the release unit. That was safer
+than Git worktrees, but it coupled admin UI releases and worker runtime releases:
+an admin-only UI change still activated the worker package path, and a worker
+deploy also implied an admin package change.
 
 ## Target Design
 
-The release unit is the npm package:
+The release units are scoped npm packages under the `agent-session-broker` npm
+organization:
 
-The package is named `agent-session-broker`, not after Slack or Codex. The
-release artifact should describe the stable abstraction: sessions from external
-message systems connected to agent runtimes. Slack and Codex are adapters inside
-that package, not the package identity.
+- `@agent-session-broker/admin` contains the admin HTTP entry point, admin UI
+  assets, and the launchd helpers needed by the admin service.
+- `@agent-session-broker/worker` contains the worker entry point and the launchd
+  helpers needed by the worker service.
+
+The root package is a private build workspace. It must not be published as the
+runtime artifact.
 
 1. `pnpm build` creates `dist/` with server code, copied prompt assets, and the
    built admin UI.
-2. `pnpm release:pack` packs the runtime package from explicit `package.json`
-   `files`.
-3. CI always builds, tests, and packs an artifact for the checked commit.
-4. The npm publish workflow publishes that same package to npm for versioned
+2. `pnpm release:stage` creates runtime-only package directories for admin and
+   worker from explicit package templates.
+3. `pnpm release:pack` packs both staged package directories.
+4. CI always builds, tests, stages, and packs both artifacts for the checked
+   commit.
+5. The npm publish workflow publishes both packages to npm for versioned
    releases.
-5. The admin deployment service reads candidate versions from the package
-   registry.
-6. Deploy installs `agent-session-broker@<version>` into
-   `<service-root>/releases/npm-<version>/`.
-7. The `current` symlink points at the installed package root inside that release
-   directory.
-8. Rollback only activates a release that is already installed locally. It never
-   fetches source or builds a missing version during rollback.
+6. The admin deployment service reads candidate versions from each target's
+   package registry entry.
+7. Deploy requires `{ target, version }` where target is `admin` or `worker`.
+8. Admin deploy installs `@agent-session-broker/admin@<version>` into
+   `<service-root>/releases/admin/npm-<version>/`, switches the admin current
+   symlink, and restarts only the admin launchd service.
+9. Worker deploy installs `@agent-session-broker/worker@<version>` into
+   `<service-root>/releases/worker/npm-<version>/`, switches the worker current
+   symlink, restarts only the worker launchd service, and waits for worker
+   readiness.
+10. Rollback requires a target and only activates a release already installed
+    locally for that target. It never fetches source or builds a missing version
+    during rollback.
 
 Package contents are runtime-only:
 
-- `dist/`;
+- package metadata;
+- `dist/src/`;
+- `dist/admin-ui/` only for the admin package;
 - launchd helper scripts needed by installed services;
-- README, license, and package metadata.
+- README and license.
 
 Source files, tests, local state, generated preview data, and private operator
-configuration are not part of the package.
+configuration are not part of either package.
 
 ## Publish Workflow
 
 Npm publication is a release operation, not a side effect of every push.
 
-- Pull requests and pushes run CI build, test, and pack.
+- Pull requests and pushes run CI build, test, stage, and pack.
 - Versioned release tags and manual dispatch run the npm publish workflow.
 - The publish workflow installs dependencies from the lockfile, builds, tests,
-  packs the artifact for inspection, then runs `npm publish`.
+  stages both package directories, packs both artifacts for inspection, then runs
+  `npm publish` for both staged package directories.
 - The workflow uses `NPM_TOKEN` from GitHub Actions secrets and does not store
   npm credentials in the repository.
 - The workflow requests GitHub OIDC permission and publishes with npm
@@ -86,28 +102,35 @@ repository metadata, deployment commands, and UI labels. Avoid tests like
 
 ## Admin UX
 
-The publish panel selects package versions, not free-form refs or main commits.
+The publish panel selects target and package version, not free-form refs or main
+commits.
 
-- The deploy selector lists recent package versions returned by deployment
-  status.
-- The deploy request sends a version.
-- The recent release list remains the rollback surface.
-- Each rollback button activates that already-installed package release.
+- The target selector chooses admin or worker.
+- The version selector lists recent package versions returned for the selected
+  target.
+- The deploy request sends `{ target, version }`.
+- The recent release list is grouped by target.
+- Each rollback button activates that already-installed target release.
 
 ## Acceptance Criteria
 
-- `package.json` has explicit package metadata for the public repository.
-- `package.json` exposes a runtime-only `files` boundary for packed releases.
-- CI builds, tests, and packs the npm artifact.
-- `.github/workflows/npm-publish.yml` publishes `agent-session-broker` from
+- The root `package.json` is private and acts as the build workspace.
+- Admin package metadata names `@agent-session-broker/admin`.
+- Worker package metadata names `@agent-session-broker/worker`.
+- Package staging creates runtime-only directories for both packages.
+- CI builds, tests, stages, and packs both npm artifacts.
+- `.github/workflows/npm-publish.yml` publishes both scoped packages from
   versioned release tags or manual dispatch using `NPM_TOKEN`.
-- Admin deployment status reports package name and recent package versions.
-- Admin publish UI selects a package version.
-- `/admin/api/deploy` requires a package `version`, not a Git `ref`.
+- Admin deployment status reports admin and worker package targets separately.
+- Admin publish UI selects target and package version.
+- `/admin/api/deploy` requires target and package version.
+- `/admin/api/rollback` requires target and uses an optional package version.
 - `ReleaseDeploymentService.deploy` does not run Git fetch/worktree commands.
 - `ReleaseDeploymentService.deploy` does not run `pnpm install` or
   `pnpm build` on the live host.
-- `ReleaseDeploymentService.rollback` only uses local installed releases.
-- Launchd services still execute through the `current` symlink.
+- `ReleaseDeploymentService.rollback` only uses local installed releases for
+  the requested target.
+- Admin launchd runs through the admin current symlink.
+- Worker launchd runs through the worker current symlink.
 - Regression tests avoid private-string negative assertions.
 - `pnpm test` and `pnpm build` pass.

--- a/docs/npm-package-deployment.md
+++ b/docs/npm-package-deployment.md
@@ -1,0 +1,113 @@
+# NPM Package Deployment
+
+## Goal
+
+Ship broker releases as built npm packages, then let admin deploy and roll back
+installed package versions.
+
+Production must not be a build machine. CI or a release workstation builds the
+TypeScript and admin assets, packs the npm artifact, and publishes or stores that
+artifact. The live admin process only chooses a package version, installs that
+version into a versioned release directory, switches the `current` symlink, and
+restarts the launchd services.
+
+## Current State
+
+The current release path is Git based:
+
+- the live machine keeps a repository clone;
+- admin fetches refs from that clone;
+- deploy creates a Git worktree under `releases/<sha>`;
+- deploy runs `pnpm install`, `pnpm build`, then `pnpm install --prod` on the
+  live machine;
+- rollback can resolve an arbitrary Git ref and build it if that release is not
+  already present.
+
+That couples live deploy safety to Git/network/build behavior on the production
+host. It also makes the public package boundary unclear because deployment relies
+on a whole checkout instead of a runtime artifact.
+
+## Target Design
+
+The release unit is the npm package:
+
+The package is named `agent-session-broker`, not after Slack or Codex. The
+release artifact should describe the stable abstraction: sessions from external
+message systems connected to agent runtimes. Slack and Codex are adapters inside
+that package, not the package identity.
+
+1. `pnpm build` creates `dist/` with server code, copied prompt assets, and the
+   built admin UI.
+2. `pnpm release:pack` packs the runtime package from explicit `package.json`
+   `files`.
+3. CI always builds, tests, and packs an artifact for the checked commit.
+4. The npm publish workflow publishes that same package to npm for versioned
+   releases.
+5. The admin deployment service reads candidate versions from the package
+   registry.
+6. Deploy installs `agent-session-broker@<version>` into
+   `<service-root>/releases/npm-<version>/`.
+7. The `current` symlink points at the installed package root inside that release
+   directory.
+8. Rollback only activates a release that is already installed locally. It never
+   fetches source or builds a missing version during rollback.
+
+Package contents are runtime-only:
+
+- `dist/`;
+- launchd helper scripts needed by installed services;
+- README, license, and package metadata.
+
+Source files, tests, local state, generated preview data, and private operator
+configuration are not part of the package.
+
+## Publish Workflow
+
+Npm publication is a release operation, not a side effect of every push.
+
+- Pull requests and pushes run CI build, test, and pack.
+- Versioned release tags and manual dispatch run the npm publish workflow.
+- The publish workflow installs dependencies from the lockfile, builds, tests,
+  packs the artifact for inspection, then runs `npm publish`.
+- The workflow uses `NPM_TOKEN` from GitHub Actions secrets and does not store
+  npm credentials in the repository.
+- The workflow requests GitHub OIDC permission and publishes with npm
+  provenance.
+
+## Public Boundary
+
+Open-source metadata must point at the public repository. Tests and fixtures may
+use reserved example identities, but must not encode real operator emails,
+accounts, hosts, domains, or tokens as negative assertions.
+
+The right test shape is to assert the expected public structure: package files,
+repository metadata, deployment commands, and UI labels. Avoid tests like
+"repository does not contain X" where `X` is a real private value.
+
+## Admin UX
+
+The publish panel selects package versions, not free-form refs or main commits.
+
+- The deploy selector lists recent package versions returned by deployment
+  status.
+- The deploy request sends a version.
+- The recent release list remains the rollback surface.
+- Each rollback button activates that already-installed package release.
+
+## Acceptance Criteria
+
+- `package.json` has explicit package metadata for the public repository.
+- `package.json` exposes a runtime-only `files` boundary for packed releases.
+- CI builds, tests, and packs the npm artifact.
+- `.github/workflows/npm-publish.yml` publishes `agent-session-broker` from
+  versioned release tags or manual dispatch using `NPM_TOKEN`.
+- Admin deployment status reports package name and recent package versions.
+- Admin publish UI selects a package version.
+- `/admin/api/deploy` requires a package `version`, not a Git `ref`.
+- `ReleaseDeploymentService.deploy` does not run Git fetch/worktree commands.
+- `ReleaseDeploymentService.deploy` does not run `pnpm install` or
+  `pnpm build` on the live host.
+- `ReleaseDeploymentService.rollback` only uses local installed releases.
+- Launchd services still execute through the `current` symlink.
+- Regression tests avoid private-string negative assertions.
+- `pnpm test` and `pnpm build` pass.

--- a/docs/session-github-pr-identity.md
+++ b/docs/session-github-pr-identity.md
@@ -131,7 +131,7 @@ Example:
 Session 页面：https://...
 
 当前发起人还没有绑定 GitHub 账号。
-不绑定时，后续创建 PR 会使用默认账号 zzj3720。
+不绑定时，后续创建 PR 会使用默认账号 default-bot。
 绑定 GitHub：https://.../session/<key>/github/bind
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "agent-session-broker",
+  "name": "agent-session-broker-repo",
   "version": "0.1.0",
+  "private": true,
   "description": "Slack Socket Mode broker that routes Slack threads into Codex app-server sessions with isolated workspaces.",
   "license": "MIT",
   "repository": {
@@ -13,20 +14,6 @@
   "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "bin": {
-    "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"
-  },
-  "files": [
-    "dist/src/",
-    "dist/admin-ui/",
-    "scripts/ops/*.mjs",
-    "README.md",
-    "LICENSE"
-  ],
   "engines": {
     "node": ">=22.5.0"
   },
@@ -45,7 +32,8 @@
     "ops:rollout:real": "node scripts/ops/rollout-real.mjs",
     "ops:status:real": "node scripts/ops/status-real.mjs",
     "ops:macos:bootstrap": "node scripts/ops/macos-bootstrap.mjs",
-    "release:pack": "pnpm build && pnpm pack --pack-destination artifacts",
+    "release:stage": "node scripts/build/stage-npm-packages.mjs",
+    "release:pack": "pnpm build && pnpm release:stage && find artifacts -maxdepth 1 -name '*.tgz' -delete && npm pack artifacts/npm-packages/admin --pack-destination artifacts && npm pack artifacts/npm-packages/worker --pack-destination artifacts",
     "start": "node dist/src/index.js",
     "start:admin": "node dist/src/admin-index.js",
     "start:worker": "node dist/src/worker-index.js",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,32 @@
 {
-  "name": "slack-codex-broker",
+  "name": "agent-session-broker",
   "version": "0.1.0",
   "description": "Slack Socket Mode broker that routes Slack threads into Codex app-server sessions with isolated workspaces.",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zzj3720/slack-codex-broker.git"
+    "url": "git+https://github.com/HOOLC/slack-codex-broker.git"
   },
   "bugs": {
-    "url": "https://github.com/zzj3720/slack-codex-broker/issues"
+    "url": "https://github.com/HOOLC/slack-codex-broker/issues"
   },
-  "homepage": "https://github.com/zzj3720/slack-codex-broker#readme",
+  "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "bin": {
+    "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"
+  },
+  "files": [
+    "dist/src/",
+    "dist/admin-ui/",
+    "scripts/ops/*.mjs",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=22.5.0"
   },
@@ -31,6 +45,7 @@
     "ops:rollout:real": "node scripts/ops/rollout-real.mjs",
     "ops:status:real": "node scripts/ops/status-real.mjs",
     "ops:macos:bootstrap": "node scripts/ops/macos-bootstrap.mjs",
+    "release:pack": "pnpm build && pnpm pack --pack-destination artifacts",
     "start": "node dist/src/index.js",
     "start:admin": "node dist/src/admin-index.js",
     "start:worker": "node dist/src/worker-index.js",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@agent-session-broker/admin",
+  "version": "0.1.0",
+  "description": "Admin service and UI for the agent session broker.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HOOLC/slack-codex-broker.git"
+  },
+  "bugs": {
+    "url": "https://github.com/HOOLC/slack-codex-broker/issues"
+  },
+  "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
+  "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "bin": {
+    "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"
+  },
+  "files": [
+    "dist/src/",
+    "dist/admin-ui/",
+    "scripts/ops/macos-bootstrap.mjs",
+    "scripts/ops/macos-launchd-launcher.mjs",
+    "scripts/ops/macos-launchd-restart.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=22.5.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.27.1",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "ws": "^8.18.3"
+  }
+}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@agent-session-broker/worker",
+  "version": "0.1.0",
+  "description": "Worker runtime for the agent session broker.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HOOLC/slack-codex-broker.git"
+  },
+  "bugs": {
+    "url": "https://github.com/HOOLC/slack-codex-broker/issues"
+  },
+  "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
+  "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "files": [
+    "dist/src/",
+    "scripts/ops/macos-launchd-launcher.mjs",
+    "scripts/ops/macos-launchd-restart.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=22.5.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.27.1",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "ws": "^8.18.3"
+  }
+}

--- a/scripts/build/stage-npm-packages.mjs
+++ b/scripts/build/stage-npm-packages.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const stageRoot = path.join(repoRoot, "artifacts", "npm-packages");
+
+const packageTargets = [
+  {
+    source: path.join(repoRoot, "packages", "admin"),
+    destination: path.join(stageRoot, "admin"),
+    includeAdminUi: true,
+    scripts: [
+      "macos-bootstrap.mjs",
+      "macos-launchd-launcher.mjs",
+      "macos-launchd-restart.mjs"
+    ]
+  },
+  {
+    source: path.join(repoRoot, "packages", "worker"),
+    destination: path.join(stageRoot, "worker"),
+    includeAdminUi: false,
+    scripts: [
+      "macos-launchd-launcher.mjs",
+      "macos-launchd-restart.mjs"
+    ]
+  }
+];
+
+await fs.rm(stageRoot, { force: true, recursive: true });
+
+for (const target of packageTargets) {
+  await stagePackage(target);
+}
+
+async function stagePackage(target) {
+  await fs.mkdir(target.destination, { recursive: true });
+  await copyFile(path.join(target.source, "package.json"), path.join(target.destination, "package.json"));
+  await copyFile(path.join(repoRoot, "README.md"), path.join(target.destination, "README.md"));
+  await copyFile(path.join(repoRoot, "LICENSE"), path.join(target.destination, "LICENSE"));
+  await copyDirectory(path.join(repoRoot, "dist", "src"), path.join(target.destination, "dist", "src"));
+  if (target.includeAdminUi) {
+    await copyDirectory(path.join(repoRoot, "dist", "admin-ui"), path.join(target.destination, "dist", "admin-ui"));
+  }
+  for (const script of target.scripts) {
+    await copyFile(
+      path.join(repoRoot, "scripts", "ops", script),
+      path.join(target.destination, "scripts", "ops", script)
+    );
+  }
+}
+
+async function copyFile(source, destination) {
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.copyFile(source, destination);
+}
+
+async function copyDirectory(source, destination) {
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.cp(source, destination, { recursive: true });
+}

--- a/scripts/ops/macos-bootstrap.mjs
+++ b/scripts/ops/macos-bootstrap.mjs
@@ -68,12 +68,14 @@ function readDefaultPackageInfo() {
   try {
     const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
     return {
-      name: packageJson.name || "agent-session-broker",
+      adminName: "@agent-session-broker/admin",
+      workerName: "@agent-session-broker/worker",
       version: packageJson.version || "latest"
     };
   } catch {
     return {
-      name: "agent-session-broker",
+      adminName: "@agent-session-broker/admin",
+      workerName: "@agent-session-broker/worker",
       version: "latest"
     };
   }
@@ -86,7 +88,8 @@ function parseArgs(argv) {
     workerLabel: DEFAULT_WORKER_LABEL,
     nodePath: DEFAULT_NODE_PATH,
     npmPath: undefined,
-    packageName: DEFAULT_PACKAGE_INFO.name,
+    adminPackageName: DEFAULT_PACKAGE_INFO.adminName,
+    workerPackageName: DEFAULT_PACKAGE_INFO.workerName,
     packageVersion: DEFAULT_PACKAGE_INFO.version,
     npmRegistryUrl: undefined,
     codexVersion: DEFAULT_CODEX_VERSION,
@@ -117,8 +120,12 @@ function parseArgs(argv) {
         options.npmPath = argv[index + 1];
         index += 1;
         break;
-      case "--package-name":
-        options.packageName = argv[index + 1];
+      case "--admin-package-name":
+        options.adminPackageName = argv[index + 1];
+        index += 1;
+        break;
+      case "--worker-package-name":
+        options.workerPackageName = argv[index + 1];
         index += 1;
         break;
       case "--package-version":
@@ -160,12 +167,12 @@ function printHelp() {
       "",
       "What it does:",
       "  - prepares shared runtime directories under the service root",
-      "  - installs a built npm package under releases/npm-<version>",
+      "  - installs built admin and worker npm packages under releases/<target>/npm-<version>",
       "  - writes admin/worker launchd plists and env files",
       "  - starts admin immediately; worker is optional",
       "",
       "Notes:",
-      "  - preferred flow: install this package, then run this script with --package-version",
+      "  - preferred flow: install the admin package, then run this script with --package-version",
       "  - auth.json is not copied by this script; import auth profiles later through /admin",
       "  - Slack tokens come from the current shell env or an existing config/broker.env",
       "",
@@ -176,7 +183,8 @@ function printHelp() {
       "  --start-worker                      Also start the worker after bootstrap",
       "  --node-path <path>                  Node binary for launchd",
       "  --npm-path <path>                   npm binary, default next to --node-path",
-      "  --package-name <name>               Broker npm package name",
+      "  --admin-package-name <name>         Admin npm package name",
+      "  --worker-package-name <name>        Worker npm package name",
       "  --package-version <version>         Broker npm package version",
       "  --npm-registry-url <url>            Optional npm registry URL",
       "  --codex-version <version>           codex CLI version to install globally",
@@ -418,9 +426,12 @@ function buildPaths(serviceRoot, options) {
     serviceRoot,
     repoRoot: serviceRoot,
     releasesRoot: path.join(serviceRoot, "releases"),
-    currentReleasePath: path.join(serviceRoot, "current"),
-    previousReleasePath: path.join(serviceRoot, "previous"),
-    failedReleasePath: path.join(serviceRoot, "failed"),
+    currentAdminReleasePath: path.join(serviceRoot, "current-admin"),
+    previousAdminReleasePath: path.join(serviceRoot, "previous-admin"),
+    failedAdminReleasePath: path.join(serviceRoot, "failed-admin"),
+    currentWorkerReleasePath: path.join(serviceRoot, "current-worker"),
+    previousWorkerReleasePath: path.join(serviceRoot, "previous-worker"),
+    failedWorkerReleasePath: path.join(serviceRoot, "failed-worker"),
     dataRoot: path.join(serviceRoot, ".data"),
     runtimeSupportRoot: path.join(serviceRoot, "runtime-support"),
     codexSupportHome: path.join(serviceRoot, "runtime-support", "codex"),
@@ -439,11 +450,12 @@ function buildPaths(serviceRoot, options) {
   };
 }
 
-function buildReleaseMetadata(packageName, packageVersion) {
+function buildReleaseMetadata(target, packageName, packageVersion) {
   return {
     revision: null,
     shortRevision: null,
     branch: null,
+    target,
     packageName,
     packageVersion,
     packageSpec: packageSpec(packageName, packageVersion),
@@ -451,7 +463,7 @@ function buildReleaseMetadata(packageName, packageVersion) {
     installedAt: new Date().toISOString(),
     installedBy: os.userInfo().username,
     installedFromHost: os.hostname(),
-    stateSchemaVersion: 2
+    stateSchemaVersion: 3
   };
 }
 
@@ -498,12 +510,16 @@ function buildAdminEnv(paths, options, seedBrokerEnv) {
     ADMIN_LAUNCHD_LABEL: options.adminLabel,
     WORKER_LAUNCHD_LABEL: options.workerLabel,
     ADMIN_PLIST_PATH: paths.adminPlistPath,
-    RELEASE_PACKAGE_NAME: options.packageName,
+    RELEASE_ADMIN_PACKAGE_NAME: options.adminPackageName,
+    RELEASE_WORKER_PACKAGE_NAME: options.workerPackageName,
     ...(options.npmRegistryUrl ? { RELEASE_NPM_REGISTRY_URL: options.npmRegistryUrl } : {}),
     RELEASES_ROOT: paths.releasesRoot,
-    CURRENT_RELEASE_PATH: paths.currentReleasePath,
-    PREVIOUS_RELEASE_PATH: paths.previousReleasePath,
-    FAILED_RELEASE_PATH: paths.failedReleasePath,
+    CURRENT_ADMIN_RELEASE_PATH: paths.currentAdminReleasePath,
+    PREVIOUS_ADMIN_RELEASE_PATH: paths.previousAdminReleasePath,
+    FAILED_ADMIN_RELEASE_PATH: paths.failedAdminReleasePath,
+    CURRENT_WORKER_RELEASE_PATH: paths.currentWorkerReleasePath,
+    PREVIOUS_WORKER_RELEASE_PATH: paths.previousWorkerReleasePath,
+    FAILED_WORKER_RELEASE_PATH: paths.failedWorkerReleasePath,
     WORKER_PLIST_PATH: paths.workerPlistPath
   };
 }
@@ -536,13 +552,17 @@ function buildWorkerEnv(paths, options, seedBrokerEnv) {
     WORKER_LAUNCHD_LABEL: options.workerLabel,
     ADMIN_PLIST_PATH: paths.adminPlistPath,
     WORKER_PLIST_PATH: paths.workerPlistPath,
-    RELEASE_PACKAGE_NAME: options.packageName,
+    RELEASE_ADMIN_PACKAGE_NAME: options.adminPackageName,
+    RELEASE_WORKER_PACKAGE_NAME: options.workerPackageName,
     ...(options.npmRegistryUrl ? { RELEASE_NPM_REGISTRY_URL: options.npmRegistryUrl } : {}),
     RELEASES_ROOT: paths.releasesRoot,
-    CURRENT_RELEASE_PATH: paths.currentReleasePath,
-    PREVIOUS_RELEASE_PATH: paths.previousReleasePath,
-    FAILED_RELEASE_PATH: paths.failedReleasePath,
-    BROKER_GEMINI_UI_HELPER: path.join(paths.currentReleasePath, "dist", "src", "tools", "gemini-ui.js")
+    CURRENT_ADMIN_RELEASE_PATH: paths.currentAdminReleasePath,
+    PREVIOUS_ADMIN_RELEASE_PATH: paths.previousAdminReleasePath,
+    FAILED_ADMIN_RELEASE_PATH: paths.failedAdminReleasePath,
+    CURRENT_WORKER_RELEASE_PATH: paths.currentWorkerReleasePath,
+    PREVIOUS_WORKER_RELEASE_PATH: paths.previousWorkerReleasePath,
+    FAILED_WORKER_RELEASE_PATH: paths.failedWorkerReleasePath,
+    BROKER_GEMINI_UI_HELPER: path.join(paths.currentWorkerReleasePath, "dist", "src", "tools", "gemini-ui.js")
   };
 }
 
@@ -572,12 +592,29 @@ async function prepareSharedHomes(paths) {
   await copyDirectoryResolved(sourceAgentsHome, paths.agentsSupportHome);
 }
 
-async function ensureInitialWorkerRelease(paths, options) {
+async function ensureInitialReleases(paths, options) {
   const version = normalizePackageVersion(options.packageVersion);
-  const installRoot = path.join(paths.releasesRoot, `npm-${version}`);
-  const releaseRoot = packageRootForInstallRoot(installRoot, options.packageName);
+  const admin = await ensureInitialReleaseTarget(paths, options, {
+    target: "admin",
+    packageName: options.adminPackageName,
+    currentReleasePath: paths.currentAdminReleasePath
+  }, version);
+  const worker = await ensureInitialReleaseTarget(paths, options, {
+    target: "worker",
+    packageName: options.workerPackageName,
+    currentReleasePath: paths.currentWorkerReleasePath
+  }, version);
+  return {
+    admin,
+    worker
+  };
+}
+
+async function ensureInitialReleaseTarget(paths, options, targetOptions, version) {
+  const installRoot = path.join(paths.releasesRoot, targetOptions.target, `npm-${version}`);
+  const releaseRoot = packageRootForInstallRoot(installRoot, targetOptions.packageName);
   const npmPath = options.npmPath || path.join(path.dirname(options.nodePath), "npm");
-  await ensureDir(paths.releasesRoot);
+  await ensureDir(path.dirname(installRoot));
   if (!(await fileExists(releaseRoot))) {
     await fs.rm(installRoot, { recursive: true, force: true });
     runCommand(npmPath, [
@@ -589,31 +626,36 @@ async function ensureInitialWorkerRelease(paths, options) {
       "--no-audit",
       "--no-fund",
       ...(options.npmRegistryUrl ? ["--registry", options.npmRegistryUrl] : []),
-      packageSpec(options.packageName, version)
+      packageSpec(targetOptions.packageName, version)
     ]);
   }
   await fs.writeFile(
     path.join(releaseRoot, RELEASE_METADATA_FILENAME),
-    `${JSON.stringify(buildReleaseMetadata(options.packageName, version), null, 2)}\n`,
+    `${JSON.stringify(buildReleaseMetadata(targetOptions.target, targetOptions.packageName, version), null, 2)}\n`,
     "utf8"
   );
 
-  await fs.rm(paths.currentReleasePath, { recursive: true, force: true });
-  await fs.symlink(path.relative(path.dirname(paths.currentReleasePath), releaseRoot), paths.currentReleasePath, "dir");
+  await fs.rm(targetOptions.currentReleasePath, { recursive: true, force: true });
+  await fs.symlink(
+    path.relative(path.dirname(targetOptions.currentReleasePath), releaseRoot),
+    targetOptions.currentReleasePath,
+    "dir"
+  );
   return {
-    packageName: options.packageName,
+    packageName: targetOptions.packageName,
     packageVersion: version,
     releaseRoot
   };
 }
 
 async function writeLaunchdFiles(paths, options, seedBrokerEnv) {
-  const launcherPath = path.join(paths.currentReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
+  const adminLauncherPath = path.join(paths.currentAdminReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
+  const workerLauncherPath = path.join(paths.currentWorkerReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
   const adminPlist = renderPlist({
     label: options.adminLabel,
     nodePath: options.nodePath,
-    launcherPath,
-    repoRootPath: paths.currentReleasePath,
+    launcherPath: adminLauncherPath,
+    repoRootPath: paths.currentAdminReleasePath,
     envFilePath: paths.adminEnvFile,
     entryPoint: "dist/src/admin-index.js",
     stdoutPath: paths.adminStdoutPath,
@@ -622,8 +664,8 @@ async function writeLaunchdFiles(paths, options, seedBrokerEnv) {
   const workerPlist = renderPlist({
     label: options.workerLabel,
     nodePath: options.nodePath,
-    launcherPath,
-    repoRootPath: paths.currentReleasePath,
+    launcherPath: workerLauncherPath,
+    repoRootPath: paths.currentWorkerReleasePath,
     envFilePath: paths.workerEnvFile,
     entryPoint: "dist/src/worker-index.js",
     stdoutPath: paths.workerStdoutPath,
@@ -667,7 +709,7 @@ async function main() {
 
   await prepareSharedHomes(paths);
   await installTooling(options);
-  const initialRelease = await ensureInitialWorkerRelease(paths, options);
+  const initialReleases = await ensureInitialReleases(paths, options);
   await writeLaunchdFiles(paths, options, seedBrokerEnv);
 
   bootout(paths.adminPlistPath);
@@ -687,8 +729,9 @@ async function main() {
         serviceRoot: paths.serviceRoot,
         adminPlistPath: paths.adminPlistPath,
         workerPlistPath: paths.workerPlistPath,
-        currentReleasePath: paths.currentReleasePath,
-        initialRelease,
+        currentAdminReleasePath: paths.currentAdminReleasePath,
+        currentWorkerReleasePath: paths.currentWorkerReleasePath,
+        initialReleases,
         workerStarted: options.startWorker
       },
       null,

--- a/scripts/ops/macos-bootstrap.mjs
+++ b/scripts/ops/macos-bootstrap.mjs
@@ -8,13 +8,12 @@ import path from "node:path";
 import { repoRoot, runCommand } from "./lib.mjs";
 
 const DEFAULT_SERVICE_ROOT = repoRoot;
-const DEFAULT_ADMIN_LABEL = "com.zzj3720.slack-codex-broker";
-const DEFAULT_WORKER_LABEL = "com.zzj3720.slack-codex-broker.worker";
+const DEFAULT_ADMIN_LABEL = "io.github.hoolc.agent-session-broker";
+const DEFAULT_WORKER_LABEL = "io.github.hoolc.agent-session-broker.worker";
 const DEFAULT_NODE_PATH = "/opt/homebrew/opt/node@24/bin/node";
-const DEFAULT_COREPACK_PATH = "/opt/homebrew/opt/node@24/bin/corepack";
 const DEFAULT_CODEX_VERSION = "0.114.0";
 const DEFAULT_GEMINI_VERSION = "0.33.0";
-const DEFAULT_PNPM_VERSION = readDefaultPnpmVersion();
+const DEFAULT_PACKAGE_INFO = readDefaultPackageInfo();
 const RELEASE_METADATA_FILENAME = ".broker-release.json";
 
 const CODEX_HOME_FILE_ENTRIES = [
@@ -65,18 +64,19 @@ const BROKER_ENV_PASSTHROUGH_KEYS = [
   "BROKER_ADMIN_TOKEN"
 ];
 
-function readDefaultPnpmVersion() {
+function readDefaultPackageInfo() {
   try {
     const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
-    const packageManager = packageJson.packageManager?.trim();
-    if (packageManager?.startsWith("pnpm@")) {
-      return packageManager.slice("pnpm@".length);
-    }
+    return {
+      name: packageJson.name || "agent-session-broker",
+      version: packageJson.version || "latest"
+    };
   } catch {
-    // fall back to a pinned version below
+    return {
+      name: "agent-session-broker",
+      version: "latest"
+    };
   }
-
-  return "10.33.0";
 }
 
 function parseArgs(argv) {
@@ -85,8 +85,10 @@ function parseArgs(argv) {
     adminLabel: DEFAULT_ADMIN_LABEL,
     workerLabel: DEFAULT_WORKER_LABEL,
     nodePath: DEFAULT_NODE_PATH,
-    corepackPath: DEFAULT_COREPACK_PATH,
-    pnpmVersion: DEFAULT_PNPM_VERSION,
+    npmPath: undefined,
+    packageName: DEFAULT_PACKAGE_INFO.name,
+    packageVersion: DEFAULT_PACKAGE_INFO.version,
+    npmRegistryUrl: undefined,
     codexVersion: DEFAULT_CODEX_VERSION,
     geminiVersion: DEFAULT_GEMINI_VERSION,
     startWorker: false
@@ -111,12 +113,20 @@ function parseArgs(argv) {
         options.nodePath = argv[index + 1];
         index += 1;
         break;
-      case "--corepack-path":
-        options.corepackPath = argv[index + 1];
+      case "--npm-path":
+        options.npmPath = argv[index + 1];
         index += 1;
         break;
-      case "--pnpm-version":
-        options.pnpmVersion = argv[index + 1];
+      case "--package-name":
+        options.packageName = argv[index + 1];
+        index += 1;
+        break;
+      case "--package-version":
+        options.packageVersion = argv[index + 1];
+        index += 1;
+        break;
+      case "--npm-registry-url":
+        options.npmRegistryUrl = argv[index + 1];
         index += 1;
         break;
       case "--codex-version":
@@ -149,15 +159,13 @@ function printHelp() {
       "  node scripts/ops/macos-bootstrap.mjs [options]",
       "",
       "What it does:",
-      "  - expects to run inside the VM's long-lived git clone",
-      "  - uses that clone as the stable Git source for release worktrees",
       "  - prepares shared runtime directories under the service root",
-      "  - creates an admin/worker release from the current commit under releases/<sha>",
+      "  - installs a built npm package under releases/npm-<version>",
       "  - writes admin/worker launchd plists and env files",
       "  - starts admin immediately; worker is optional",
       "",
       "Notes:",
-      "  - preferred flow: git clone on the VM, cd into the repo, then run this script there",
+      "  - preferred flow: install this package, then run this script with --package-version",
       "  - auth.json is not copied by this script; import auth profiles later through /admin",
       "  - Slack tokens come from the current shell env or an existing config/broker.env",
       "",
@@ -167,8 +175,10 @@ function printHelp() {
       `  --worker-label <label>              Worker launchd label, default ${DEFAULT_WORKER_LABEL}`,
       "  --start-worker                      Also start the worker after bootstrap",
       "  --node-path <path>                  Node binary for launchd",
-      "  --corepack-path <path>              Corepack binary",
-      "  --pnpm-version <version>            pnpm version to activate",
+      "  --npm-path <path>                   npm binary, default next to --node-path",
+      "  --package-name <name>               Broker npm package name",
+      "  --package-version <version>         Broker npm package version",
+      "  --npm-registry-url <url>            Optional npm registry URL",
       "  --codex-version <version>           codex CLI version to install globally",
       "  --gemini-version <version>          gemini CLI version to install globally"
     ].join("\n")
@@ -429,16 +439,36 @@ function buildPaths(serviceRoot, options) {
   };
 }
 
-function buildReleaseMetadata(revision) {
+function buildReleaseMetadata(packageName, packageVersion) {
   return {
-    revision,
-    shortRevision: revision ? revision.slice(0, 12) : null,
-    branch: runCommand("git", ["branch", "--show-current"], { capture: true, cwd: repoRoot }) || null,
-    builtAt: new Date().toISOString(),
-    builtBy: os.userInfo().username,
-    builtFromHost: os.hostname(),
-    stateSchemaVersion: 1
+    revision: null,
+    shortRevision: null,
+    branch: null,
+    packageName,
+    packageVersion,
+    packageSpec: packageSpec(packageName, packageVersion),
+    requestedVersion: packageVersion,
+    installedAt: new Date().toISOString(),
+    installedBy: os.userInfo().username,
+    installedFromHost: os.hostname(),
+    stateSchemaVersion: 2
   };
+}
+
+function packageSpec(packageName, version) {
+  return `${packageName}@${version}`;
+}
+
+function packageRootForInstallRoot(installRoot, packageName) {
+  return path.join(installRoot, "node_modules", ...packageName.split("/"));
+}
+
+function normalizePackageVersion(version) {
+  const normalized = String(version || "").trim();
+  if (!normalized || !/^[0-9A-Za-z][0-9A-Za-z._+-]*$/.test(normalized)) {
+    throw new Error(`Invalid package version: ${version}`);
+  }
+  return normalized;
 }
 
 function buildAdminEnv(paths, options, seedBrokerEnv) {
@@ -468,7 +498,8 @@ function buildAdminEnv(paths, options, seedBrokerEnv) {
     ADMIN_LAUNCHD_LABEL: options.adminLabel,
     WORKER_LAUNCHD_LABEL: options.workerLabel,
     ADMIN_PLIST_PATH: paths.adminPlistPath,
-    RELEASE_REPO_ROOT: paths.repoRoot,
+    RELEASE_PACKAGE_NAME: options.packageName,
+    ...(options.npmRegistryUrl ? { RELEASE_NPM_REGISTRY_URL: options.npmRegistryUrl } : {}),
     RELEASES_ROOT: paths.releasesRoot,
     CURRENT_RELEASE_PATH: paths.currentReleasePath,
     PREVIOUS_RELEASE_PATH: paths.previousReleasePath,
@@ -505,7 +536,8 @@ function buildWorkerEnv(paths, options, seedBrokerEnv) {
     WORKER_LAUNCHD_LABEL: options.workerLabel,
     ADMIN_PLIST_PATH: paths.adminPlistPath,
     WORKER_PLIST_PATH: paths.workerPlistPath,
-    RELEASE_REPO_ROOT: paths.repoRoot,
+    RELEASE_PACKAGE_NAME: options.packageName,
+    ...(options.npmRegistryUrl ? { RELEASE_NPM_REGISTRY_URL: options.npmRegistryUrl } : {}),
     RELEASES_ROOT: paths.releasesRoot,
     CURRENT_RELEASE_PATH: paths.currentReleasePath,
     PREVIOUS_RELEASE_PATH: paths.previousReleasePath,
@@ -515,9 +547,7 @@ function buildWorkerEnv(paths, options, seedBrokerEnv) {
 }
 
 async function installTooling(options) {
-  const npmPath = path.join(path.dirname(options.nodePath), "npm");
-  runCommand(options.corepackPath, ["enable"]);
-  runCommand(options.corepackPath, ["prepare", `pnpm@${options.pnpmVersion}`, "--activate"]);
+  const npmPath = options.npmPath || path.join(path.dirname(options.nodePath), "npm");
   runCommand(npmPath, [
     "install",
     "-g",
@@ -525,12 +555,6 @@ async function installTooling(options) {
     `@openai/codex@${options.codexVersion}`,
     `@google/gemini-cli@${options.geminiVersion}`
   ]);
-}
-
-async function installRepoAtPath(repoPath, options) {
-  runCommand(options.corepackPath, ["pnpm", "install", "--frozen-lockfile"], { cwd: repoPath });
-  runCommand(options.corepackPath, ["pnpm", "build"], { cwd: repoPath });
-  runCommand(options.corepackPath, ["pnpm", "install", "--prod", "--frozen-lockfile"], { cwd: repoPath });
 }
 
 async function prepareSharedHomes(paths) {
@@ -549,26 +573,36 @@ async function prepareSharedHomes(paths) {
 }
 
 async function ensureInitialWorkerRelease(paths, options) {
-  const revision = runCommand("git", ["rev-parse", "HEAD"], { capture: true, cwd: paths.repoRoot });
-  const releaseRoot = path.join(paths.releasesRoot, revision);
+  const version = normalizePackageVersion(options.packageVersion);
+  const installRoot = path.join(paths.releasesRoot, `npm-${version}`);
+  const releaseRoot = packageRootForInstallRoot(installRoot, options.packageName);
+  const npmPath = options.npmPath || path.join(path.dirname(options.nodePath), "npm");
   await ensureDir(paths.releasesRoot);
-  if (!(await fileExists(path.join(releaseRoot, ".git")))) {
-    if (await fileExists(releaseRoot)) {
-      await fs.rm(releaseRoot, { recursive: true, force: true });
-    }
-    runCommand("git", ["-C", paths.repoRoot, "worktree", "add", "--detach", releaseRoot, revision]);
+  if (!(await fileExists(releaseRoot))) {
+    await fs.rm(installRoot, { recursive: true, force: true });
+    runCommand(npmPath, [
+      "install",
+      "--prefix",
+      installRoot,
+      "--omit=dev",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      ...(options.npmRegistryUrl ? ["--registry", options.npmRegistryUrl] : []),
+      packageSpec(options.packageName, version)
+    ]);
   }
-  await installRepoAtPath(releaseRoot, options);
   await fs.writeFile(
     path.join(releaseRoot, RELEASE_METADATA_FILENAME),
-    `${JSON.stringify(buildReleaseMetadata(revision), null, 2)}\n`,
+    `${JSON.stringify(buildReleaseMetadata(options.packageName, version), null, 2)}\n`,
     "utf8"
   );
 
   await fs.rm(paths.currentReleasePath, { recursive: true, force: true });
   await fs.symlink(path.relative(path.dirname(paths.currentReleasePath), releaseRoot), paths.currentReleasePath, "dir");
   return {
-    revision,
+    packageName: options.packageName,
+    packageVersion: version,
     releaseRoot
   };
 }
@@ -633,7 +667,6 @@ async function main() {
 
   await prepareSharedHomes(paths);
   await installTooling(options);
-  await installRepoAtPath(paths.repoRoot, options);
   const initialRelease = await ensureInitialWorkerRelease(paths, options);
   await writeLaunchdFiles(paths, options, seedBrokerEnv);
 

--- a/src/admin-index.ts
+++ b/src/admin-index.ts
@@ -86,7 +86,6 @@ export async function startAdminService(): Promise<{
 function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): ReleaseDeploymentService | undefined {
   if (
     !config.serviceRoot ||
-    !config.releaseRepoRoot ||
     !config.releasesRoot ||
     !config.currentReleasePath ||
     !config.previousReleasePath ||
@@ -101,7 +100,6 @@ function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): 
 
   return new ReleaseDeploymentService({
     serviceRoot: config.serviceRoot,
-    repoRoot: config.releaseRepoRoot,
     releasesRoot: config.releasesRoot,
     currentReleasePath: config.currentReleasePath,
     previousReleasePath: config.previousReleasePath,
@@ -113,7 +111,8 @@ function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): 
     workerLaunchdLabel: config.workerLaunchdLabel,
     workerBaseUrl: config.workerBaseUrl,
     codexAppServerPort: config.codexAppServerPort,
-    releaseRepoUrl: config.releaseRepoUrl,
+    packageName: config.releasePackageName,
+    npmRegistryUrl: config.releaseNpmRegistryUrl,
     scheduleAdminRestart: scheduleAdminRestartAfterResponse
   });
 }

--- a/src/admin-index.ts
+++ b/src/admin-index.ts
@@ -87,9 +87,12 @@ function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): 
   if (
     !config.serviceRoot ||
     !config.releasesRoot ||
-    !config.currentReleasePath ||
-    !config.previousReleasePath ||
-    !config.failedReleasePath ||
+    !config.currentAdminReleasePath ||
+    !config.previousAdminReleasePath ||
+    !config.failedAdminReleasePath ||
+    !config.currentWorkerReleasePath ||
+    !config.previousWorkerReleasePath ||
+    !config.failedWorkerReleasePath ||
     !config.adminPlistPath ||
     !config.adminLaunchdLabel ||
     !config.workerPlistPath ||
@@ -101,9 +104,12 @@ function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): 
   return new ReleaseDeploymentService({
     serviceRoot: config.serviceRoot,
     releasesRoot: config.releasesRoot,
-    currentReleasePath: config.currentReleasePath,
-    previousReleasePath: config.previousReleasePath,
-    failedReleasePath: config.failedReleasePath,
+    currentAdminReleasePath: config.currentAdminReleasePath,
+    previousAdminReleasePath: config.previousAdminReleasePath,
+    failedAdminReleasePath: config.failedAdminReleasePath,
+    currentWorkerReleasePath: config.currentWorkerReleasePath,
+    previousWorkerReleasePath: config.previousWorkerReleasePath,
+    failedWorkerReleasePath: config.failedWorkerReleasePath,
     adminPlistPath: config.adminPlistPath,
     adminLaunchdLabel: config.adminLaunchdLabel,
     adminBaseUrl: config.adminBaseUrl,
@@ -111,7 +117,10 @@ function createReleaseDeploymentService(config: ReturnType<typeof loadConfig>): 
     workerLaunchdLabel: config.workerLaunchdLabel,
     workerBaseUrl: config.workerBaseUrl,
     codexAppServerPort: config.codexAppServerPort,
-    packageName: config.releasePackageName,
+    packages: {
+      admin: config.releaseAdminPackageName,
+      worker: config.releaseWorkerPackageName
+    },
     npmRegistryUrl: config.releaseNpmRegistryUrl,
     scheduleAdminRestart: scheduleAdminRestartAfterResponse
   });

--- a/src/admin-ui/admin-shell.tsx
+++ b/src/admin-ui/admin-shell.tsx
@@ -162,7 +162,11 @@ function DeployPanel({ status, message, setMessage }: {
   readonly setMessage: (message: string | null) => void;
 }): React.JSX.Element {
   const [busy, setBusy] = useState<"deploy" | "rollback" | null>(null);
-  const deployTargetOptions = useMemo(() => buildDeployTargetOptions(status.deployment), [status.deployment]);
+  const [selectedDeployTarget, setSelectedDeployTarget] = useState<"admin" | "worker">("worker");
+  const deployTargetOptions = useMemo(
+    () => buildDeployTargetOptions(status.deployment, selectedDeployTarget),
+    [status.deployment, selectedDeployTarget]
+  );
   const deployTargetValues = deployTargetOptions.map((option) => option.value).join("\n");
   const [selectedDeployVersion, setSelectedDeployVersion] = useState("");
   useEffect(() => {
@@ -189,10 +193,14 @@ function DeployPanel({ status, message, setMessage }: {
       const payload = await requestJson("/admin/api/deploy", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ version: selectedDeployVersion, allow_active: allowActive })
+        body: JSON.stringify({
+          target: selectedDeployTarget,
+          version: selectedDeployVersion,
+          allow_active: allowActive
+        })
       });
       publishStatusFromPayload(payload);
-      setMessage(`已发布 ${selectedDeployVersion} · 操作 ${payload.operation?.id || ""}`);
+      setMessage(`已发布 ${targetLabel(selectedDeployTarget)} ${selectedDeployVersion} · 操作 ${payload.operation?.id || ""}`);
     } catch (error) {
       setMessage(errorMessage(error));
     } finally {
@@ -200,7 +208,7 @@ function DeployPanel({ status, message, setMessage }: {
     }
   }
 
-  async function runRollbackTo(version: string): Promise<void> {
+  async function runRollbackTo(target: "admin" | "worker", version: string): Promise<void> {
     if (!version) {
       setMessage("缺少回滚目标");
       return;
@@ -216,10 +224,10 @@ function DeployPanel({ status, message, setMessage }: {
       const payload = await requestJson("/admin/api/rollback", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ version, allow_active: allowActive })
+        body: JSON.stringify({ target, version, allow_active: allowActive })
       });
       publishStatusFromPayload(payload);
-      setMessage(`已回滚到 ${version} · 操作 ${payload.operation?.id || ""}`);
+      setMessage(`已回滚 ${targetLabel(target)} 到 ${version} · 操作 ${payload.operation?.id || ""}`);
     } catch (error) {
       setMessage(errorMessage(error));
     } finally {
@@ -234,6 +242,19 @@ function DeployPanel({ status, message, setMessage }: {
       </div>
       <div className="panel-body">
         <div className="deploy-actions">
+          <label className="deploy-target-field">
+            <span className="summary-label">目标</span>
+            <select
+              id="deploy-package-target-select"
+              aria-label="发布目标"
+              value={selectedDeployTarget}
+              disabled={busy !== null}
+              onChange={(event) => setSelectedDeployTarget(event.target.value === "admin" ? "admin" : "worker")}
+            >
+              <option value="worker">Worker</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
           <label className="deploy-target-field">
             <span className="summary-label">Package 版本</span>
             <select
@@ -260,7 +281,7 @@ function DeployPanel({ status, message, setMessage }: {
         <DeploymentPanel
           deployment={status.deployment}
           rollbackBusy={busy === "rollback"}
-          onRollback={(version) => { void runRollbackTo(version); }}
+          onRollback={(target, version) => { void runRollbackTo(target, version); }}
         />
         {message ? <div className={"summary-detail " + (message.includes("失败") || message.includes("必须") ? "danger" : "")} style={{ marginTop: 6 }}>{message}</div> : null}
       </div>
@@ -857,17 +878,17 @@ function RiskCell({ label, value, danger = false }: {
 function DeploymentPanel({ deployment, rollbackBusy, onRollback }: {
   readonly deployment: any;
   readonly rollbackBusy: boolean;
-  readonly onRollback: (ref: string) => void;
+  readonly onRollback: (target: "admin" | "worker", ref: string) => void;
 }): React.JSX.Element {
   if (!deployment) {
-    return <div className="summary-detail">Worker 发布状态不可用</div>;
+    return <div className="summary-detail">发布状态不可用</div>;
   }
   if (deployment.ok === false) {
     return <div className="summary-detail danger">发布状态读取失败：{deployment.error || "unknown"}</div>;
   }
   const admin = deployment.admin || {};
   const worker = deployment.worker || {};
-  const rollbackReleases = buildRollbackReleaseOptions(deployment);
+  const targets = deployment.targets || {};
   return (
     <>
       <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -877,35 +898,60 @@ function DeploymentPanel({ deployment, rollbackBusy, onRollback }: {
         <Badge label={worker.healthOk ? "HTTP 正常" : "HTTP 异常"} tone={worker.healthOk ? "good" : "danger"} />
         <Badge label={worker.readyOk ? "Codex 就绪" : "Codex 异常"} tone={worker.readyOk ? "good" : "danger"} />
       </div>
-      <div className="release-stack">
-        <ReleaseRow label="当前版本" release={deployment.currentRelease} />
-      </div>
-      <div className="release-stack">
-        <div className="summary-label">最近已发布</div>
-        {rollbackReleases.length ? rollbackReleases.map((release) => {
-          const ref = releaseRollbackRef(release);
-          return (
-            <ReleaseRow
-              key={ref}
-              label="版本"
-              release={release}
-              action={ref ? (
-                <button
-                  className="secondary"
-                  type="button"
-                  disabled={rollbackBusy}
-                  onClick={() => onRollback(ref)}
-                >
-                  回滚
-                </button>
-              ) : null}
-            />
-          );
-        }) : (
-          <div className="summary-detail">暂无可回滚版本</div>
-        )}
-      </div>
+      <ReleaseTargetPanel
+        target="worker"
+        status={targets.worker}
+        rollbackBusy={rollbackBusy}
+        onRollback={onRollback}
+      />
+      <ReleaseTargetPanel
+        target="admin"
+        status={targets.admin}
+        rollbackBusy={rollbackBusy}
+        onRollback={onRollback}
+      />
     </>
+  );
+}
+
+function ReleaseTargetPanel({ target, status, rollbackBusy, onRollback }: {
+  readonly target: "admin" | "worker";
+  readonly status: any;
+  readonly rollbackBusy: boolean;
+  readonly onRollback: (target: "admin" | "worker", ref: string) => void;
+}): React.JSX.Element {
+  const rollbackReleases = buildRollbackReleaseOptions(status);
+  return (
+    <div className="release-stack">
+      <div className="profile-line">
+        <span className="profile-account">{targetLabel(target)}</span>
+        <span className="profile-plan">{status?.packageName || "package"}</span>
+      </div>
+      <ReleaseRow label="当前版本" release={status?.currentRelease} />
+      <div className="summary-label">最近已发布</div>
+      {rollbackReleases.length ? rollbackReleases.map((release) => {
+        const ref = releaseRollbackRef(release);
+        return (
+          <ReleaseRow
+            key={`${target}-${ref}`}
+            label="版本"
+            release={release}
+            action={ref ? (
+              <button
+                className="secondary"
+                type="button"
+                disabled={rollbackBusy}
+                onClick={() => onRollback(target, ref)}
+              >
+                回滚
+              </button>
+            ) : null}
+          />
+        );
+      }) : (
+        <div className="summary-detail">暂无可回滚版本</div>
+      )}
+    </div>
   );
 }
 
@@ -937,8 +983,9 @@ type DeployTargetOption = {
   readonly label: string;
 };
 
-function buildDeployTargetOptions(deployment: any): readonly DeployTargetOption[] {
-  const versions = Array.isArray(deployment?.recentPackageVersions) ? deployment.recentPackageVersions : [];
+function buildDeployTargetOptions(deployment: any, target: "admin" | "worker"): readonly DeployTargetOption[] {
+  const targetStatus = deployment?.targets?.[target] || {};
+  const versions = Array.isArray(targetStatus.recentPackageVersions) ? targetStatus.recentPackageVersions : [];
   return versions
     .map((entry: Record<string, any>) => {
       const version = String(entry.version || "").trim();
@@ -952,10 +999,10 @@ function buildDeployTargetOptions(deployment: any): readonly DeployTargetOption[
     .filter((option): option is DeployTargetOption => Boolean(option));
 }
 
-function buildRollbackReleaseOptions(deployment: any): readonly Record<string, any>[] {
-  const currentTargetPath = String(deployment?.currentRelease?.targetPath || "");
-  const releases = Array.isArray(deployment?.recentReleases) ? deployment.recentReleases : [];
-  const fallback = deployment?.previousRelease?.targetPath ? [deployment.previousRelease] : [];
+function buildRollbackReleaseOptions(targetStatus: any): readonly Record<string, any>[] {
+  const currentTargetPath = String(targetStatus?.currentRelease?.targetPath || "");
+  const releases = Array.isArray(targetStatus?.recentReleases) ? targetStatus.recentReleases : [];
+  const fallback = targetStatus?.previousRelease?.targetPath ? [targetStatus.previousRelease] : [];
   const deduped = new Map<string, Record<string, any>>();
   for (const release of [...releases, ...fallback]) {
     const ref = releaseRollbackRef(release);
@@ -965,6 +1012,10 @@ function buildRollbackReleaseOptions(deployment: any): readonly Record<string, a
     deduped.set(ref, release);
   }
   return [...deduped.values()];
+}
+
+function targetLabel(target: "admin" | "worker"): string {
+  return target === "admin" ? "Admin" : "Worker";
 }
 
 function releaseRollbackRef(release: any): string {

--- a/src/admin-ui/admin-shell.tsx
+++ b/src/admin-ui/admin-shell.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
-import { formatAuthQuotaDisplay, remainingPercent, weightedWeeklyQuotaScore, daysUntilReset } from "../auth-profile-quota";
+import {
+  formatAuthQuotaDisplay,
+  formatWeightedWeeklyQuotaScore,
+  remainingPercent,
+  weightedWeeklyQuotaScore,
+  daysUntilReset
+} from "../auth-profile-quota";
 import {
   profileAccountLabel,
   profilePlanLabel,
@@ -107,13 +113,13 @@ function OperationsView({ status }: {
   const [githubStatus, setGitHubStatus] = useState<string | null>(null);
 
   return (
-    <>
-      <div className="view-grid">
+    <div className="ops-page">
+      <div className="view-grid ops-grid">
         <DeployPanel status={status} message={deployStatus} setMessage={setDeployStatus} />
         <OperationRecords status={status} />
       </div>
 
-      <div className="view-grid">
+      <div className="view-grid ops-grid">
         <AuthProfilesPanel
           status={status}
           message={profileStatus}
@@ -128,7 +134,7 @@ function OperationsView({ status }: {
         />
       </div>
 
-      <div className="view-grid">
+      <div className="view-grid ops-grid">
         <LogsPanel logs={status.state?.recentBrokerLogs || []} />
         <ServicePanel service={status.service || {}} />
       </div>
@@ -146,7 +152,7 @@ function OperationsView({ status }: {
           onStatus={setGitHubStatus}
         />
       ) : null}
-    </>
+    </div>
   );
 }
 
@@ -155,13 +161,21 @@ function DeployPanel({ status, message, setMessage }: {
   readonly message: string | null;
   readonly setMessage: (message: string | null) => void;
 }): React.JSX.Element {
-  const [ref, setRef] = useState("");
   const [busy, setBusy] = useState<"deploy" | "rollback" | null>(null);
+  const deployTargetOptions = useMemo(() => buildDeployTargetOptions(status.deployment), [status.deployment]);
+  const deployTargetValues = deployTargetOptions.map((option) => option.value).join("\n");
+  const [selectedDeployVersion, setSelectedDeployVersion] = useState("");
+  useEffect(() => {
+    setSelectedDeployVersion((previous) =>
+      previous && deployTargetOptions.some((option) => option.value === previous)
+        ? previous
+        : deployTargetOptions[0]?.value || ""
+    );
+  }, [deployTargetValues]);
 
   async function runDeploy(): Promise<void> {
-    const trimmed = ref.trim();
-    if (!trimmed) {
-      setMessage("必须填写发布目标");
+    if (!selectedDeployVersion) {
+      setMessage("没有可发布的 package 版本");
       return;
     }
     setBusy("deploy");
@@ -175,10 +189,10 @@ function DeployPanel({ status, message, setMessage }: {
       const payload = await requestJson("/admin/api/deploy", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ ref: trimmed, allow_active: allowActive })
+        body: JSON.stringify({ version: selectedDeployVersion, allow_active: allowActive })
       });
       publishStatusFromPayload(payload);
-      setMessage(`已发布 ${trimmed} · 操作 ${payload.operation?.id || ""}`);
+      setMessage(`已发布 ${selectedDeployVersion} · 操作 ${payload.operation?.id || ""}`);
     } catch (error) {
       setMessage(errorMessage(error));
     } finally {
@@ -186,7 +200,11 @@ function DeployPanel({ status, message, setMessage }: {
     }
   }
 
-  async function runRollback(): Promise<void> {
+  async function runRollbackTo(version: string): Promise<void> {
+    if (!version) {
+      setMessage("缺少回滚目标");
+      return;
+    }
     setBusy("rollback");
     setMessage("正在回滚...");
     try {
@@ -198,10 +216,10 @@ function DeployPanel({ status, message, setMessage }: {
       const payload = await requestJson("/admin/api/rollback", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ allow_active: allowActive })
+        body: JSON.stringify({ version, allow_active: allowActive })
       });
       publishStatusFromPayload(payload);
-      setMessage(`已回滚 · 操作 ${payload.operation?.id || ""}`);
+      setMessage(`已回滚到 ${version} · 操作 ${payload.operation?.id || ""}`);
     } catch (error) {
       setMessage(errorMessage(error));
     } finally {
@@ -210,27 +228,40 @@ function DeployPanel({ status, message, setMessage }: {
   }
 
   return (
-    <section className="panel">
+    <section className="panel ops-panel">
       <div className="panel-head">
         <div className="panel-title">发布</div>
-        <button className="primary" type="button" disabled={busy !== null} onClick={() => { void runDeploy(); }}>
-          发布
-        </button>
       </div>
       <div className="panel-body">
         <div className="deploy-actions">
-          <input
-            type="text"
-            placeholder="提交 / 分支 / 标签"
-            value={ref}
-            onChange={(event) => setRef(event.target.value)}
-          />
-          <button className="secondary" type="button" disabled={busy !== null} onClick={() => { void runRollback(); }}>
-            回滚
+          <label className="deploy-target-field">
+            <span className="summary-label">Package 版本</span>
+            <select
+              id="deploy-package-version-select"
+              aria-label="Package 版本"
+              value={selectedDeployVersion}
+              disabled={deployTargetOptions.length === 0 || busy !== null}
+              onChange={(event) => setSelectedDeployVersion(event.target.value)}
+            >
+              {deployTargetOptions.length ? deployTargetOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              )) : (
+                <option value="">没有可发布的 package 版本</option>
+              )}
+            </select>
+          </label>
+          <button className="primary" type="button" disabled={busy !== null || !selectedDeployVersion} onClick={() => { void runDeploy(); }}>
+            发布
           </button>
         </div>
         <RiskPanel state={status.state || {}} />
-        <DeploymentPanel deployment={status.deployment} />
+        <DeploymentPanel
+          deployment={status.deployment}
+          rollbackBusy={busy === "rollback"}
+          onRollback={(version) => { void runRollbackTo(version); }}
+        />
         {message ? <div className={"summary-detail " + (message.includes("失败") || message.includes("必须") ? "danger" : "")} style={{ marginTop: 6 }}>{message}</div> : null}
       </div>
     </section>
@@ -243,7 +274,7 @@ function OperationRecords({ status }: {
   const operations = Array.isArray(status.operations) ? status.operations : [];
   const events = Array.isArray(status.auditEvents) ? status.auditEvents : [];
   return (
-    <section className="panel">
+    <section className="panel ops-panel">
       <div className="panel-head">
         <div className="panel-title">操作记录</div>
         <span className="badge purple">审计</span>
@@ -298,26 +329,35 @@ function AuthProfilesPanel({ status, message, setMessage, onAdd }: {
   }
 
   return (
-    <section className="panel">
+    <section className="panel ops-panel">
       <div className="panel-head">
         <div className="panel-title">账号池</div>
         <button type="button" onClick={onAdd}>添加</button>
       </div>
       <div className="panel-body maintenance-grid">
-        {profiles.length ? profiles.map((profile: Record<string, any>) => (
-          <div className="profile-row" key={profile.name || profile.path || profile.mtime}>
-            <div className="profile-line">
-              <span className="profile-account">{profileAccountLabel(profile)}</span>
-              <span className="profile-plan">{profilePlanLabel(profile) || profile.account?.error || "ChatGPT"}</span>
-            </div>
-            <ProfileQuota rateLimits={profile.rateLimits} />
-            <div className="profile-actions">
-              <button className="danger" type="button" onClick={() => { void deleteProfile(String(profile.name || "")); }}>
+        {profiles.length ? profiles.map((profile: Record<string, any>) => {
+          const quota = profileQuotaSummary(profile.rateLimits);
+          const plan = profilePlanLabel(profile);
+          const issue = profile.account?.error || profile.rateLimits?.error || "";
+          const cardTone = profile.account?.ok === false || quota.ok === false ? "danger" : quota.tone;
+          return (
+          <div className={"profile-card " + cardTone} key={profile.name || profile.path || profile.mtime} title={profileTitle(profile)}>
+            <div className="profile-card-head">
+              <div className="profile-identity">
+                <div className="profile-account-row">
+                  <span className="profile-account">{profileAccountLabel(profile)}</span>
+                  {plan ? <span className="profile-plan-badge">{plan}</span> : null}
+                </div>
+                {issue ? <div className="profile-card-subtitle">{issue}</div> : null}
+              </div>
+              <button className="profile-delete-button danger" type="button" onClick={() => { void deleteProfile(String(profile.name || "")); }}>
                 删除
               </button>
             </div>
+            <ProfileQuotaMetrics quota={quota} />
           </div>
-        )) : (
+          );
+        }) : (
           <div className="empty-state">暂无账号</div>
         )}
       </div>
@@ -332,36 +372,23 @@ function GitHubAccountsPanel({ status, message, setMessage, onBind }: {
   readonly setMessage: (message: string | null) => void;
   readonly onBind: (account: Record<string, any>) => void;
 }): React.JSX.Element {
-  const [query, setQuery] = useState("");
   const accounts = normalizeGitHubAccounts(status);
   const boundAccounts = accounts.filter((account) => account.prBinding?.state === "bound");
   const currentDefaultAccount = accounts.find((account) => account.isDefaultPrAccount);
   const defaultPrAccount = status.githubAccounts?.defaultPrAccount;
-  const boundAccountKeys = boundAccounts.map((account) => account.slackUserId).join("\n");
+  const selectableDefaultAccounts = boundAccounts;
+  const defaultSelectValue = currentDefaultAccount?.slackUserId ||
+    (defaultPrAccount?.available && defaultPrAccount.source === "env" ? "__env_default__" : "");
+  const selectableDefaultAccountKeys = selectableDefaultAccounts.map((account) => account.slackUserId).join("\n");
   const [defaultSelection, setDefaultSelection] = useState("");
   useEffect(() => {
-    const nextSelection = currentDefaultAccount?.slackUserId || boundAccounts[0]?.slackUserId || "";
+    const nextSelection = defaultSelectValue || selectableDefaultAccounts[0]?.slackUserId || "";
     setDefaultSelection((previous) =>
-      previous && boundAccounts.some((account) => account.slackUserId === previous)
+      previous && (previous === defaultSelectValue || selectableDefaultAccounts.some((account) => account.slackUserId === previous))
         ? previous
         : nextSelection
     );
-  }, [boundAccountKeys, currentDefaultAccount?.slackUserId]);
-  const filtered = accounts.filter((account) => {
-    const lower = query.trim().toLowerCase();
-    if (!lower) return true;
-    const identity = account.slackIdentity || {};
-    const binding = account.prBinding || {};
-    return [
-      account.slackUserId,
-      binding.githubLogin,
-      identity.displayName,
-      identity.realName,
-      identity.username,
-      identity.email,
-      binding.githubEmail
-    ].some((value) => String(value || "").toLowerCase().includes(lower));
-  });
+  }, [defaultSelectValue, selectableDefaultAccountKeys]);
 
   async function setDefault(slackUserId: string): Promise<void> {
     if (!slackUserId) {
@@ -387,56 +414,52 @@ function GitHubAccountsPanel({ status, message, setMessage, onBind }: {
     : defaultPrAccount?.available && defaultPrAccount.source === "env"
       ? `环境默认账号 ${defaultPrAccount.githubLogin || ""}`.trim()
       : "未设置";
-  const canSwitchDefault = Boolean(defaultSelection) && defaultSelection !== currentDefaultAccount?.slackUserId;
+  const canSwitchDefault = Boolean(defaultSelection) &&
+    defaultSelection !== defaultSelectValue &&
+    selectableDefaultAccounts.some((account) => account.slackUserId === defaultSelection);
 
   return (
-    <section className="panel">
+    <section className="panel ops-panel">
       <div className="panel-head">
         <div className="panel-title">GitHub 账号</div>
       </div>
       <div className="github-default-control">
-        <div className="github-default-summary">
-          <div className="summary-label">默认 PR 账号</div>
-          <div className="summary-detail">{currentDefaultLabel}</div>
-          {boundAccounts.length === 0 ? (
-            <div className="summary-detail">先绑定任意 Slack 用户的 GitHub OAuth 后，才能设置默认账号。</div>
-          ) : null}
-        </div>
-        <div className="github-default-actions">
+        <label className="github-default-field">
+          <span className="summary-label">默认 PR 账号</span>
           <select
-            aria-label="选择默认 PR GitHub 账号"
+            aria-label="选择候选 GitHub PR 账号"
             value={defaultSelection}
-            disabled={boundAccounts.length === 0}
+            disabled={selectableDefaultAccounts.length === 0}
             onChange={(event) => setDefaultSelection(event.target.value)}
           >
-            {boundAccounts.length ? boundAccounts.map((account) => (
+            {defaultSelectValue && !currentDefaultAccount ? (
+              <option value={defaultSelectValue}>{currentDefaultLabel}</option>
+            ) : null}
+            {selectableDefaultAccounts.length ? selectableDefaultAccounts.map((account) => (
               <option key={account.slackUserId} value={account.slackUserId}>
                 {githubAccountOptionLabel(account)}
               </option>
             )) : (
-              <option value="">暂无已绑定账号</option>
+              <option value="">未设置</option>
             )}
           </select>
+        </label>
+        <div className="github-default-actions">
           <button
             className="secondary"
             type="button"
             disabled={!canSwitchDefault}
             onClick={() => { void setDefault(defaultSelection); }}
           >
-            设为默认 PR
+            切换
           </button>
         </div>
-      </div>
-      <div className="toolbar" style={{ gridTemplateColumns: "1fr", borderTop: 0 }}>
-        <input
-          type="search"
-          placeholder="筛选 Slack / GitHub 账号..."
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-        />
+        {boundAccounts.length === 0 ? (
+          <div className="summary-detail github-default-hint">先绑定任意 Slack 用户的 GitHub OAuth 后，才能设置默认账号。</div>
+        ) : null}
       </div>
       <div className="panel-body maintenance-grid">
-        {filtered.length ? filtered.map((account) => {
+        {accounts.length ? accounts.map((account) => {
           const identity = account.slackIdentity || {};
           const binding = account.prBinding || {};
           const label = identity.realName || identity.displayName || identity.username || account.slackUserId;
@@ -477,7 +500,7 @@ function LogsPanel({ logs }: {
   readonly logs: readonly Record<string, any>[];
 }): React.JSX.Element {
   return (
-    <section className="panel">
+    <section className="panel ops-panel">
       <div className="panel-head">
         <div className="panel-title">系统日志</div>
       </div>
@@ -499,7 +522,7 @@ function ServicePanel({ service }: {
   readonly service: Record<string, any>;
 }): React.JSX.Element {
   return (
-    <section className="panel">
+    <section className="panel ops-panel">
       <div className="panel-head">
         <div className="panel-title">运行信息</div>
       </div>
@@ -831,8 +854,10 @@ function RiskCell({ label, value, danger = false }: {
   );
 }
 
-function DeploymentPanel({ deployment }: {
+function DeploymentPanel({ deployment, rollbackBusy, onRollback }: {
   readonly deployment: any;
+  readonly rollbackBusy: boolean;
+  readonly onRollback: (ref: string) => void;
 }): React.JSX.Element {
   if (!deployment) {
     return <div className="summary-detail">Worker 发布状态不可用</div>;
@@ -842,6 +867,7 @@ function DeploymentPanel({ deployment }: {
   }
   const admin = deployment.admin || {};
   const worker = deployment.worker || {};
+  const rollbackReleases = buildRollbackReleaseOptions(deployment);
   return (
     <>
       <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
@@ -853,52 +879,178 @@ function DeploymentPanel({ deployment }: {
       </div>
       <div className="release-stack">
         <ReleaseRow label="当前版本" release={deployment.currentRelease} />
-        <ReleaseRow label="上一版本" release={deployment.previousRelease} />
+      </div>
+      <div className="release-stack">
+        <div className="summary-label">最近已发布</div>
+        {rollbackReleases.length ? rollbackReleases.map((release) => {
+          const ref = releaseRollbackRef(release);
+          return (
+            <ReleaseRow
+              key={ref}
+              label="版本"
+              release={release}
+              action={ref ? (
+                <button
+                  className="secondary"
+                  type="button"
+                  disabled={rollbackBusy}
+                  onClick={() => onRollback(ref)}
+                >
+                  回滚
+                </button>
+              ) : null}
+            />
+          );
+        }) : (
+          <div className="summary-detail">暂无可回滚版本</div>
+        )}
       </div>
     </>
   );
 }
 
-function ReleaseRow({ label, release }: {
+function ReleaseRow({ label, release, action = null }: {
   readonly label: string;
   readonly release: any;
+  readonly action?: React.ReactNode;
 }): React.JSX.Element {
   if (!release?.targetPath) {
     return <div className="summary-detail">{label}：无</div>;
   }
   const metadata = release.metadata || {};
-  const heading = metadata.shortRevision || metadata.revision || String(release.targetPath).split("/").pop() || "release";
+  const heading = metadata.packageVersion || metadata.shortRevision || metadata.revision || String(release.targetPath).split("/").pop() || "release";
+  const detailTime = metadata.installedAt || metadata.builtAt;
   return (
     <div className="release-row">
       <div className="profile-line">
         <span className="profile-account">{label}：{heading}</span>
-        <span className="profile-plan">{metadata.branch || "detached"}</span>
+        <span className="profile-plan">{metadata.packageName || metadata.branch || "package"}</span>
       </div>
-      <div className="summary-detail">{metadata.builtAt ? fmtDateTime(metadata.builtAt) : release.targetPath}</div>
+      <div className="summary-detail">{detailTime ? fmtDateTime(detailTime) : release.targetPath}</div>
+      {action ? <div className="release-row-action">{action}</div> : null}
     </div>
   );
 }
 
-function ProfileQuota({ rateLimits }: {
-  readonly rateLimits: any;
-}): React.JSX.Element {
-  if (!rateLimits || rateLimits.ok === false) {
-    return <div className="summary-detail">{rateLimits?.error || "额度不可用"}</div>;
+type DeployTargetOption = {
+  readonly value: string;
+  readonly label: string;
+};
+
+function buildDeployTargetOptions(deployment: any): readonly DeployTargetOption[] {
+  const versions = Array.isArray(deployment?.recentPackageVersions) ? deployment.recentPackageVersions : [];
+  return versions
+    .map((entry: Record<string, any>) => {
+      const version = String(entry.version || "").trim();
+      if (!version) return null;
+      const spec = String(entry.packageSpec || "").trim();
+      return {
+        value: version,
+        label: spec || version
+      };
+    })
+    .filter((option): option is DeployTargetOption => Boolean(option));
+}
+
+function buildRollbackReleaseOptions(deployment: any): readonly Record<string, any>[] {
+  const currentTargetPath = String(deployment?.currentRelease?.targetPath || "");
+  const releases = Array.isArray(deployment?.recentReleases) ? deployment.recentReleases : [];
+  const fallback = deployment?.previousRelease?.targetPath ? [deployment.previousRelease] : [];
+  const deduped = new Map<string, Record<string, any>>();
+  for (const release of [...releases, ...fallback]) {
+    const ref = releaseRollbackRef(release);
+    if (!ref || release?.targetPath === currentTargetPath) {
+      continue;
+    }
+    deduped.set(ref, release);
   }
-  const snapshot = rateLimits.rateLimits || {};
-  const label = formatAuthQuotaDisplay({
-    primary: snapshot.primary,
-    secondary: snapshot.secondary
-  });
+  return [...deduped.values()];
+}
+
+function releaseRollbackRef(release: any): string {
+  const version = String(release?.metadata?.packageVersion || "").trim();
+  if (version) return version;
+  const targetPath = String(release?.targetPath || "").trim();
+  const installRoot = targetPath.split("/node_modules/")[0] || "";
+  const leaf = installRoot.split("/").filter(Boolean).pop() || "";
+  return leaf.startsWith("npm-") ? leaf.slice("npm-".length) : leaf;
+}
+
+function ProfileQuotaMetrics({ quota }: {
+  readonly quota: ProfileQuotaSummary;
+}): React.JSX.Element {
+  if (quota.ok === false) {
+    return <div className="profile-quota-error">{quota.error}</div>;
+  }
   return (
-    <div className="quota-grid">
-      <div className="quota-line">
-        <span>额度</span>
-        <strong>{label || "--"}</strong>
-        <span>{snapshot.secondary ? "周 " + formatResetTime(snapshot.secondary.resetsAt) : "不可用"}</span>
+    <div className="profile-quota-block" title={quota.fullLabel}>
+      <div className="profile-quota-metrics">
+        <div className={"profile-quota-metric " + quota.tone}>
+          <span>7d 剩余</span>
+          <strong>{quota.remainingLabel}</strong>
+        </div>
+        <div className={"profile-quota-metric " + quota.tone}>
+          <span>加权</span>
+          <strong>{quota.scoreLabel}</strong>
+        </div>
+        <div className="profile-quota-metric">
+          <span>重置</span>
+          <strong>{quota.resetLabel}</strong>
+        </div>
       </div>
+      {quota.shortLabel ? (
+        <div className="profile-short-window">
+          <span>短窗</span>
+          <strong>{quota.shortLabel}</strong>
+        </div>
+      ) : null}
     </div>
   );
+}
+
+type ProfileQuotaSummary =
+  | {
+      readonly ok: true;
+      readonly fullLabel: string;
+      readonly remainingLabel: string;
+      readonly scoreLabel: string;
+      readonly resetLabel: string;
+      readonly shortLabel: string | null;
+      readonly tone: Tone;
+    }
+  | {
+      readonly ok: false;
+      readonly error: string;
+      readonly tone: Tone;
+    };
+
+function profileQuotaSummary(rateLimits: any): ProfileQuotaSummary {
+  if (!rateLimits || rateLimits.ok === false) {
+    return {
+      ok: false,
+      error: rateLimits?.error || "额度不可用",
+      tone: "danger"
+    };
+  }
+
+  const snapshot = rateLimits.rateLimits || {};
+  const secondary = snapshot.secondary || {};
+  const fullLabel = formatAuthQuotaDisplay({
+    primary: snapshot.primary,
+    secondary
+  }) || "额度未知";
+  const [weeklyLabel, ...shortParts] = fullLabel.split(" | ");
+  const remaining = remainingPercent(secondary.usedPercent);
+  const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(secondary.resetsAt));
+  return {
+    ok: true,
+    fullLabel,
+    remainingLabel: remaining === undefined ? "--" : `${Math.round(remaining)}%`,
+    scoreLabel: formatWeightedWeeklyQuotaScore(score),
+    resetLabel: formatResetTime(secondary.resetsAt),
+    shortLabel: shortParts.length ? shortParts.join(" | ") : null,
+    tone: quotaTone(remaining ?? 100) || (weeklyLabel ? "" : "warn")
+  };
 }
 
 function Badge({ label, tone = "" }: {
@@ -923,7 +1075,7 @@ async function loadAdminStatus(): Promise<AdminStatus> {
 }
 
 async function loadAdminSessionsStatus(): Promise<AdminStatus> {
-  const sessionsPayload = await requestJson("/admin/api/sessions", { timeoutMs: 15_000 });
+  const sessionsPayload = await requestJson("/admin/api/sessions", { timeoutMs: 45_000 });
   const sessions = Array.isArray(sessionsPayload.sessions) ? sessionsPayload.sessions : [];
   return {
     ok: true,
@@ -936,7 +1088,7 @@ async function loadAdminSessionsStatus(): Promise<AdminStatus> {
 }
 
 async function loadAdminOverview(): Promise<Record<string, any>> {
-  return await requestJson("/admin/api/overview", { timeoutMs: 8_000 });
+  return await requestJson("/admin/api/overview", { timeoutMs: 45_000 });
 }
 
 async function loadAdminLogs(): Promise<Record<string, any>> {
@@ -1279,7 +1431,7 @@ function operationLabel(value: unknown): string {
 }
 
 function pickOperationLabel(operation: Record<string, any>): string {
-  return operation?.request?.ref || operation?.request?.name || operation?.request?.slackUserId || operation?.id || "-";
+  return operation?.request?.version || operation?.request?.ref || operation?.request?.name || operation?.request?.slackUserId || operation?.id || "-";
 }
 
 function fmtTime(value: unknown): string {
@@ -1302,6 +1454,11 @@ function fmtDateTime(value: unknown): string {
     String(date.getMonth() + 1).padStart(2, "0"),
     String(date.getDate()).padStart(2, "0")
   ].join("-") + " " + fmtTime(value);
+}
+
+function shortRevision(value: unknown): string {
+  const text = String(value || "").trim();
+  return text.length > 12 ? text.slice(0, 12) : text;
 }
 
 function formatRelativeDuration(ms: number): string {

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -51,10 +51,17 @@
     .admin-view.active { display: block; height: 100%; min-height: 0; overflow: auto; }
     .admin-view[data-admin-view="sessions"].active { overflow: hidden; }
     .view-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-bottom: 8px; align-items: start; }
+    .ops-page { display: grid; gap: 12px; padding: 1px 1px 10px; }
+    .ops-page .view-grid { margin-bottom: 0; }
+    .ops-grid { gap: 12px; align-items: stretch; }
+    .ops-grid > .ops-panel { min-height: 100%; }
 
     .panel { min-height: 0; background: var(--panel); border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }
     .panel-head { display: flex; justify-content: space-between; align-items: center; padding: 5px 8px; border-bottom: 1px solid var(--line); font-size: 11px; font-weight: 700; text-transform: uppercase; }
     .panel-body { padding: 6px 8px; }
+    .ops-panel { background: #0b1118; border-color: #283543; box-shadow: 0 0 0 1px rgba(225,231,236,0.02), 0 10px 22px rgba(0,0,0,0.16); }
+    .ops-panel > .panel-head { padding: 7px 9px; background: #101821; border-bottom-color: #2a3846; text-transform: none; }
+    .ops-panel > .panel-body { padding: 8px; }
 
     .toolbar { display: flex; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line); }
     input, textarea, select { width: 100%; padding: 3px 6px; border: 1px solid var(--line); background: #05080c; color: var(--text); font-family: inherit; font-size: 11px; }
@@ -210,6 +217,8 @@
 
     .operation-list { display: grid; gap: 1px; background: var(--line); }
     .operation-row { display: grid; grid-template-columns: auto 1fr auto; gap: 6px; align-items: center; padding: 5px 6px; background: var(--panel); }
+    .ops-panel .operation-list { display: grid; gap: 4px; background: transparent; }
+    .ops-panel .operation-row { background: #080d13; border: 1px solid rgba(30,40,50,0.82); }
     .operation-title { font-weight: 700; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .operation-detail { color: var(--muted); font-size: 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .audit-list { color: var(--muted); font-size: 10px; margin-top: 6px; }
@@ -217,12 +226,42 @@
     .usage-row { display: flex; justify-content: space-between; padding: 3px 0; border-top: 1px solid var(--line); }
 
     .maintenance-grid { display: grid; gap: 1px; background: var(--line); }
-    .github-default-control { display: grid; grid-template-columns: minmax(0, 1fr) minmax(240px, 0.9fr); gap: 8px; align-items: end; padding: 6px 8px; border-bottom: 1px solid var(--line); background: #080d13; }
+    .ops-panel .maintenance-grid { display: grid; gap: 6px; background: transparent; }
+    .ops-panel .risk-strip { background: transparent; gap: 6px; margin-bottom: 8px; }
+    .ops-panel .risk-cell { background: #080d13; border: 1px solid rgba(30,40,50,0.82); }
+    .ops-panel .toolbar { background: transparent; border: 0; padding: 8px; }
+    .github-default-control { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 8px; align-items: end; padding: 6px 8px; border-bottom: 1px solid var(--line); background: #080d13; }
     .github-default-summary { min-width: 0; display: grid; gap: 2px; }
-    .github-default-actions { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px; }
+    .github-default-field { min-width: 0; display: contents; }
+    .github-default-field .summary-label { align-self: center; white-space: nowrap; }
+    .github-default-actions { display: flex; align-items: end; gap: 6px; }
+    .github-default-hint { grid-column: 1 / -1; }
+    .profile-card { display: grid; gap: 7px; padding: 8px; background: var(--panel); }
+    .profile-card.warn, .profile-card.danger { padding-left: 9px; }
+    .profile-card.warn { box-shadow: inset 2px 0 0 var(--amber); }
+    .profile-card.danger { box-shadow: inset 2px 0 0 var(--red); }
+    .profile-card-head { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: start; }
+    .profile-identity { min-width: 0; display: grid; gap: 2px; }
+    .profile-account-row { display: flex; gap: 6px; align-items: baseline; min-width: 0; }
+    .profile-card-subtitle { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 9px; }
+    .profile-plan-badge { flex: 0 0 auto; color: var(--muted); font-size: 10px; }
+    .profile-quota-block { display: grid; gap: 4px; min-width: 0; }
+    .profile-quota-metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+    .profile-quota-metric { min-width: 0; display: grid; gap: 1px; }
+    .profile-quota-metric span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 9px; }
+    .profile-quota-metric strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text); font-size: 12px; }
+    .profile-quota-metric.good strong { color: var(--green); }
+    .profile-quota-metric.warn strong { color: var(--amber); }
+    .profile-quota-metric.danger strong { color: var(--red); }
+    .profile-short-window { display: flex; gap: 6px; align-items: baseline; min-width: 0; color: var(--amber); font-size: 9px; }
+    .profile-short-window span { color: var(--muted); }
+    .profile-short-window strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .profile-quota-error { padding: 5px 6px; border: 1px solid rgba(255,107,107,0.45); color: var(--red); font-size: 10px; }
+    button.profile-delete-button { display: inline-flex; align-items: center; justify-content: center; min-width: 42px; height: 24px; padding: 0 7px; line-height: 1; background: transparent; color: var(--red); border-color: var(--red); }
+    button.profile-delete-button:hover { color: var(--red); border-color: var(--red); background: rgba(224,108,92,0.08); }
     .profile-row { display: grid; gap: 4px; padding: 5px 6px; background: var(--panel); }
     .profile-line { display: flex; gap: 6px; align-items: baseline; flex-wrap: wrap; }
-    .profile-account { font-weight: 700; font-size: 11px; }
+    .profile-account { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 700; font-size: 11px; }
     .profile-plan, .summary-detail { color: var(--muted); font-size: 10px; }
     .profile-actions { display: flex; gap: 6px; }
     .modal-heading { display: grid; gap: 2px; }
@@ -252,9 +291,12 @@
     .quota-line::-webkit-scrollbar { display: none; }
     .quota-line span, .quota-line strong { flex: 0 0 auto; white-space: nowrap; }
     .quota-line strong { color: var(--text); }
-    .deploy-actions { display: grid; grid-template-columns: 1fr auto; gap: 6px; margin-bottom: 6px; }
+    .deploy-actions { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 6px; align-items: center; margin-bottom: 6px; }
+    .deploy-target-field { min-width: 0; display: contents; }
+    .deploy-target-field .summary-label { white-space: nowrap; }
     .release-stack { display: grid; gap: 4px; margin-top: 6px; }
-    .release-row { border: 1px solid var(--line); padding: 5px 6px; }
+    .release-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 4px 8px; align-items: center; border: 1px solid var(--line); padding: 5px 6px; }
+    .release-row-action { grid-column: 2; grid-row: 1 / span 2; }
     .log-list { max-height: 180px; overflow: auto; font-size: 10px; }
     .log-entry { display: grid; grid-template-columns: 60px 1fr; gap: 6px; padding: 2px 6px; border-bottom: 1px solid var(--line); }
     .log-entry.warn { color: var(--amber); }
@@ -295,8 +337,7 @@
       .toolbar { gap: 4px; padding: 4px 6px; }
       .toolbar input { min-width: 0; }
       .toolbar select { flex: 0 0 126px; }
-      .github-default-control { grid-template-columns: 1fr; gap: 6px; padding: 6px; }
-      .github-default-actions { grid-template-columns: 1fr; }
+      .github-default-control { grid-template-columns: auto minmax(0, 1fr) auto; gap: 4px; padding: 6px; }
       .selected-session-head { grid-template-columns: 1fr; align-items: start; gap: 6px; padding: 6px; }
       .session-detail-actions { width: 100%; min-width: 0; overflow-x: auto; padding-bottom: 2px; }
       .session-detail-title, .session-detail-subtitle { white-space: normal; overflow-wrap: anywhere; }
@@ -324,7 +365,6 @@
       .timeline-title span { margin-top: 2px; }
       .trace-details pre { max-height: 220px; }
       .operation-row { grid-template-columns: 1fr; }
-      .deploy-actions { grid-template-columns: 1fr; }
       .auth-primary-card { grid-template-columns: 1fr; }
       .auth-primary-card button { width: 100%; }
     }

--- a/src/admin-ui/admin.css
+++ b/src/admin-ui/admin.css
@@ -291,7 +291,7 @@
     .quota-line::-webkit-scrollbar { display: none; }
     .quota-line span, .quota-line strong { flex: 0 0 auto; white-space: nowrap; }
     .quota-line strong { color: var(--text); }
-    .deploy-actions { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 6px; align-items: center; margin-bottom: 6px; }
+    .deploy-actions { display: grid; grid-template-columns: auto minmax(110px, 0.35fr) auto minmax(0, 1fr) auto; gap: 6px; align-items: center; margin-bottom: 6px; }
     .deploy-target-field { min-width: 0; display: contents; }
     .deploy-target-field .summary-label { white-space: nowrap; }
     .release-stack { display: grid; gap: 4px; margin-top: 6px; }

--- a/src/admin-ui/session-view.tsx
+++ b/src/admin-ui/session-view.tsx
@@ -32,7 +32,6 @@ import { getTimelineEventDisplay, isTimelineEventVisible, statusLabel, type Time
 
 type UiState = {
   readonly adminView: string;
-  readonly sessionSearch: string;
   readonly sessionFilter: string;
   readonly selectedSessionKey: string | null;
 };
@@ -69,18 +68,17 @@ export function AdminSessionsView(): React.JSX.Element {
   );
   const channelLabelById = useMemo(() => buildChannelLabelById(sessions), [sessions]);
   const [uiState, setUiState] = useState(loadUiState);
-  const query = uiState.sessionSearch.trim().toLowerCase();
   const mode = uiState.sessionFilter;
   const orderRef = useRef<{ viewKey: string; keys: readonly string[] }>({ viewKey: "", keys: [] });
 
   const filtered = useMemo(() => {
     return sessions
-      .filter((session) => sessionMatchesFilter(session, mode, query, authProfileByName))
+      .filter((session) => sessionMatchesFilter(session, mode, authProfileByName))
       .sort((left, right) => compareSessionsForMode(mode, left, right, authProfileByName));
-  }, [authProfileByName, mode, query, sessions]);
+  }, [authProfileByName, mode, sessions]);
 
   const filteredKeys = filtered.map((session) => String(session.key)).join("\u001f");
-  const viewKey = mode + "\n" + query;
+  const viewKey = mode;
   const filteredByKey = new Map(filtered.map((session) => [String(session.key), session]));
 
   orderRef.current = stableSessionOrder(orderRef.current, viewKey, filtered.map((session) => String(session.key)));
@@ -117,13 +115,6 @@ export function AdminSessionsView(): React.JSX.Element {
           </span>
         </div>
         <div className="toolbar">
-          <input
-            id="session-search"
-            type="search"
-            placeholder="筛选会话..."
-            value={uiState.sessionSearch}
-            onChange={(event) => updateSessionUiState({ sessionSearch: event.target.value })}
-          />
           <select
             id="session-filter"
             value={mode}
@@ -151,7 +142,7 @@ export function AdminSessionsView(): React.JSX.Element {
               />
             ))
           ) : (
-            <div className="empty-state">没有匹配的会话</div>
+            <div className="empty-state">没有符合当前状态的会话</div>
           )}
         </div>
       </section>
@@ -1255,7 +1246,6 @@ function Badge({ label, tone, title }: { readonly label: unknown; readonly tone?
 function sessionMatchesFilter(
   session: SessionRecord,
   mode: string,
-  query: string,
   authProfileByName?: ReadonlyMap<string, SessionRecord>
 ): boolean {
   const authProfile = session.authProfileName ? authProfileByName?.get(String(session.authProfileName)) : null;
@@ -1265,9 +1255,7 @@ function sessionMatchesFilter(
   if (mode === "jobs" && !session.runningBackgroundJobCount) return false;
   if (mode === "issues" && !sessionAuthBlockActive(session, authProfile)) return false;
   if (mode === "usage" && !session.usage?.turnCount) return false;
-  if (!query) return true;
-  return [session.key, session.channelId, session.channelLabel, session.workspacePath, sessionPrimaryText(session), sessionFirstText(session)]
-    .some((value) => String(value || "").toLowerCase().includes(query));
+  return true;
 }
 
 function resolveSelectedSession(sessions: readonly SessionRecord[], selectedSessionKey: string | null): SessionRecord | null {
@@ -1412,16 +1400,15 @@ function uiStateStorageKey(): string {
 }
 
 function defaultUiState(): UiState {
-  return { adminView: "sessions", sessionSearch: "", sessionFilter: "ongoing", selectedSessionKey: null };
+  return { adminView: "sessions", sessionFilter: "ongoing", selectedSessionKey: null };
 }
 
 function normalizeUiState(value: unknown): UiState {
   const next = value && typeof value === "object" ? value as Record<string, unknown> : {};
   const adminView = ["sessions", "ops"].includes(String(next.adminView || "")) ? String(next.adminView) : "sessions";
   const sessionFilter = sessionFilters.includes(String(next.sessionFilter || "")) ? String(next.sessionFilter) : "ongoing";
-  const sessionSearch = typeof next.sessionSearch === "string" ? next.sessionSearch : "";
   const selectedSessionKey = typeof next.selectedSessionKey === "string" && next.selectedSessionKey ? next.selectedSessionKey : null;
-  return { adminView, sessionSearch, sessionFilter, selectedSessionKey };
+  return { adminView, sessionFilter, selectedSessionKey };
 }
 
 function classSafeValue(value: unknown, fallback: string): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,8 +41,8 @@ export interface AppConfig {
   readonly brokerAdminToken?: string | undefined;
   readonly adminLaunchdLabel?: string | undefined;
   readonly workerLaunchdLabel?: string | undefined;
-  readonly releaseRepoUrl?: string | undefined;
-  readonly releaseRepoRoot?: string | undefined;
+  readonly releasePackageName: string;
+  readonly releaseNpmRegistryUrl?: string | undefined;
   readonly releasesRoot?: string | undefined;
   readonly currentReleasePath?: string | undefined;
   readonly previousReleasePath?: string | undefined;
@@ -216,8 +216,8 @@ export function loadConfig(env = process.env): AppConfig {
     brokerAdminToken: getOptional(env, "BROKER_ADMIN_TOKEN"),
     adminLaunchdLabel: getOptional(env, "ADMIN_LAUNCHD_LABEL"),
     workerLaunchdLabel: getOptional(env, "WORKER_LAUNCHD_LABEL"),
-    releaseRepoUrl: getOptional(env, "RELEASE_REPO_URL"),
-    releaseRepoRoot: env.RELEASE_REPO_ROOT ? path.resolve(env.RELEASE_REPO_ROOT) : serviceRoot,
+    releasePackageName: env.RELEASE_PACKAGE_NAME ?? "agent-session-broker",
+    releaseNpmRegistryUrl: getOptional(env, "RELEASE_NPM_REGISTRY_URL"),
     releasesRoot: env.RELEASES_ROOT ? path.resolve(env.RELEASES_ROOT) : serviceRoot ? path.join(serviceRoot, "releases") : undefined,
     currentReleasePath: env.CURRENT_RELEASE_PATH ? path.resolve(env.CURRENT_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "current") : undefined,
     previousReleasePath: env.PREVIOUS_RELEASE_PATH ? path.resolve(env.PREVIOUS_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "previous") : undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,12 +41,16 @@ export interface AppConfig {
   readonly brokerAdminToken?: string | undefined;
   readonly adminLaunchdLabel?: string | undefined;
   readonly workerLaunchdLabel?: string | undefined;
-  readonly releasePackageName: string;
+  readonly releaseAdminPackageName: string;
+  readonly releaseWorkerPackageName: string;
   readonly releaseNpmRegistryUrl?: string | undefined;
   readonly releasesRoot?: string | undefined;
-  readonly currentReleasePath?: string | undefined;
-  readonly previousReleasePath?: string | undefined;
-  readonly failedReleasePath?: string | undefined;
+  readonly currentAdminReleasePath?: string | undefined;
+  readonly previousAdminReleasePath?: string | undefined;
+  readonly failedAdminReleasePath?: string | undefined;
+  readonly currentWorkerReleasePath?: string | undefined;
+  readonly previousWorkerReleasePath?: string | undefined;
+  readonly failedWorkerReleasePath?: string | undefined;
   readonly adminPlistPath?: string | undefined;
   readonly workerPlistPath?: string | undefined;
   readonly logDir: string;
@@ -216,12 +220,16 @@ export function loadConfig(env = process.env): AppConfig {
     brokerAdminToken: getOptional(env, "BROKER_ADMIN_TOKEN"),
     adminLaunchdLabel: getOptional(env, "ADMIN_LAUNCHD_LABEL"),
     workerLaunchdLabel: getOptional(env, "WORKER_LAUNCHD_LABEL"),
-    releasePackageName: env.RELEASE_PACKAGE_NAME ?? "agent-session-broker",
+    releaseAdminPackageName: env.RELEASE_ADMIN_PACKAGE_NAME ?? "@agent-session-broker/admin",
+    releaseWorkerPackageName: env.RELEASE_WORKER_PACKAGE_NAME ?? "@agent-session-broker/worker",
     releaseNpmRegistryUrl: getOptional(env, "RELEASE_NPM_REGISTRY_URL"),
     releasesRoot: env.RELEASES_ROOT ? path.resolve(env.RELEASES_ROOT) : serviceRoot ? path.join(serviceRoot, "releases") : undefined,
-    currentReleasePath: env.CURRENT_RELEASE_PATH ? path.resolve(env.CURRENT_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "current") : undefined,
-    previousReleasePath: env.PREVIOUS_RELEASE_PATH ? path.resolve(env.PREVIOUS_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "previous") : undefined,
-    failedReleasePath: env.FAILED_RELEASE_PATH ? path.resolve(env.FAILED_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "failed") : undefined,
+    currentAdminReleasePath: env.CURRENT_ADMIN_RELEASE_PATH ? path.resolve(env.CURRENT_ADMIN_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "current-admin") : undefined,
+    previousAdminReleasePath: env.PREVIOUS_ADMIN_RELEASE_PATH ? path.resolve(env.PREVIOUS_ADMIN_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "previous-admin") : undefined,
+    failedAdminReleasePath: env.FAILED_ADMIN_RELEASE_PATH ? path.resolve(env.FAILED_ADMIN_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "failed-admin") : undefined,
+    currentWorkerReleasePath: env.CURRENT_WORKER_RELEASE_PATH ? path.resolve(env.CURRENT_WORKER_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "current-worker") : undefined,
+    previousWorkerReleasePath: env.PREVIOUS_WORKER_RELEASE_PATH ? path.resolve(env.PREVIOUS_WORKER_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "previous-worker") : undefined,
+    failedWorkerReleasePath: env.FAILED_WORKER_RELEASE_PATH ? path.resolve(env.FAILED_WORKER_RELEASE_PATH) : serviceRoot ? path.join(serviceRoot, "failed-worker") : undefined,
     adminPlistPath: env.ADMIN_PLIST_PATH ? path.resolve(env.ADMIN_PLIST_PATH) : undefined,
     workerPlistPath: env.WORKER_PLIST_PATH ? path.resolve(env.WORKER_PLIST_PATH) : undefined,
     logDir,

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -359,19 +359,19 @@ export async function handleAdminRequest(
       return true;
     }
 
-    const ref = readString(body.ref);
-    if (!ref) {
+    const version = readString(body.version);
+    if (!version) {
       respondJson(response, 400, {
         ok: false,
         error: "missing_required_body",
-        required: ["ref"]
+        required: ["version"]
       });
       return true;
     }
 
     await runAdminOperation(response, () =>
       options.adminService.deployRelease({
-        ref,
+        version,
         allowActive: body.allow_active === true
       })
     );
@@ -386,7 +386,7 @@ export async function handleAdminRequest(
 
     await runAdminOperation(response, () =>
       options.adminService.rollbackRelease({
-        ref: readString(body.ref) ?? undefined,
+        version: readString(body.version) ?? undefined,
         allowActive: body.allow_active === true
       })
     );

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -359,18 +359,20 @@ export async function handleAdminRequest(
       return true;
     }
 
+    const target = readReleaseTarget(body.target);
     const version = readString(body.version);
-    if (!version) {
+    if (!target || !version) {
       respondJson(response, 400, {
         ok: false,
         error: "missing_required_body",
-        required: ["version"]
+        required: ["target", "version"]
       });
       return true;
     }
 
     await runAdminOperation(response, () =>
       options.adminService.deployRelease({
+        target,
         version,
         allowActive: body.allow_active === true
       })
@@ -384,8 +386,19 @@ export async function handleAdminRequest(
       return true;
     }
 
+    const target = readReleaseTarget(body.target);
+    if (!target) {
+      respondJson(response, 400, {
+        ok: false,
+        error: "missing_required_body",
+        required: ["target"]
+      });
+      return true;
+    }
+
     await runAdminOperation(response, () =>
       options.adminService.rollbackRelease({
+        target,
         version: readString(body.version) ?? undefined,
         allowActive: body.allow_active === true
       })
@@ -565,6 +578,10 @@ async function readAdminBody(
 function readPositiveNumber(value: unknown): number | undefined {
   const numeric = typeof value === "number" ? value : typeof value === "string" ? Number.parseFloat(value) : Number.NaN;
   return Number.isFinite(numeric) && numeric > 0 ? numeric : undefined;
+}
+
+function readReleaseTarget(value: unknown): "admin" | "worker" | undefined {
+  return value === "admin" || value === "worker" ? value : undefined;
 }
 
 async function runAdminOperation(

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -670,7 +670,7 @@ export class AdminService {
   }
 
   async deployRelease(options: {
-    readonly ref: string;
+    readonly version: string;
     readonly allowActive: boolean;
   }): Promise<Record<string, unknown>> {
     if (!this.options.deployment) {
@@ -680,13 +680,13 @@ export class AdminService {
     return await this.#runTrackedOperation(
       "deploy",
       {
-        ref: options.ref,
+        version: options.version,
         allowActive: options.allowActive
       },
       async () => {
         await this.#assertSafeToInterrupt(options.allowActive, "deploy");
         const deployment = await this.options.deployment!.deploy({
-          ref: options.ref
+          version: options.version
         } satisfies DeployReleaseOptions);
         return {
           ok: true,
@@ -697,7 +697,7 @@ export class AdminService {
   }
 
   async rollbackRelease(options: {
-    readonly ref?: string | undefined;
+    readonly version?: string | undefined;
     readonly allowActive: boolean;
   }): Promise<Record<string, unknown>> {
     if (!this.options.deployment) {
@@ -707,13 +707,13 @@ export class AdminService {
     return await this.#runTrackedOperation(
       "rollback",
       {
-        ref: options.ref ?? null,
+        version: options.version ?? null,
         allowActive: options.allowActive
       },
       async () => {
         await this.#assertSafeToInterrupt(options.allowActive, "rollback");
         const deployment = await this.options.deployment!.rollback({
-          ref: options.ref
+          version: options.version
         } satisfies RollbackReleaseOptions);
         return {
           ok: true,

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -670,6 +670,7 @@ export class AdminService {
   }
 
   async deployRelease(options: {
+    readonly target: "admin" | "worker";
     readonly version: string;
     readonly allowActive: boolean;
   }): Promise<Record<string, unknown>> {
@@ -680,12 +681,14 @@ export class AdminService {
     return await this.#runTrackedOperation(
       "deploy",
       {
+        target: options.target,
         version: options.version,
         allowActive: options.allowActive
       },
       async () => {
         await this.#assertSafeToInterrupt(options.allowActive, "deploy");
         const deployment = await this.options.deployment!.deploy({
+          target: options.target,
           version: options.version
         } satisfies DeployReleaseOptions);
         return {
@@ -697,6 +700,7 @@ export class AdminService {
   }
 
   async rollbackRelease(options: {
+    readonly target: "admin" | "worker";
     readonly version?: string | undefined;
     readonly allowActive: boolean;
   }): Promise<Record<string, unknown>> {
@@ -707,12 +711,14 @@ export class AdminService {
     return await this.#runTrackedOperation(
       "rollback",
       {
+        target: options.target,
         version: options.version ?? null,
         allowActive: options.allowActive
       },
       async () => {
         await this.#assertSafeToInterrupt(options.allowActive, "rollback");
         const deployment = await this.options.deployment!.rollback({
+          target: options.target,
           version: options.version
         } satisfies RollbackReleaseOptions);
         return {

--- a/src/services/codex/isolated-mcp-service.ts
+++ b/src/services/codex/isolated-mcp-service.ts
@@ -214,7 +214,7 @@ class StoredOauthProvider implements OAuthClientProvider {
     return {
       redirect_uris: [],
       client_name: "slack-codex-broker",
-      client_uri: "https://github.com/zzj3720/slack-codex-broker",
+      client_uri: "https://github.com/HOOLC/slack-codex-broker",
       grant_types: this.#entry.refresh_token
         ? ["refresh_token"]
         : ["authorization_code", "refresh_token"],

--- a/src/services/deploy/release-deployment-service.ts
+++ b/src/services/deploy/release-deployment-service.ts
@@ -6,21 +6,27 @@ import { execCommand, spawnDetachedCommand } from "../../utils/exec.js";
 import { ensureDir, fileExists } from "../../utils/fs.js";
 
 const RELEASE_METADATA_FILENAME = ".broker-release.json";
-const RELEASE_STATE_SCHEMA_VERSION = 2;
-const DEFAULT_RELEASE_PACKAGE_NAME = "agent-session-broker";
+const RELEASE_STATE_SCHEMA_VERSION = 3;
+const DEFAULT_RELEASE_PACKAGES: Record<ReleaseTarget, string> = {
+  admin: "@agent-session-broker/admin",
+  worker: "@agent-session-broker/worker"
+};
 export const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 90_000;
+
+export type ReleaseTarget = "admin" | "worker";
 
 export interface ReleaseMetadata {
   readonly revision: string | null;
   readonly shortRevision: string | null;
   readonly branch: string | null;
-  readonly packageName?: string | undefined;
-  readonly packageVersion?: string | undefined;
-  readonly packageSpec?: string | undefined;
-  readonly installedAt?: string | undefined;
-  readonly installedBy?: string | undefined;
-  readonly installedFromHost?: string | undefined;
-  readonly requestedVersion?: string | null | undefined;
+  readonly target: ReleaseTarget;
+  readonly packageName: string;
+  readonly packageVersion: string;
+  readonly packageSpec: string;
+  readonly installedAt: string;
+  readonly installedBy: string;
+  readonly installedFromHost: string;
+  readonly requestedVersion: string;
   readonly builtAt?: string | undefined;
   readonly builtBy?: string | undefined;
   readonly builtFromHost?: string | undefined;
@@ -40,6 +46,16 @@ export interface ReleasePackageVersionInfo {
   readonly packageSpec: string;
 }
 
+export interface ReleaseTargetStatus {
+  readonly target: ReleaseTarget;
+  readonly packageName: string;
+  readonly currentRelease: ReleaseInfo;
+  readonly previousRelease: ReleaseInfo;
+  readonly failedRelease: ReleaseInfo;
+  readonly recentReleases: readonly ReleaseInfo[];
+  readonly recentPackageVersions: readonly ReleasePackageVersionInfo[];
+}
+
 export interface WorkerHealthStatus {
   readonly launchdLoaded: boolean;
   readonly healthOk: boolean;
@@ -56,23 +72,26 @@ export interface AdminHealthStatus {
 
 export interface ReleaseDeploymentStatus {
   readonly serviceRoot: string;
-  readonly packageName: string;
   readonly npmRegistryUrl: string | null;
-  readonly currentRelease: ReleaseInfo;
-  readonly previousRelease: ReleaseInfo;
-  readonly failedRelease: ReleaseInfo;
-  readonly recentReleases: readonly ReleaseInfo[];
-  readonly recentPackageVersions: readonly ReleasePackageVersionInfo[];
+  readonly targets: Record<ReleaseTarget, ReleaseTargetStatus>;
   readonly admin: AdminHealthStatus | null;
   readonly worker: WorkerHealthStatus;
 }
 
 export interface DeployReleaseOptions {
+  readonly target: ReleaseTarget;
   readonly version: string;
 }
 
 export interface RollbackReleaseOptions {
+  readonly target: ReleaseTarget;
   readonly version?: string | undefined;
+}
+
+interface ReleaseTargetPaths {
+  readonly currentReleasePath: string;
+  readonly previousReleasePath: string;
+  readonly failedReleasePath: string;
 }
 
 export class ReleaseDeploymentService {
@@ -83,9 +102,12 @@ export class ReleaseDeploymentService {
     private readonly options: {
       readonly serviceRoot: string;
       readonly releasesRoot: string;
-      readonly currentReleasePath: string;
-      readonly previousReleasePath: string;
-      readonly failedReleasePath: string;
+      readonly currentAdminReleasePath: string;
+      readonly previousAdminReleasePath: string;
+      readonly failedAdminReleasePath: string;
+      readonly currentWorkerReleasePath: string;
+      readonly previousWorkerReleasePath: string;
+      readonly failedWorkerReleasePath: string;
       readonly adminPlistPath?: string | undefined;
       readonly adminLaunchdLabel?: string | undefined;
       readonly adminBaseUrl?: string | undefined;
@@ -93,7 +115,7 @@ export class ReleaseDeploymentService {
       readonly workerLaunchdLabel: string;
       readonly workerBaseUrl: string;
       readonly codexAppServerPort: number;
-      readonly packageName?: string | undefined;
+      readonly packages?: Partial<Record<ReleaseTarget, string>> | undefined;
       readonly npmPath?: string | undefined;
       readonly npmRegistryUrl?: string | undefined;
       readonly healthCheckTimeoutMs?: number | undefined;
@@ -105,25 +127,20 @@ export class ReleaseDeploymentService {
   ) {}
 
   async getStatus(): Promise<ReleaseDeploymentStatus> {
-    const [currentRelease, previousRelease, failedRelease, recentReleases, recentPackageVersions, admin, worker] = await Promise.all([
-      this.#readLinkedRelease(this.options.currentReleasePath),
-      this.#readLinkedRelease(this.options.previousReleasePath),
-      this.#readLinkedRelease(this.options.failedReleasePath),
-      this.#readRecentReleases(),
-      this.#readRecentPackageVersions(),
+    const [adminTarget, workerTarget, admin, worker] = await Promise.all([
+      this.#readTargetStatus("admin"),
+      this.#readTargetStatus("worker"),
       this.#readAdminHealth(),
       this.#readWorkerHealth()
     ]);
 
     return {
       serviceRoot: this.options.serviceRoot,
-      packageName: this.#packageName(),
       npmRegistryUrl: this.options.npmRegistryUrl ?? null,
-      currentRelease,
-      previousRelease,
-      failedRelease,
-      recentReleases,
-      recentPackageVersions,
+      targets: {
+        admin: adminTarget,
+        worker: workerTarget
+      },
       admin,
       worker
     };
@@ -131,21 +148,23 @@ export class ReleaseDeploymentService {
 
   async deploy(options: DeployReleaseOptions): Promise<ReleaseDeploymentStatus> {
     return await this.#runExclusive(async () => {
+      const target = normalizeReleaseTarget(options.target);
       const version = normalizePackageVersion(options.version);
-      const releaseRoot = await this.#ensurePackageRelease(version);
-      const metadata = this.#buildReleaseMetadata(version);
+      const releaseRoot = await this.#ensurePackageRelease(target, version);
+      const metadata = this.#buildReleaseMetadata(target, version);
       await this.#writeReleaseMetadata(releaseRoot, metadata);
-      await this.#activateRelease(releaseRoot);
+      await this.#activateRelease(target, releaseRoot);
       return await this.getStatus();
     });
   }
 
-  async rollback(options: RollbackReleaseOptions = {}): Promise<ReleaseDeploymentStatus> {
+  async rollback(options: RollbackReleaseOptions): Promise<ReleaseDeploymentStatus> {
     return await this.#runExclusive(async () => {
+      const target = normalizeReleaseTarget(options.target);
       const releaseRoot = options.version
-        ? await this.#requireInstalledPackageRelease(options.version)
-        : await this.#requirePreviousRelease();
-      await this.#activateRelease(releaseRoot);
+        ? await this.#requireInstalledPackageRelease(target, options.version)
+        : await this.#requirePreviousRelease(target);
+      await this.#activateRelease(target, releaseRoot);
       return await this.getStatus();
     });
   }
@@ -172,14 +191,35 @@ export class ReleaseDeploymentService {
     }
   }
 
-  async #ensurePackageRelease(version: string): Promise<string> {
-    const installRoot = this.#installRootForVersion(version);
-    const packageRoot = this.#packageRootForInstallRoot(installRoot);
-    if (await this.#isUsablePackageRoot(packageRoot)) {
+  async #readTargetStatus(target: ReleaseTarget): Promise<ReleaseTargetStatus> {
+    const paths = this.#targetPaths(target);
+    const [currentRelease, previousRelease, failedRelease, recentReleases, recentPackageVersions] = await Promise.all([
+      this.#readLinkedRelease(paths.currentReleasePath),
+      this.#readLinkedRelease(paths.previousReleasePath),
+      this.#readLinkedRelease(paths.failedReleasePath),
+      this.#readRecentReleases(target),
+      this.#readRecentPackageVersions(target)
+    ]);
+
+    return {
+      target,
+      packageName: this.#packageName(target),
+      currentRelease,
+      previousRelease,
+      failedRelease,
+      recentReleases,
+      recentPackageVersions
+    };
+  }
+
+  async #ensurePackageRelease(target: ReleaseTarget, version: string): Promise<string> {
+    const installRoot = this.#installRootForVersion(target, version);
+    const packageRoot = this.#packageRootForInstallRoot(target, installRoot);
+    if (await this.#isUsablePackageRoot(target, packageRoot)) {
       return packageRoot;
     }
 
-    await ensureDir(this.options.releasesRoot);
+    await ensureDir(path.dirname(installRoot));
     const tempRoot = `${installRoot}.tmp-${process.pid}-${Date.now()}`;
     await fs.rm(tempRoot, { force: true, recursive: true });
 
@@ -193,10 +233,10 @@ export class ReleaseDeploymentService {
         "--no-audit",
         "--no-fund",
         ...this.#npmRegistryArgs(),
-        packageSpec(this.#packageName(), version)
+        packageSpec(this.#packageName(target), version)
       ]);
-      const tempPackageRoot = this.#packageRootForInstallRoot(tempRoot);
-      await this.#assertUsablePackageRoot(tempPackageRoot);
+      const tempPackageRoot = this.#packageRootForInstallRoot(target, tempRoot);
+      await this.#assertUsablePackageRoot(target, tempPackageRoot);
       await fs.rm(installRoot, { force: true, recursive: true });
       await fs.rename(tempRoot, installRoot);
       return packageRoot;
@@ -206,31 +246,33 @@ export class ReleaseDeploymentService {
     }
   }
 
-  async #requireInstalledPackageRelease(version: string): Promise<string> {
+  async #requireInstalledPackageRelease(target: ReleaseTarget, version: string): Promise<string> {
     const normalized = normalizePackageVersion(version);
-    const packageRoot = this.#packageRootForInstallRoot(this.#installRootForVersion(normalized));
-    if (!(await this.#isUsablePackageRoot(packageRoot))) {
-      throw new Error(`Package release is not installed locally: ${this.#packageName()}@${normalized}`);
+    const packageRoot = this.#packageRootForInstallRoot(target, this.#installRootForVersion(target, normalized));
+    if (!(await this.#isUsablePackageRoot(target, packageRoot))) {
+      throw new Error(`Package release is not installed locally: ${this.#packageName(target)}@${normalized}`);
     }
     return packageRoot;
   }
 
-  async #requirePreviousRelease(): Promise<string> {
-    const previous = await this.#readLinkedRelease(this.options.previousReleasePath);
+  async #requirePreviousRelease(target: ReleaseTarget): Promise<string> {
+    const previous = await this.#readLinkedRelease(this.#targetPaths(target).previousReleasePath);
     if (!previous.targetPath || !(await fileExists(previous.targetPath))) {
-      throw new Error(`No previous worker release found at ${this.options.previousReleasePath}`);
+      throw new Error(`No previous ${target} release found at ${previous.linkPath}`);
     }
     return previous.targetPath;
   }
 
-  #buildReleaseMetadata(version: string): ReleaseMetadata {
+  #buildReleaseMetadata(target: ReleaseTarget, version: string): ReleaseMetadata {
+    const packageName = this.#packageName(target);
     return {
       revision: null,
       shortRevision: null,
       branch: null,
-      packageName: this.#packageName(),
+      target,
+      packageName,
       packageVersion: version,
-      packageSpec: packageSpec(this.#packageName(), version),
+      packageSpec: packageSpec(packageName, version),
       requestedVersion: version,
       installedAt: new Date().toISOString(),
       installedBy: process.env.USER || process.env.LOGNAME || "unknown",
@@ -247,37 +289,41 @@ export class ReleaseDeploymentService {
     );
   }
 
-  async #activateRelease(releaseRoot: string): Promise<void> {
-    const currentRelease = await this.#readLinkedRelease(this.options.currentReleasePath);
-    const previousRelease = await this.#readLinkedRelease(this.options.previousReleasePath);
+  async #activateRelease(target: ReleaseTarget, releaseRoot: string): Promise<void> {
+    const paths = this.#targetPaths(target);
+    const currentRelease = await this.#readLinkedRelease(paths.currentReleasePath);
+    const previousRelease = await this.#readLinkedRelease(paths.previousReleasePath);
     const previousCurrentPath = currentRelease.targetPath;
     const previousPreviousPath = previousRelease.targetPath;
 
-    await this.#pointLink(this.options.currentReleasePath, releaseRoot);
+    await this.#pointLink(paths.currentReleasePath, releaseRoot);
     if (previousCurrentPath && previousCurrentPath !== releaseRoot) {
-      await this.#pointLink(this.options.previousReleasePath, previousCurrentPath);
+      await this.#pointLink(paths.previousReleasePath, previousCurrentPath);
     }
 
     try {
-      await this.#restartLaunchdWorker("worker release activation");
-      await this.#assertWorkerHealthy();
-      await fs.rm(this.options.failedReleasePath, { force: true, recursive: true });
-      this.#scheduleAdminRestart("admin release activation");
-    } catch (error) {
-      await this.#pointLink(this.options.failedReleasePath, releaseRoot);
-      if (previousCurrentPath) {
-        await this.#pointLink(this.options.currentReleasePath, previousCurrentPath);
+      if (target === "worker") {
+        await this.#restartLaunchdWorker("worker release activation");
+        await this.#assertWorkerHealthy();
       } else {
-        await fs.rm(this.options.currentReleasePath, { force: true, recursive: true });
+        this.#scheduleAdminRestart("admin release activation");
+      }
+      await fs.rm(paths.failedReleasePath, { force: true, recursive: true });
+    } catch (error) {
+      await this.#pointLink(paths.failedReleasePath, releaseRoot);
+      if (previousCurrentPath) {
+        await this.#pointLink(paths.currentReleasePath, previousCurrentPath);
+      } else {
+        await fs.rm(paths.currentReleasePath, { force: true, recursive: true });
       }
 
       if (previousPreviousPath && previousPreviousPath !== releaseRoot) {
-        await this.#pointLink(this.options.previousReleasePath, previousPreviousPath);
+        await this.#pointLink(paths.previousReleasePath, previousPreviousPath);
       } else if (!previousCurrentPath || previousCurrentPath === releaseRoot) {
-        await fs.rm(this.options.previousReleasePath, { force: true, recursive: true });
+        await fs.rm(paths.previousReleasePath, { force: true, recursive: true });
       }
 
-      if (previousCurrentPath) {
+      if (target === "worker" && previousCurrentPath) {
         await this.#restartLaunchdWorker("worker release rollback");
       }
 
@@ -312,7 +358,7 @@ export class ReleaseDeploymentService {
     }
 
     const restartScriptPath = path.join(
-      this.options.currentReleasePath,
+      this.options.currentAdminReleasePath,
       "scripts",
       "ops",
       "macos-launchd-restart.mjs"
@@ -495,7 +541,7 @@ export class ReleaseDeploymentService {
         try {
           socket.close();
         } catch {
-          // ignore close failures
+          // Ignore close failures.
         }
         resolve(result);
       };
@@ -513,18 +559,19 @@ export class ReleaseDeploymentService {
     });
   }
 
-  async #readRecentReleases(): Promise<readonly ReleaseInfo[]> {
-    if (!(await fileExists(this.options.releasesRoot))) {
+  async #readRecentReleases(target: ReleaseTarget): Promise<readonly ReleaseInfo[]> {
+    const targetReleaseRoot = path.join(this.options.releasesRoot, target);
+    if (!(await fileExists(targetReleaseRoot))) {
       return [];
     }
 
-    const entries = await fs.readdir(this.options.releasesRoot, { withFileTypes: true });
+    const entries = await fs.readdir(targetReleaseRoot, { withFileTypes: true });
     const releases = await Promise.all(
       entries
         .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
         .map(async (entry) => {
-          const installRoot = path.join(this.options.releasesRoot, entry.name);
-          const targetPath = await this.#resolveReleaseRootFromInstallEntry(installRoot);
+          const installRoot = path.join(targetReleaseRoot, entry.name);
+          const targetPath = await this.#resolveReleaseRootFromInstallEntry(target, installRoot);
           if (!targetPath) {
             return null;
           }
@@ -547,8 +594,8 @@ export class ReleaseDeploymentService {
       .map(({ mtimeMs: _mtimeMs, ...release }) => release);
   }
 
-  async #resolveReleaseRootFromInstallEntry(installRoot: string): Promise<string | null> {
-    const packageRoot = this.#packageRootForInstallRoot(installRoot);
+  async #resolveReleaseRootFromInstallEntry(target: ReleaseTarget, installRoot: string): Promise<string | null> {
+    const packageRoot = this.#packageRootForInstallRoot(target, installRoot);
     if (await fileExists(packageRoot)) {
       return packageRoot;
     }
@@ -558,19 +605,21 @@ export class ReleaseDeploymentService {
     return null;
   }
 
-  async #readRecentPackageVersions(): Promise<readonly ReleasePackageVersionInfo[]> {
+  async #readRecentPackageVersions(target: ReleaseTarget): Promise<readonly ReleasePackageVersionInfo[]> {
+    const packageName = this.#packageName(target);
     try {
       const result = await this.#exec(this.#npmPath(), [
         "view",
-        this.#packageName(),
+        packageName,
         "versions",
         "--json",
         ...this.#npmRegistryArgs()
       ]);
-      return parsePackageVersions(result.stdout, this.#packageName()).slice(0, 20);
+      return parsePackageVersions(result.stdout, packageName).slice(0, 20);
     } catch (error) {
       logger.warn("Failed to read package versions for deployment status", {
-        packageName: this.#packageName(),
+        target,
+        packageName,
         error: error instanceof Error ? error.message : String(error)
       });
       return [];
@@ -621,39 +670,60 @@ export class ReleaseDeploymentService {
     await fs.rename(tempPath, linkPath);
   }
 
-  async #isUsablePackageRoot(packageRoot: string): Promise<boolean> {
+  async #isUsablePackageRoot(target: ReleaseTarget, packageRoot: string): Promise<boolean> {
     try {
-      await this.#assertUsablePackageRoot(packageRoot);
+      await this.#assertUsablePackageRoot(target, packageRoot);
       return true;
     } catch {
       return false;
     }
   }
 
-  async #assertUsablePackageRoot(packageRoot: string): Promise<void> {
-    const required = [
-      path.join(packageRoot, "dist", "src", "admin-index.js"),
-      path.join(packageRoot, "dist", "src", "worker-index.js"),
-      path.join(packageRoot, "scripts", "ops", "macos-launchd-launcher.mjs"),
-      path.join(packageRoot, "scripts", "ops", "macos-launchd-restart.mjs")
-    ];
+  async #assertUsablePackageRoot(target: ReleaseTarget, packageRoot: string): Promise<void> {
+    const required = target === "admin"
+      ? [
+          path.join(packageRoot, "dist", "src", "admin-index.js"),
+          path.join(packageRoot, "dist", "admin-ui", "index.html"),
+          path.join(packageRoot, "scripts", "ops", "macos-bootstrap.mjs"),
+          path.join(packageRoot, "scripts", "ops", "macos-launchd-launcher.mjs"),
+          path.join(packageRoot, "scripts", "ops", "macos-launchd-restart.mjs")
+        ]
+      : [
+          path.join(packageRoot, "dist", "src", "worker-index.js"),
+          path.join(packageRoot, "scripts", "ops", "macos-launchd-launcher.mjs"),
+          path.join(packageRoot, "scripts", "ops", "macos-launchd-restart.mjs")
+        ];
     for (const filePath of required) {
       if (!(await fileExists(filePath))) {
-        throw new Error(`Installed package is missing required runtime file: ${filePath}`);
+        throw new Error(`Installed ${target} package is missing required runtime file: ${filePath}`);
       }
     }
   }
 
-  #installRootForVersion(version: string): string {
-    return path.join(this.options.releasesRoot, `npm-${version}`);
+  #installRootForVersion(target: ReleaseTarget, version: string): string {
+    return path.join(this.options.releasesRoot, target, `npm-${version}`);
   }
 
-  #packageRootForInstallRoot(installRoot: string): string {
-    return path.join(installRoot, "node_modules", ...this.#packageName().split("/"));
+  #packageRootForInstallRoot(target: ReleaseTarget, installRoot: string): string {
+    return path.join(installRoot, "node_modules", ...this.#packageName(target).split("/"));
   }
 
-  #packageName(): string {
-    return this.options.packageName || DEFAULT_RELEASE_PACKAGE_NAME;
+  #targetPaths(target: ReleaseTarget): ReleaseTargetPaths {
+    return target === "admin"
+      ? {
+          currentReleasePath: this.options.currentAdminReleasePath,
+          previousReleasePath: this.options.previousAdminReleasePath,
+          failedReleasePath: this.options.failedAdminReleasePath
+        }
+      : {
+          currentReleasePath: this.options.currentWorkerReleasePath,
+          previousReleasePath: this.options.previousWorkerReleasePath,
+          failedReleasePath: this.options.failedWorkerReleasePath
+        };
+  }
+
+  #packageName(target: ReleaseTarget): string {
+    return this.options.packages?.[target] || DEFAULT_RELEASE_PACKAGES[target];
   }
 
   #npmPath(): string {
@@ -690,6 +760,13 @@ export class ReleaseDeploymentService {
 
 function packageSpec(packageName: string, version: string): string {
   return `${packageName}@${version}`;
+}
+
+function normalizeReleaseTarget(target: string): ReleaseTarget {
+  if (target === "admin" || target === "worker") {
+    return target;
+  }
+  throw new Error(`Invalid release target: ${target}`);
 }
 
 function normalizePackageVersion(version: string): string {

--- a/src/services/deploy/release-deployment-service.ts
+++ b/src/services/deploy/release-deployment-service.ts
@@ -6,16 +6,24 @@ import { execCommand, spawnDetachedCommand } from "../../utils/exec.js";
 import { ensureDir, fileExists } from "../../utils/fs.js";
 
 const RELEASE_METADATA_FILENAME = ".broker-release.json";
-const RELEASE_STATE_SCHEMA_VERSION = 1;
+const RELEASE_STATE_SCHEMA_VERSION = 2;
+const DEFAULT_RELEASE_PACKAGE_NAME = "agent-session-broker";
 export const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 90_000;
 
 export interface ReleaseMetadata {
   readonly revision: string | null;
   readonly shortRevision: string | null;
   readonly branch: string | null;
-  readonly builtAt: string;
-  readonly builtBy: string;
-  readonly builtFromHost: string;
+  readonly packageName?: string | undefined;
+  readonly packageVersion?: string | undefined;
+  readonly packageSpec?: string | undefined;
+  readonly installedAt?: string | undefined;
+  readonly installedBy?: string | undefined;
+  readonly installedFromHost?: string | undefined;
+  readonly requestedVersion?: string | null | undefined;
+  readonly builtAt?: string | undefined;
+  readonly builtBy?: string | undefined;
+  readonly builtFromHost?: string | undefined;
   readonly requestedRef?: string | null | undefined;
   readonly stateSchemaVersion: number;
 }
@@ -25,6 +33,11 @@ export interface ReleaseInfo {
   readonly targetPath: string | null;
   readonly exists: boolean;
   readonly metadata: ReleaseMetadata | null;
+}
+
+export interface ReleasePackageVersionInfo {
+  readonly version: string;
+  readonly packageSpec: string;
 }
 
 export interface WorkerHealthStatus {
@@ -43,22 +56,23 @@ export interface AdminHealthStatus {
 
 export interface ReleaseDeploymentStatus {
   readonly serviceRoot: string;
-  readonly repoRoot: string;
-  readonly repoUrl: string | null;
+  readonly packageName: string;
+  readonly npmRegistryUrl: string | null;
   readonly currentRelease: ReleaseInfo;
   readonly previousRelease: ReleaseInfo;
   readonly failedRelease: ReleaseInfo;
   readonly recentReleases: readonly ReleaseInfo[];
+  readonly recentPackageVersions: readonly ReleasePackageVersionInfo[];
   readonly admin: AdminHealthStatus | null;
   readonly worker: WorkerHealthStatus;
 }
 
 export interface DeployReleaseOptions {
-  readonly ref: string;
+  readonly version: string;
 }
 
 export interface RollbackReleaseOptions {
-  readonly ref?: string | undefined;
+  readonly version?: string | undefined;
 }
 
 export class ReleaseDeploymentService {
@@ -68,7 +82,6 @@ export class ReleaseDeploymentService {
   constructor(
     private readonly options: {
       readonly serviceRoot: string;
-      readonly repoRoot: string;
       readonly releasesRoot: string;
       readonly currentReleasePath: string;
       readonly previousReleasePath: string;
@@ -80,8 +93,9 @@ export class ReleaseDeploymentService {
       readonly workerLaunchdLabel: string;
       readonly workerBaseUrl: string;
       readonly codexAppServerPort: number;
-      readonly releaseRepoUrl?: string | undefined;
-      readonly corepackPath?: string | undefined;
+      readonly packageName?: string | undefined;
+      readonly npmPath?: string | undefined;
+      readonly npmRegistryUrl?: string | undefined;
       readonly healthCheckTimeoutMs?: number | undefined;
       readonly healthCheckIntervalMs?: number | undefined;
       readonly scheduleAdminRestart?: ((restart: () => Promise<void>) => void) | undefined;
@@ -91,23 +105,25 @@ export class ReleaseDeploymentService {
   ) {}
 
   async getStatus(): Promise<ReleaseDeploymentStatus> {
-    const [currentRelease, previousRelease, failedRelease, recentReleases, admin, worker] = await Promise.all([
+    const [currentRelease, previousRelease, failedRelease, recentReleases, recentPackageVersions, admin, worker] = await Promise.all([
       this.#readLinkedRelease(this.options.currentReleasePath),
       this.#readLinkedRelease(this.options.previousReleasePath),
       this.#readLinkedRelease(this.options.failedReleasePath),
       this.#readRecentReleases(),
+      this.#readRecentPackageVersions(),
       this.#readAdminHealth(),
       this.#readWorkerHealth()
     ]);
 
     return {
       serviceRoot: this.options.serviceRoot,
-      repoRoot: this.options.repoRoot,
-      repoUrl: await this.#readRepoUrl(),
+      packageName: this.#packageName(),
+      npmRegistryUrl: this.options.npmRegistryUrl ?? null,
       currentRelease,
       previousRelease,
       failedRelease,
       recentReleases,
+      recentPackageVersions,
       admin,
       worker
     };
@@ -115,11 +131,9 @@ export class ReleaseDeploymentService {
 
   async deploy(options: DeployReleaseOptions): Promise<ReleaseDeploymentStatus> {
     return await this.#runExclusive(async () => {
-      await this.#ensureRepoReady();
-      const revision = await this.#resolveRevision(options.ref);
-      const releaseRoot = await this.#ensureReleaseWorktree(revision);
-      const metadata = await this.#buildReleaseMetadata(revision, options.ref);
-      await this.#buildRelease(releaseRoot);
+      const version = normalizePackageVersion(options.version);
+      const releaseRoot = await this.#ensurePackageRelease(version);
+      const metadata = this.#buildReleaseMetadata(version);
       await this.#writeReleaseMetadata(releaseRoot, metadata);
       await this.#activateRelease(releaseRoot);
       return await this.getStatus();
@@ -128,8 +142,8 @@ export class ReleaseDeploymentService {
 
   async rollback(options: RollbackReleaseOptions = {}): Promise<ReleaseDeploymentStatus> {
     return await this.#runExclusive(async () => {
-      const releaseRoot = options.ref
-        ? await this.#resolveRollbackRelease(options.ref)
+      const releaseRoot = options.version
+        ? await this.#requireInstalledPackageRelease(options.version)
         : await this.#requirePreviousRelease();
       await this.#activateRelease(releaseRoot);
       return await this.getStatus();
@@ -158,22 +172,47 @@ export class ReleaseDeploymentService {
     }
   }
 
-  async #resolveRollbackRelease(ref: string): Promise<string> {
-    const directPath = path.join(this.options.releasesRoot, ref);
-    if (await fileExists(directPath)) {
-      return directPath;
+  async #ensurePackageRelease(version: string): Promise<string> {
+    const installRoot = this.#installRootForVersion(version);
+    const packageRoot = this.#packageRootForInstallRoot(installRoot);
+    if (await this.#isUsablePackageRoot(packageRoot)) {
+      return packageRoot;
     }
 
-    await this.#ensureRepoReady();
-    const revision = await this.#resolveRevision(ref);
-    const releaseRoot = await this.#ensureReleaseWorktree(revision);
-    const metadataPath = path.join(releaseRoot, RELEASE_METADATA_FILENAME);
-    if (!(await fileExists(metadataPath))) {
-      const metadata = await this.#buildReleaseMetadata(revision, ref);
-      await this.#buildRelease(releaseRoot);
-      await this.#writeReleaseMetadata(releaseRoot, metadata);
+    await ensureDir(this.options.releasesRoot);
+    const tempRoot = `${installRoot}.tmp-${process.pid}-${Date.now()}`;
+    await fs.rm(tempRoot, { force: true, recursive: true });
+
+    try {
+      await this.#exec(this.#npmPath(), [
+        "install",
+        "--prefix",
+        tempRoot,
+        "--omit=dev",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        ...this.#npmRegistryArgs(),
+        packageSpec(this.#packageName(), version)
+      ]);
+      const tempPackageRoot = this.#packageRootForInstallRoot(tempRoot);
+      await this.#assertUsablePackageRoot(tempPackageRoot);
+      await fs.rm(installRoot, { force: true, recursive: true });
+      await fs.rename(tempRoot, installRoot);
+      return packageRoot;
+    } catch (error) {
+      await fs.rm(tempRoot, { force: true, recursive: true });
+      throw error;
     }
-    return releaseRoot;
+  }
+
+  async #requireInstalledPackageRelease(version: string): Promise<string> {
+    const normalized = normalizePackageVersion(version);
+    const packageRoot = this.#packageRootForInstallRoot(this.#installRootForVersion(normalized));
+    if (!(await this.#isUsablePackageRoot(packageRoot))) {
+      throw new Error(`Package release is not installed locally: ${this.#packageName()}@${normalized}`);
+    }
+    return packageRoot;
   }
 
   async #requirePreviousRelease(): Promise<string> {
@@ -184,76 +223,20 @@ export class ReleaseDeploymentService {
     return previous.targetPath;
   }
 
-  async #ensureRepoReady(): Promise<void> {
-    if (!(await fileExists(path.join(this.options.repoRoot, ".git")))) {
-      if (!this.options.releaseRepoUrl) {
-        throw new Error("Missing release repo clone and RELEASE_REPO_URL is not configured.");
-      }
-      await ensureDir(path.dirname(this.options.repoRoot));
-      await this.#exec("git", ["clone", this.options.releaseRepoUrl, this.options.repoRoot]);
-    }
-
-    if (this.options.releaseRepoUrl) {
-      await this.#exec("git", ["-C", this.options.repoRoot, "remote", "set-url", "origin", this.options.releaseRepoUrl]);
-    }
-
-    await this.#exec("git", ["-C", this.options.repoRoot, "fetch", "--prune", "--tags", "origin"]);
-  }
-
-  async #resolveRevision(ref: string): Promise<string> {
-    const result = await this.#exec("git", ["-C", this.options.repoRoot, "rev-parse", `${ref}^{commit}`]);
-    return result.stdout.trim();
-  }
-
-  async #ensureReleaseWorktree(revision: string): Promise<string> {
-    const releaseRoot = path.join(this.options.releasesRoot, revision);
-    if (await fileExists(path.join(releaseRoot, ".git"))) {
-      const existingRevision = (await this.#exec("git", ["-C", releaseRoot, "rev-parse", "HEAD"])).stdout.trim();
-      if (existingRevision === revision) {
-        return releaseRoot;
-      }
-      throw new Error(`Existing release path points at a different revision: ${releaseRoot}`);
-    }
-
-    if (await fileExists(releaseRoot)) {
-      await fs.rm(releaseRoot, { force: true, recursive: true });
-      await this.#exec("git", ["-C", this.options.repoRoot, "worktree", "prune"]);
-    }
-
-    await ensureDir(this.options.releasesRoot);
-    await this.#exec("git", ["-C", this.options.repoRoot, "worktree", "add", "--detach", releaseRoot, revision]);
-    return releaseRoot;
-  }
-
-  async #buildReleaseMetadata(revision: string, requestedRef: string): Promise<ReleaseMetadata> {
-    let branch: string | null = null;
-    try {
-      const result = await this.#exec("git", ["-C", this.options.repoRoot, "branch", "--contains", revision, "--format=%(refname:short)"]);
-      branch = result.stdout
-        .split(/\r?\n/)
-        .map((entry) => entry.trim())
-        .find(Boolean) ?? null;
-    } catch {
-      branch = null;
-    }
-
+  #buildReleaseMetadata(version: string): ReleaseMetadata {
     return {
-      revision,
-      shortRevision: revision.slice(0, 12),
-      branch,
-      builtAt: new Date().toISOString(),
-      builtBy: process.env.USER || process.env.LOGNAME || "unknown",
-      builtFromHost: process.env.HOSTNAME || "unknown",
-      requestedRef,
+      revision: null,
+      shortRevision: null,
+      branch: null,
+      packageName: this.#packageName(),
+      packageVersion: version,
+      packageSpec: packageSpec(this.#packageName(), version),
+      requestedVersion: version,
+      installedAt: new Date().toISOString(),
+      installedBy: process.env.USER || process.env.LOGNAME || "unknown",
+      installedFromHost: process.env.HOSTNAME || "unknown",
       stateSchemaVersion: RELEASE_STATE_SCHEMA_VERSION
     };
-  }
-
-  async #buildRelease(releaseRoot: string): Promise<void> {
-    const corepack = this.options.corepackPath || "corepack";
-    await this.#exec(corepack, ["pnpm", "install", "--frozen-lockfile"], { cwd: releaseRoot });
-    await this.#exec(corepack, ["pnpm", "build"], { cwd: releaseRoot });
-    await this.#exec(corepack, ["pnpm", "install", "--prod", "--frozen-lockfile"], { cwd: releaseRoot });
   }
 
   async #writeReleaseMetadata(releaseRoot: string, metadata: ReleaseMetadata): Promise<void> {
@@ -434,30 +417,6 @@ export class ReleaseDeploymentService {
     };
   }
 
-  async #assertAdminHealthy(): Promise<void> {
-    if (!this.options.adminLaunchdLabel || !this.options.adminBaseUrl) {
-      return;
-    }
-
-    const timeoutMs = this.options.healthCheckTimeoutMs ?? DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
-    const intervalMs = this.options.healthCheckIntervalMs ?? 500;
-    const deadline = Date.now() + timeoutMs;
-    let lastStatus = await this.#readAdminHealth();
-
-    while (Date.now() < deadline) {
-      if (lastStatus?.launchdLoaded && lastStatus.healthOk) {
-        return;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-      lastStatus = await this.#readAdminHealth();
-    }
-
-    throw new Error(
-      `Admin failed health checks: launchdLoaded=${lastStatus?.launchdLoaded ?? false} healthOk=${lastStatus?.healthOk ?? false}`
-    );
-  }
-
   #scheduleAdminRestart(reason: string): void {
     if (!this.options.adminPlistPath || !this.options.adminLaunchdLabel) {
       return;
@@ -554,19 +513,6 @@ export class ReleaseDeploymentService {
     });
   }
 
-  async #readRepoUrl(): Promise<string | null> {
-    if (!(await fileExists(path.join(this.options.repoRoot, ".git")))) {
-      return this.options.releaseRepoUrl ?? null;
-    }
-
-    try {
-      const result = await this.#exec("git", ["-C", this.options.repoRoot, "remote", "get-url", "origin"]);
-      return result.stdout.trim() || this.options.releaseRepoUrl || null;
-    } catch {
-      return this.options.releaseRepoUrl ?? null;
-    }
-  }
-
   async #readRecentReleases(): Promise<readonly ReleaseInfo[]> {
     if (!(await fileExists(this.options.releasesRoot))) {
       return [];
@@ -575,9 +521,13 @@ export class ReleaseDeploymentService {
     const entries = await fs.readdir(this.options.releasesRoot, { withFileTypes: true });
     const releases = await Promise.all(
       entries
-        .filter((entry) => entry.isDirectory())
+        .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
         .map(async (entry) => {
-          const targetPath = path.join(this.options.releasesRoot, entry.name);
+          const installRoot = path.join(this.options.releasesRoot, entry.name);
+          const targetPath = await this.#resolveReleaseRootFromInstallEntry(installRoot);
+          if (!targetPath) {
+            return null;
+          }
           const metadata = await this.#readReleaseMetadata(targetPath);
           const stat = await fs.stat(targetPath);
           return {
@@ -591,9 +541,40 @@ export class ReleaseDeploymentService {
     );
 
     return releases
+      .filter((release): release is NonNullable<typeof release> => Boolean(release))
       .sort((left, right) => right.mtimeMs - left.mtimeMs)
       .slice(0, 10)
       .map(({ mtimeMs: _mtimeMs, ...release }) => release);
+  }
+
+  async #resolveReleaseRootFromInstallEntry(installRoot: string): Promise<string | null> {
+    const packageRoot = this.#packageRootForInstallRoot(installRoot);
+    if (await fileExists(packageRoot)) {
+      return packageRoot;
+    }
+    if (await fileExists(path.join(installRoot, RELEASE_METADATA_FILENAME))) {
+      return installRoot;
+    }
+    return null;
+  }
+
+  async #readRecentPackageVersions(): Promise<readonly ReleasePackageVersionInfo[]> {
+    try {
+      const result = await this.#exec(this.#npmPath(), [
+        "view",
+        this.#packageName(),
+        "versions",
+        "--json",
+        ...this.#npmRegistryArgs()
+      ]);
+      return parsePackageVersions(result.stdout, this.#packageName()).slice(0, 20);
+    } catch (error) {
+      logger.warn("Failed to read package versions for deployment status", {
+        packageName: this.#packageName(),
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return [];
+    }
   }
 
   async #readLinkedRelease(linkPath: string): Promise<ReleaseInfo> {
@@ -640,6 +621,49 @@ export class ReleaseDeploymentService {
     await fs.rename(tempPath, linkPath);
   }
 
+  async #isUsablePackageRoot(packageRoot: string): Promise<boolean> {
+    try {
+      await this.#assertUsablePackageRoot(packageRoot);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async #assertUsablePackageRoot(packageRoot: string): Promise<void> {
+    const required = [
+      path.join(packageRoot, "dist", "src", "admin-index.js"),
+      path.join(packageRoot, "dist", "src", "worker-index.js"),
+      path.join(packageRoot, "scripts", "ops", "macos-launchd-launcher.mjs"),
+      path.join(packageRoot, "scripts", "ops", "macos-launchd-restart.mjs")
+    ];
+    for (const filePath of required) {
+      if (!(await fileExists(filePath))) {
+        throw new Error(`Installed package is missing required runtime file: ${filePath}`);
+      }
+    }
+  }
+
+  #installRootForVersion(version: string): string {
+    return path.join(this.options.releasesRoot, `npm-${version}`);
+  }
+
+  #packageRootForInstallRoot(installRoot: string): string {
+    return path.join(installRoot, "node_modules", ...this.#packageName().split("/"));
+  }
+
+  #packageName(): string {
+    return this.options.packageName || DEFAULT_RELEASE_PACKAGE_NAME;
+  }
+
+  #npmPath(): string {
+    return this.options.npmPath || "npm";
+  }
+
+  #npmRegistryArgs(): readonly string[] {
+    return this.options.npmRegistryUrl ? ["--registry", this.options.npmRegistryUrl] : [];
+  }
+
   async #exec(
     command: string,
     args: readonly string[],
@@ -662,4 +686,29 @@ export class ReleaseDeploymentService {
     const spawnDetached = this.options.spawnDetached ?? spawnDetachedCommand;
     spawnDetached(command, args, options);
   }
+}
+
+function packageSpec(packageName: string, version: string): string {
+  return `${packageName}@${version}`;
+}
+
+function normalizePackageVersion(version: string): string {
+  const normalized = String(version || "").trim();
+  if (!normalized || !/^[0-9A-Za-z][0-9A-Za-z._+-]*$/.test(normalized)) {
+    throw new Error(`Invalid package version: ${version}`);
+  }
+  return normalized;
+}
+
+function parsePackageVersions(stdout: string, packageName: string): readonly ReleasePackageVersionInfo[] {
+  const parsed = JSON.parse(stdout || "[]") as unknown;
+  const versions = Array.isArray(parsed) ? parsed : typeof parsed === "string" ? [parsed] : [];
+  return versions
+    .map((version) => String(version || "").trim())
+    .filter(Boolean)
+    .reverse()
+    .map((version) => ({
+      version,
+      packageSpec: packageSpec(packageName, version)
+    }));
 }

--- a/test/admin-auth-profile-display.test.ts
+++ b/test/admin-auth-profile-display.test.ts
@@ -17,7 +17,7 @@ describe("admin auth profile display", () => {
     const sevenDays = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
     const profile = authProfile({
       name: "575d9997-db66-4b21-979d-4d3b9597b36e",
-      email: "hejiachen@toeverything.info",
+      email: "operator@example.com",
       planType: "prolite",
       primaryUsed: 4,
       primaryResetsAt: fiveHours,
@@ -25,12 +25,12 @@ describe("admin auth profile display", () => {
       secondaryResetsAt: sevenDays
     });
 
-    expect(profileAccountLabel(profile)).toBe("hejiachen@toeverything.info");
-    expect(profileDisplayLabel(profile)).toBe("hejiachen@toeverything.info · Pro Lite");
+    expect(profileAccountLabel(profile)).toBe("operator@example.com");
+    expect(profileDisplayLabel(profile)).toBe("operator@example.com · Pro Lite");
     expect(profileQuotaLabel(profile, { now })).toBe("7d 64% / 0.64");
     expect(profileWeeklyQuotaLabel(profile, { now })).toBe("7d 64% / 0.64");
-    expect(profileOptionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 7d 64% / 0.64");
-    expect(profileSessionActionLabel(profile, { now })).toBe("hejiachen@toeverything.info · Pro Lite · 7d 64% / 0.64");
+    expect(profileOptionLabel(profile, { now })).toBe("operator@example.com · Pro Lite · 7d 64% / 0.64");
+    expect(profileSessionActionLabel(profile, { now })).toBe("operator@example.com · Pro Lite · 7d 64% / 0.64");
     expect(profileTitle(profile, { now })).toContain("内部标识 575d9997-db66-4b21-979d-4d3b9597b36e");
   });
 

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -556,6 +556,7 @@ describe("admin control plane e2e", () => {
     const { baseUrl, deploymentCalls } = await startAdminFixture();
 
     const deploy = await postJson(`${baseUrl}/admin/api/deploy`, {
+      target: "worker",
       version: "0.2.0",
       allow_active: false
     });
@@ -565,11 +566,12 @@ describe("admin control plane e2e", () => {
         kind: "deploy",
         status: "succeeded",
         request: {
+          target: "worker",
           version: "0.2.0"
         }
       }
     });
-    expect(deploymentCalls).toEqual([{ kind: "deploy", version: "0.2.0" }]);
+    expect(deploymentCalls).toEqual([{ kind: "deploy", target: "worker", version: "0.2.0" }]);
 
     const operations = await readJson(`${baseUrl}/admin/api/operations`);
     expect(operations).toMatchObject({
@@ -580,6 +582,7 @@ describe("admin control plane e2e", () => {
           kind: "deploy",
           status: "succeeded",
           request: {
+            target: "worker",
             version: "0.2.0"
           }
         }
@@ -614,6 +617,7 @@ describe("admin control plane e2e", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
+        target: "worker",
         version: "0.2.0",
         allow_active: false
       })
@@ -634,6 +638,7 @@ describe("admin control plane e2e", () => {
           kind: "deploy",
           status: "failed",
           request: {
+            target: "worker",
             version: "0.2.0"
           }
         }
@@ -735,12 +740,12 @@ describe("admin control plane e2e", () => {
       } as never,
       deployment: {
         getStatus: async () => deploymentStatus(config),
-        deploy: async ({ version }: { readonly version: string }) => {
-          deploymentCalls.push({ kind: "deploy", version });
+        deploy: async ({ target, version }: { readonly target: "admin" | "worker"; readonly version: string }) => {
+          deploymentCalls.push({ kind: "deploy", target, version });
           return deploymentStatus(config);
         },
-        rollback: async ({ version }: { readonly version?: string | undefined }) => {
-          deploymentCalls.push({ kind: "rollback", version: version ?? null });
+        rollback: async ({ target, version }: { readonly target: "admin" | "worker"; readonly version?: string | undefined }) => {
+          deploymentCalls.push({ kind: "rollback", target, version: version ?? null });
           return deploymentStatus(config);
         },
         restartWorker: async () => {}
@@ -1079,46 +1084,84 @@ function backgroundJob(patch: Partial<PersistedBackgroundJob>): PersistedBackgro
 }
 
 function deploymentStatus(config: AppConfig): Record<string, unknown> {
+  const adminPackageName = "@agent-session-broker/admin";
+  const workerPackageName = "@agent-session-broker/worker";
   return {
     serviceRoot: config.serviceRoot ?? "",
-    packageName: "agent-session-broker",
     npmRegistryUrl: null,
-    currentRelease: {
-      linkPath: config.currentReleasePath ?? "",
-      targetPath: path.join(config.serviceRoot ?? "", "releases", "npm-0.2.0", "node_modules", "agent-session-broker"),
-      exists: true,
-      metadata: {
-        revision: null,
-        shortRevision: null,
-        branch: null,
-        packageName: "agent-session-broker",
-        packageVersion: "0.2.0",
-        packageSpec: "agent-session-broker@0.2.0",
-        installedAt: "2026-03-19T00:00:00.000Z",
-        installedBy: "test",
-        installedFromHost: "test-host",
-        stateSchemaVersion: 2
+    targets: {
+      admin: {
+        target: "admin",
+        packageName: adminPackageName,
+        currentRelease: {
+          linkPath: config.currentAdminReleasePath ?? "",
+          targetPath: null,
+          exists: false,
+          metadata: null
+        },
+        previousRelease: {
+          linkPath: config.previousAdminReleasePath ?? "",
+          targetPath: null,
+          exists: false,
+          metadata: null
+        },
+        failedRelease: {
+          linkPath: config.failedAdminReleasePath ?? "",
+          targetPath: null,
+          exists: false,
+          metadata: null
+        },
+        recentReleases: [],
+        recentPackageVersions: [
+          {
+            version: "0.2.0",
+            packageSpec: `${adminPackageName}@0.2.0`
+          }
+        ]
+      },
+      worker: {
+        target: "worker",
+        packageName: workerPackageName,
+        currentRelease: {
+          linkPath: config.currentWorkerReleasePath ?? "",
+          targetPath: path.join(config.serviceRoot ?? "", "releases", "worker", "npm-0.2.0", "node_modules", "@agent-session-broker", "worker"),
+          exists: true,
+          metadata: {
+            revision: null,
+            shortRevision: null,
+            branch: null,
+            target: "worker",
+            packageName: workerPackageName,
+            packageVersion: "0.2.0",
+            packageSpec: `${workerPackageName}@0.2.0`,
+            installedAt: "2026-03-19T00:00:00.000Z",
+            installedBy: "test",
+            installedFromHost: "test-host",
+            requestedVersion: "0.2.0",
+            stateSchemaVersion: 3
+          }
+        },
+        previousRelease: {
+          linkPath: config.previousWorkerReleasePath ?? "",
+          targetPath: null,
+          exists: false,
+          metadata: null
+        },
+        failedRelease: {
+          linkPath: config.failedWorkerReleasePath ?? "",
+          targetPath: null,
+          exists: false,
+          metadata: null
+        },
+        recentReleases: [],
+        recentPackageVersions: [
+          {
+            version: "0.2.0",
+            packageSpec: `${workerPackageName}@0.2.0`
+          }
+        ]
       }
     },
-    previousRelease: {
-      linkPath: config.previousReleasePath ?? "",
-      targetPath: null,
-      exists: false,
-      metadata: null
-    },
-    failedRelease: {
-      linkPath: config.failedReleasePath ?? "",
-      targetPath: null,
-      exists: false,
-      metadata: null
-    },
-    recentReleases: [],
-    recentPackageVersions: [
-      {
-        version: "0.2.0",
-        packageSpec: "agent-session-broker@0.2.0"
-      }
-    ],
     admin: {
       launchdLoaded: true,
       healthOk: true,

--- a/test/admin-control-plane.e2e.test.ts
+++ b/test/admin-control-plane.e2e.test.ts
@@ -556,7 +556,7 @@ describe("admin control plane e2e", () => {
     const { baseUrl, deploymentCalls } = await startAdminFixture();
 
     const deploy = await postJson(`${baseUrl}/admin/api/deploy`, {
-      ref: "main",
+      version: "0.2.0",
       allow_active: false
     });
     expect(deploy).toMatchObject({
@@ -565,11 +565,11 @@ describe("admin control plane e2e", () => {
         kind: "deploy",
         status: "succeeded",
         request: {
-          ref: "main"
+          version: "0.2.0"
         }
       }
     });
-    expect(deploymentCalls).toEqual([{ kind: "deploy", ref: "main" }]);
+    expect(deploymentCalls).toEqual([{ kind: "deploy", version: "0.2.0" }]);
 
     const operations = await readJson(`${baseUrl}/admin/api/operations`);
     expect(operations).toMatchObject({
@@ -580,7 +580,7 @@ describe("admin control plane e2e", () => {
           kind: "deploy",
           status: "succeeded",
           request: {
-            ref: "main"
+            version: "0.2.0"
           }
         }
       ]
@@ -614,7 +614,7 @@ describe("admin control plane e2e", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
-        ref: "main",
+        version: "0.2.0",
         allow_active: false
       })
     });
@@ -634,7 +634,7 @@ describe("admin control plane e2e", () => {
           kind: "deploy",
           status: "failed",
           request: {
-            ref: "main"
+            version: "0.2.0"
           }
         }
       ]
@@ -735,12 +735,12 @@ describe("admin control plane e2e", () => {
       } as never,
       deployment: {
         getStatus: async () => deploymentStatus(config),
-        deploy: async ({ ref }: { readonly ref: string }) => {
-          deploymentCalls.push({ kind: "deploy", ref });
+        deploy: async ({ version }: { readonly version: string }) => {
+          deploymentCalls.push({ kind: "deploy", version });
           return deploymentStatus(config);
         },
-        rollback: async ({ ref }: { readonly ref?: string | undefined }) => {
-          deploymentCalls.push({ kind: "rollback", ref: ref ?? null });
+        rollback: async ({ version }: { readonly version?: string | undefined }) => {
+          deploymentCalls.push({ kind: "rollback", version: version ?? null });
           return deploymentStatus(config);
         },
         restartWorker: async () => {}
@@ -1081,20 +1081,23 @@ function backgroundJob(patch: Partial<PersistedBackgroundJob>): PersistedBackgro
 function deploymentStatus(config: AppConfig): Record<string, unknown> {
   return {
     serviceRoot: config.serviceRoot ?? "",
-    repoRoot: config.serviceRoot ?? "",
-    repoUrl: "https://github.com/HOOLC/slack-codex-broker.git",
+    packageName: "agent-session-broker",
+    npmRegistryUrl: null,
     currentRelease: {
       linkPath: config.currentReleasePath ?? "",
-      targetPath: path.join(config.serviceRoot ?? "", "releases", "current"),
+      targetPath: path.join(config.serviceRoot ?? "", "releases", "npm-0.2.0", "node_modules", "agent-session-broker"),
       exists: true,
       metadata: {
-        revision: "abc123",
-        shortRevision: "abc123",
-        branch: "main",
-        builtAt: "2026-03-19T00:00:00.000Z",
-        builtBy: "test",
-        builtFromHost: "test-host",
-        stateSchemaVersion: 1
+        revision: null,
+        shortRevision: null,
+        branch: null,
+        packageName: "agent-session-broker",
+        packageVersion: "0.2.0",
+        packageSpec: "agent-session-broker@0.2.0",
+        installedAt: "2026-03-19T00:00:00.000Z",
+        installedBy: "test",
+        installedFromHost: "test-host",
+        stateSchemaVersion: 2
       }
     },
     previousRelease: {
@@ -1110,6 +1113,12 @@ function deploymentStatus(config: AppConfig): Record<string, unknown> {
       metadata: null
     },
     recentReleases: [],
+    recentPackageVersions: [
+      {
+        version: "0.2.0",
+        packageSpec: "agent-session-broker@0.2.0"
+      }
+    ],
     admin: {
       launchdLoaded: true,
       healthOk: true,

--- a/test/admin-react-ui.test.ts
+++ b/test/admin-react-ui.test.ts
@@ -104,7 +104,10 @@ describe("admin React UI architecture", () => {
     const css = await fs.readFile(new URL("admin.css", adminUiRoot), "utf8");
     expect(shell).toContain("buildDeployTargetOptions");
     expect(shell).toContain("recentPackageVersions");
+    expect(shell).toContain('id="deploy-package-target-select"');
     expect(shell).toContain('id="deploy-package-version-select"');
+    expect(shell).toContain('body: JSON.stringify({');
+    expect(shell).toContain("target: selectedDeployTarget");
     expect(shell).toContain("Package 版本");
     expect(shell).toContain("releaseRollbackRef");
     expect(shell).toContain("最近已发布");
@@ -112,7 +115,7 @@ describe("admin React UI architecture", () => {
     expect(shell).not.toContain("origin/main");
     expect(shell).not.toContain('placeholder="提交 / 分支 / 标签"');
     expect(shell).not.toContain('const [ref, setRef] = useState("");');
-    expect(css).toContain(".deploy-actions { display: grid; grid-template-columns: auto minmax(0, 1fr) auto;");
+    expect(css).toContain(".deploy-actions { display: grid; grid-template-columns: auto minmax(110px, 0.35fr) auto minmax(0, 1fr) auto;");
     expect(css).toContain(".deploy-target-field { min-width: 0; display: contents;");
     expect(css).not.toContain(".deploy-actions { grid-template-columns: 1fr;");
   });

--- a/test/admin-react-ui.test.ts
+++ b/test/admin-react-ui.test.ts
@@ -41,8 +41,8 @@ describe("admin React UI architecture", () => {
     expect(shell.indexOf("const nextStatus = await loadAdminSessionsStatus()")).toBeLessThan(
       shell.indexOf("void loadAdminOverview()")
     );
-    expect(shell).toContain('requestJson("/admin/api/sessions", { timeoutMs: 15_000 })');
-    expect(shell).toContain('requestJson("/admin/api/overview", { timeoutMs: 8_000 })');
+    expect(shell).toContain('requestJson("/admin/api/sessions", { timeoutMs: 45_000 })');
+    expect(shell).toContain('requestJson("/admin/api/overview", { timeoutMs: 45_000 })');
     expect(shell).toContain('requestJson("/admin/api/logs?limit=40", { timeoutMs: 5_000 })');
     expect(shell).not.toContain('requestJson("/admin/api/status")');
   });
@@ -66,7 +66,6 @@ describe("admin React UI architecture", () => {
     expect(shell).toContain("绑定 GitHub");
     expect(shell).toContain("重新绑定 GitHub");
     expect(shell).toContain("默认 PR 账号");
-    expect(shell).toContain("选择默认 PR GitHub 账号");
     expect(shell).toContain("设为默认 PR");
     expect(shell).toContain("buildFallbackGitHubAccounts");
     expect(shell).toContain("firstUserMessage");
@@ -81,12 +80,95 @@ describe("admin React UI architecture", () => {
     expect(shell).not.toContain("历史 Commit 作者");
   });
 
+  it("keeps the default GitHub PR account control from repeating the current account", async () => {
+    const shell = await readAdminShellSource();
+    const css = await fs.readFile(new URL("admin.css", adminUiRoot), "utf8");
+    expect(shell).toContain("github-default-field");
+    expect(shell).toContain("defaultSelectValue");
+    expect(shell).toContain("selectableDefaultAccounts");
+    expect(shell).toContain("选择候选 GitHub PR 账号");
+    expect(shell).toContain("切换");
+    expect(shell).not.toContain("github-default-current");
+    expect(shell).not.toContain("只有当前账号可用");
+    expect(shell).not.toContain("没有可切换账号");
+    expect(shell).not.toContain("选择默认 PR GitHub 账号");
+    expect(shell).not.toContain('<div className="summary-detail">{currentDefaultLabel}</div>');
+    expect(shell).not.toContain("candidateAccounts");
+    expect(css).toContain(".github-default-control { display: grid; grid-template-columns: auto minmax(0, 1fr) auto;");
+    expect(css).toContain(".github-default-field { min-width: 0; display: contents;");
+    expect(css).not.toContain(".github-default-control { grid-template-columns: 1fr;");
+  });
+
+  it("uses selectable package versions instead of a free-form publish ref input", async () => {
+    const shell = await readAdminShellSource();
+    const css = await fs.readFile(new URL("admin.css", adminUiRoot), "utf8");
+    expect(shell).toContain("buildDeployTargetOptions");
+    expect(shell).toContain("recentPackageVersions");
+    expect(shell).toContain('id="deploy-package-version-select"');
+    expect(shell).toContain("Package 版本");
+    expect(shell).toContain("releaseRollbackRef");
+    expect(shell).toContain("最近已发布");
+    expect(shell).not.toContain("recentMainCommits");
+    expect(shell).not.toContain("origin/main");
+    expect(shell).not.toContain('placeholder="提交 / 分支 / 标签"');
+    expect(shell).not.toContain('const [ref, setRef] = useState("");');
+    expect(css).toContain(".deploy-actions { display: grid; grid-template-columns: auto minmax(0, 1fr) auto;");
+    expect(css).toContain(".deploy-target-field { min-width: 0; display: contents;");
+    expect(css).not.toContain(".deploy-actions { grid-template-columns: 1fr;");
+  });
+
   it("keeps session auth profile action detailed without expanding dense quota labels", async () => {
     const sessionView = await fs.readFile(new URL("session-view.tsx", adminUiRoot), "utf8");
     const authProfileDisplay = await fs.readFile(new URL("auth-profile-display.ts", adminUiRoot), "utf8");
     expect(authProfileDisplay).toContain("export function profileSessionActionLabel");
     expect(sessionView).toContain("profileSessionActionLabel(currentProfile)");
     expect(sessionView).toContain('className={"auth-profile-detail-button " + (blocked ? "danger" : "")}');
+  });
+
+  it("renders the account pool as structured profile cards instead of plain quota rows", async () => {
+    const shell = await readAdminShellSource();
+    const css = await fs.readFile(new URL("admin.css", adminUiRoot), "utf8");
+    expect(shell).toContain("profile-card");
+    expect(shell).toContain("profile-quota-metrics");
+    expect(shell).toContain("profile-quota-metric");
+    expect(shell).toContain("短窗");
+    expect(css).toContain(".profile-card");
+    expect(css).toContain(".profile-quota-metrics");
+    expect(css).toContain(".profile-delete-button");
+    expect(css).not.toContain(".profile-quota-metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1px; background: var(--line);");
+    expect(css).not.toContain(".profile-quota-metric { min-width: 0; display: grid; gap: 1px; padding: 5px 6px; background: #070b10;");
+    expect(css).not.toContain(".profile-quota-metric + .profile-quota-metric");
+    expect(css).not.toContain(".profile-plan-badge { flex: 0 0 auto; border:");
+    expect(css).not.toContain(".profile-short-window { display: flex; gap: 6px; align-items: baseline; min-width: 0; padding: 3px 5px; border:");
+    expect(shell).not.toContain('<div className="quota-grid">');
+    expect(shell).not.toContain("ChatGPT Codex 账号");
+  });
+
+  it("gives operation page modules distinct boundaries without table-like internals", async () => {
+    const shell = await readAdminShellSource();
+    const css = await fs.readFile(new URL("admin.css", adminUiRoot), "utf8");
+    expect(shell).toContain('className="ops-page"');
+    expect(shell).toContain('className="view-grid ops-grid"');
+    expect(shell).toContain('className="panel ops-panel"');
+    expect(css).toContain(".ops-page");
+    expect(css).toContain(".ops-grid");
+    expect(css).toContain(".ops-panel");
+    expect(css).toContain(".ops-panel > .panel-head");
+    expect(css).toContain(".ops-panel .operation-list");
+    expect(css).not.toContain(".ops-panel .operation-list { display: grid; gap: 1px; background: var(--line);");
+    expect(css).not.toContain(".ops-panel .maintenance-grid { display: grid; gap: 1px; background: var(--line);");
+  });
+
+  it("does not render free-text search controls in the admin UI", async () => {
+    const shell = await readAdminShellSource();
+    const sessionView = await fs.readFile(new URL("session-view.tsx", adminUiRoot), "utf8");
+    const combined = shell + "\n" + sessionView;
+    expect(combined).not.toContain('type="search"');
+    expect(combined).not.toContain("sessionSearch");
+    expect(combined).not.toContain("session-search");
+    expect(combined).not.toContain("筛选会话");
+    expect(combined).not.toContain("筛选 Slack / GitHub 账号");
+    expect(combined).not.toContain("setQuery");
   });
 
   it("opens Slack threads through a backend permalink resolver", async () => {

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -103,7 +103,7 @@ describe("admin routes", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
-        ref: "main",
+        version: "0.2.0",
         allow_active: true
       })
     });
@@ -205,7 +205,11 @@ describe("admin routes", () => {
     expect(adminShellSource).not.toContain("编辑作者");
     expect(adminShellSource).not.toContain("历史 Commit 作者");
     expect(adminShellSource).not.toContain("session-react-root");
-    expect(sessionViewSource).toContain("session-search");
+    expect(sessionViewSource).not.toContain("session-search");
+    expect(sessionViewSource).not.toContain("sessionSearch");
+    expect(sessionViewSource).not.toContain('type="search"');
+    expect(adminShellSource).not.toContain('type="search"');
+    expect(adminShellSource).not.toContain("筛选 Slack / GitHub 账号");
     expect(sessionViewSource).toContain("session-detail-panel");
     expect(sessionViewSource).toContain("会话详情");
     expect(adminShellSource).not.toContain("Session Inspector");
@@ -775,14 +779,14 @@ describe("admin routes", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
-        ref: "deadbeef",
+        version: "0.2.0",
         allow_active: true
       })
     });
     expect(response.status).toBe(200);
     expect(calls).toEqual([
       {
-        ref: "deadbeef",
+        version: "0.2.0",
         allowActive: true
       }
     ]);
@@ -812,14 +816,14 @@ describe("admin routes", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
-        ref: "abc123",
+        version: "0.1.0",
         allow_active: false
       })
     });
     expect(response.status).toBe(200);
     expect(calls).toEqual([
       {
-        ref: "abc123",
+        version: "0.1.0",
         allowActive: false
       }
     ]);

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -103,6 +103,7 @@ describe("admin routes", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
+        target: "worker",
         version: "0.2.0",
         allow_active: true
       })
@@ -779,6 +780,7 @@ describe("admin routes", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
+        target: "worker",
         version: "0.2.0",
         allow_active: true
       })
@@ -786,6 +788,7 @@ describe("admin routes", () => {
     expect(response.status).toBe(200);
     expect(calls).toEqual([
       {
+        target: "worker",
         version: "0.2.0",
         allowActive: true
       }
@@ -816,6 +819,7 @@ describe("admin routes", () => {
         "content-type": "application/json"
       },
       body: JSON.stringify({
+        target: "admin",
         version: "0.1.0",
         allow_active: false
       })
@@ -823,6 +827,7 @@ describe("admin routes", () => {
     expect(response.status).toBe(200);
     expect(calls).toEqual([
       {
+        target: "admin",
         version: "0.1.0",
         allowActive: false
       }

--- a/test/admin-session-view.test.ts
+++ b/test/admin-session-view.test.ts
@@ -297,7 +297,7 @@ describe("admin session row display", () => {
         account: {
           ok: true,
           account: {
-            email: "hejiachen@toeverything.info",
+            email: "operator@example.com",
             planType: "prolite"
           }
         },
@@ -335,7 +335,6 @@ describe("admin session row display", () => {
     const labels = meta.map((item) => item.label);
 
     expect(labels).toEqual(["#ops", "7d 64% / 0.64", "Token 5.1K"]);
-    expect(labels.join(" ")).not.toContain("hejiachen@toeverything.info");
     expect(labels.join(" ")).not.toContain("Pro Lite");
     expect(shouldShowSessionState({ rank: 10 })).toBe(false);
   });

--- a/test/macos-bootstrap.test.ts
+++ b/test/macos-bootstrap.test.ts
@@ -70,29 +70,34 @@ describe("macOS bootstrap", () => {
     expect(payload).toMatchObject({
       ok: true,
       serviceRoot,
-      currentReleasePath: path.join(serviceRoot, "current"),
+      currentAdminReleasePath: path.join(serviceRoot, "current-admin"),
+      currentWorkerReleasePath: path.join(serviceRoot, "current-worker"),
       workerStarted: false
     });
 
-    const currentReleasePath = path.join(serviceRoot, "current");
-    const releaseRoot = path.join(serviceRoot, "releases", `npm-${packageVersion}`, "node_modules", "agent-session-broker");
-    await expect(fs.readlink(currentReleasePath)).resolves.toBe(path.relative(serviceRoot, releaseRoot));
+    const currentAdminReleasePath = path.join(serviceRoot, "current-admin");
+    const currentWorkerReleasePath = path.join(serviceRoot, "current-worker");
+    const adminReleaseRoot = path.join(serviceRoot, "releases", "admin", `npm-${packageVersion}`, "node_modules", "@agent-session-broker", "admin");
+    const workerReleaseRoot = path.join(serviceRoot, "releases", "worker", `npm-${packageVersion}`, "node_modules", "@agent-session-broker", "worker");
+    await expect(fs.readlink(currentAdminReleasePath)).resolves.toBe(path.relative(serviceRoot, adminReleaseRoot));
+    await expect(fs.readlink(currentWorkerReleasePath)).resolves.toBe(path.relative(serviceRoot, workerReleaseRoot));
 
     const adminPlist = await fs.readFile(path.join(home, "Library", "LaunchAgents", "test.admin.plist"), "utf8");
     const workerPlist = await fs.readFile(path.join(home, "Library", "LaunchAgents", "test.worker.plist"), "utf8");
     const adminEnv = await fs.readFile(path.join(serviceRoot, "config", "admin.env"), "utf8");
-    const launcherPath = path.join(currentReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
+    const adminLauncherPath = path.join(currentAdminReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
+    const workerLauncherPath = path.join(currentWorkerReleasePath, "scripts", "ops", "macos-launchd-launcher.mjs");
     const adminPlistPath = path.join(home, "Library", "LaunchAgents", "test.admin.plist");
     const workerPlistPath = path.join(home, "Library", "LaunchAgents", "test.worker.plist");
 
     expectLaunchdRuntime(adminPlist, {
-      launcherPath,
-      repoRootPath: currentReleasePath,
+      launcherPath: adminLauncherPath,
+      repoRootPath: currentAdminReleasePath,
       entryPoint: "dist/src/admin-index.js"
     });
     expectLaunchdRuntime(workerPlist, {
-      launcherPath,
-      repoRootPath: currentReleasePath,
+      launcherPath: workerLauncherPath,
+      repoRootPath: currentWorkerReleasePath,
       entryPoint: "dist/src/worker-index.js"
     });
     expect(adminEnv).toContain(`ADMIN_PLIST_PATH="${adminPlistPath}"`);
@@ -123,13 +128,23 @@ function fakeNpmScript(): string {
     "  last=\"\"",
     "  for arg in \"$@\"; do last=\"$arg\"; done",
     "  version=\"${last##*@}\"",
-    "  package_root=\"$prefix/node_modules/agent-session-broker\"",
+    "  package_name=\"${last%@*}\"",
+    "  package_path=\"$(printf '%s' \"$package_name\" | sed 's#/# #g')\"",
+    "  set -- $package_path",
+    "  package_root=\"$prefix/node_modules/$1/$2\"",
     "  mkdir -p \"$package_root/dist/src\" \"$package_root/scripts/ops\"",
-    "  : > \"$package_root/dist/src/admin-index.js\"",
-    "  : > \"$package_root/dist/src/worker-index.js\"",
+    "  if [ \"$package_name\" = \"@agent-session-broker/admin\" ]; then",
+    "    mkdir -p \"$package_root/dist/admin-ui\"",
+    "    : > \"$package_root/dist/src/admin-index.js\"",
+    "    : > \"$package_root/dist/admin-ui/index.html\"",
+    "    : > \"$package_root/scripts/ops/macos-bootstrap.mjs\"",
+    "  fi",
+    "  if [ \"$package_name\" = \"@agent-session-broker/worker\" ]; then",
+    "    : > \"$package_root/dist/src/worker-index.js\"",
+    "  fi",
     "  : > \"$package_root/scripts/ops/macos-launchd-launcher.mjs\"",
     "  : > \"$package_root/scripts/ops/macos-launchd-restart.mjs\"",
-    "  printf '{\"name\":\"agent-session-broker\",\"version\":\"%s\"}\\n' \"$version\" > \"$package_root/package.json\"",
+    "  printf '{\"name\":\"%s\",\"version\":\"%s\"}\\n' \"$package_name\" \"$version\" > \"$package_root/package.json\"",
     "fi"
   ].join("\n");
 }

--- a/test/macos-bootstrap.test.ts
+++ b/test/macos-bootstrap.test.ts
@@ -30,33 +30,12 @@ describe("macOS bootstrap", () => {
     const fakeBin = path.join(tempRoot, "bin");
     const serviceRoot = path.join(tempRoot, "service");
     const commandLog = path.join(tempRoot, "commands.log");
-    const revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const packageVersion = "0.2.0";
 
     await fs.mkdir(path.join(home, ".codex"), { recursive: true });
     await fs.mkdir(fakeBin, { recursive: true });
     await fs.mkdir(serviceRoot, { recursive: true });
-    await writeExecutable(path.join(fakeBin, "git"), [
-      "#!/bin/sh",
-      "set -eu",
-      "echo \"git $*\" >> \"$FAKE_COMMAND_LOG\"",
-      "if [ \"${1:-}\" = \"rev-parse\" ] && [ \"${2:-}\" = \"HEAD\" ]; then",
-      "  echo \"$TEST_REVISION\"",
-      "  exit 0",
-      "fi",
-      "if [ \"${1:-}\" = \"branch\" ] && [ \"${2:-}\" = \"--show-current\" ]; then",
-      "  echo main",
-      "  exit 0",
-      "fi",
-      "if [ \"${1:-}\" = \"-C\" ] && [ \"${3:-}\" = \"worktree\" ] && [ \"${4:-}\" = \"add\" ]; then",
-      "  mkdir -p \"$6/.git\"",
-      "  echo \"$7\" > \"$6/.revision\"",
-      "  exit 0",
-      "fi",
-      "echo \"unexpected git command: $*\" >&2",
-      "exit 1"
-    ].join("\n"));
-    await writeExecutable(path.join(fakeBin, "corepack"), fakeCommandScript("corepack"));
-    await writeExecutable(path.join(fakeBin, "npm"), fakeCommandScript("npm"));
+    await writeExecutable(path.join(fakeBin, "npm"), fakeNpmScript());
     await writeExecutable(path.join(fakeBin, "launchctl"), fakeCommandScript("launchctl"));
     await writeExecutable(path.join(fakeBin, "node"), fakeCommandScript("node"));
 
@@ -71,8 +50,10 @@ describe("macOS bootstrap", () => {
         "test.worker",
         "--node-path",
         path.join(fakeBin, "node"),
-        "--corepack-path",
-        path.join(fakeBin, "corepack")
+        "--npm-path",
+        path.join(fakeBin, "npm"),
+        "--package-version",
+        packageVersion
       ],
       {
         ...process.env,
@@ -80,7 +61,6 @@ describe("macOS bootstrap", () => {
         HOME: home,
         SLACK_APP_TOKEN: "xapp-test",
         SLACK_BOT_TOKEN: "xoxb-test",
-        TEST_REVISION: revision,
         FAKE_COMMAND_LOG: commandLog
       }
     );
@@ -95,7 +75,7 @@ describe("macOS bootstrap", () => {
     });
 
     const currentReleasePath = path.join(serviceRoot, "current");
-    const releaseRoot = path.join(serviceRoot, "releases", revision);
+    const releaseRoot = path.join(serviceRoot, "releases", `npm-${packageVersion}`, "node_modules", "agent-session-broker");
     await expect(fs.readlink(currentReleasePath)).resolves.toBe(path.relative(serviceRoot, releaseRoot));
 
     const adminPlist = await fs.readFile(path.join(home, "Library", "LaunchAgents", "test.admin.plist"), "utf8");
@@ -130,6 +110,27 @@ function fakeCommandScript(command: string): string {
     "#!/bin/sh",
     "set -eu",
     `echo "${command} $*" >> "$FAKE_COMMAND_LOG"`
+  ].join("\n");
+}
+
+function fakeNpmScript(): string {
+  return [
+    "#!/bin/sh",
+    "set -eu",
+    "echo \"npm $*\" >> \"$FAKE_COMMAND_LOG\"",
+    "if [ \"${1:-}\" = \"install\" ] && [ \"${2:-}\" = \"--prefix\" ]; then",
+    "  prefix=\"$3\"",
+    "  last=\"\"",
+    "  for arg in \"$@\"; do last=\"$arg\"; done",
+    "  version=\"${last##*@}\"",
+    "  package_root=\"$prefix/node_modules/agent-session-broker\"",
+    "  mkdir -p \"$package_root/dist/src\" \"$package_root/scripts/ops\"",
+    "  : > \"$package_root/dist/src/admin-index.js\"",
+    "  : > \"$package_root/dist/src/worker-index.js\"",
+    "  : > \"$package_root/scripts/ops/macos-launchd-launcher.mjs\"",
+    "  : > \"$package_root/scripts/ops/macos-launchd-restart.mjs\"",
+    "  printf '{\"name\":\"agent-session-broker\",\"version\":\"%s\"}\\n' \"$version\" > \"$package_root/package.json\"",
+    "fi"
   ].join("\n");
 }
 

--- a/test/npm-package-deployment.test.ts
+++ b/test/npm-package-deployment.test.ts
@@ -5,58 +5,100 @@ import { describe, expect, it } from "vitest";
 describe("npm package deployment contract", () => {
   it("documents the package release target and privacy-safe test shape", async () => {
     const doc = await fs.readFile(new URL("../docs/npm-package-deployment.md", import.meta.url), "utf8");
-    expect(doc).toContain("Ship broker releases as built npm packages");
-    expect(doc).toContain("The package is named `agent-session-broker`, not after Slack or Codex");
+    expect(doc).toContain("Ship broker releases as built npm packages, with separate admin and worker");
+    expect(doc).toContain("`@agent-session-broker/admin` contains the admin HTTP entry point");
+    expect(doc).toContain("`@agent-session-broker/worker` contains the worker entry point");
     expect(doc).toContain("Production must not be a build machine");
-    expect(doc).toContain("Rollback only activates a release that is already installed locally");
+    expect(doc).toContain("Rollback requires a target");
     expect(doc).toContain("Avoid tests like");
     expect(doc).toContain("where `X` is a real private value");
   });
 
-  it("defines an explicit runtime package boundary for public releases", async () => {
+  it("defines explicit split runtime package boundaries for public releases", async () => {
     const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      readonly name?: string;
+      readonly private?: boolean;
       readonly repository?: { readonly url?: string };
       readonly bugs?: { readonly url?: string };
       readonly homepage?: string;
+      readonly scripts?: Record<string, string>;
+    };
+    const adminPackageJson = JSON.parse(await fs.readFile(new URL("../packages/admin/package.json", import.meta.url), "utf8")) as {
+      readonly name?: string;
       readonly publishConfig?: Record<string, string>;
       readonly files?: readonly string[];
-      readonly scripts?: Record<string, string>;
+      readonly bin?: Record<string, string>;
+    };
+    const workerPackageJson = JSON.parse(await fs.readFile(new URL("../packages/worker/package.json", import.meta.url), "utf8")) as {
+      readonly name?: string;
+      readonly publishConfig?: Record<string, string>;
+      readonly files?: readonly string[];
     };
 
     expect(packageJson).toMatchObject({
-      name: "agent-session-broker",
-      bin: {
-        "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"
-      }
+      name: "agent-session-broker-repo",
+      private: true
     });
     expect(packageJson.repository?.url).toBe("git+https://github.com/HOOLC/slack-codex-broker.git");
     expect(packageJson.bugs?.url).toBe("https://github.com/HOOLC/slack-codex-broker/issues");
     expect(packageJson.homepage).toBe("https://github.com/HOOLC/slack-codex-broker#readme");
-    expect(packageJson.publishConfig).toMatchObject({
+    expect(adminPackageJson).toMatchObject({
+      name: "@agent-session-broker/admin",
+      bin: {
+        "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"
+      }
+    });
+    expect(workerPackageJson).toMatchObject({
+      name: "@agent-session-broker/worker"
+    });
+    expect(adminPackageJson.publishConfig).toMatchObject({
       access: "public",
       registry: "https://registry.npmjs.org/"
     });
-    expect(packageJson.files).toEqual(expect.arrayContaining([
+    expect(workerPackageJson.publishConfig).toMatchObject({
+      access: "public",
+      registry: "https://registry.npmjs.org/"
+    });
+    expect(adminPackageJson.files).toEqual(expect.arrayContaining([
       "dist/src/",
       "dist/admin-ui/",
-      "scripts/ops/*.mjs"
+      "scripts/ops/macos-bootstrap.mjs",
+      "scripts/ops/macos-launchd-launcher.mjs",
+      "scripts/ops/macos-launchd-restart.mjs"
     ]));
-    expect(packageJson.files).not.toEqual(expect.arrayContaining([
+    expect(workerPackageJson.files).toEqual(expect.arrayContaining([
+      "dist/src/",
+      "scripts/ops/macos-launchd-launcher.mjs",
+      "scripts/ops/macos-launchd-restart.mjs"
+    ]));
+    expect(workerPackageJson.files).not.toEqual(expect.arrayContaining(["dist/admin-ui/"]));
+    expect(adminPackageJson.files).not.toEqual(expect.arrayContaining([
       "src/",
       "test/",
       "dist/test/",
       ".data/",
       ".data-agent-trace-preview/"
     ]));
+    expect(workerPackageJson.files).not.toEqual(expect.arrayContaining([
+      "src/",
+      "test/",
+      "dist/test/",
+      ".data/",
+      ".data-agent-trace-preview/"
+    ]));
+    expect(packageJson.scripts?.["release:stage"]).toContain("stage-npm-packages");
     expect(packageJson.scripts?.["release:pack"]).toContain("pnpm build");
-    expect(packageJson.scripts?.["release:pack"]).toContain("pnpm pack");
+    expect(packageJson.scripts?.["release:pack"]).toContain("npm pack artifacts/npm-packages/admin");
+    expect(packageJson.scripts?.["release:pack"]).toContain("npm pack artifacts/npm-packages/worker");
   });
 
-  it("makes CI produce the same packed artifact that deployment consumes", async () => {
+  it("makes CI produce the same packed artifacts that deployment consumes", async () => {
     const workflow = await fs.readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
     expect(workflow).toContain("pnpm build");
     expect(workflow).toContain("pnpm test");
-    expect(workflow).toContain("pnpm pack --pack-destination artifacts");
+    expect(workflow).toContain("pnpm release:stage");
+    expect(workflow).toContain("npm pack artifacts/npm-packages/admin --pack-destination artifacts");
+    expect(workflow).toContain("npm pack artifacts/npm-packages/worker --pack-destination artifacts");
     expect(workflow).toContain("actions/upload-artifact");
   });
 
@@ -70,9 +112,13 @@ describe("npm package deployment contract", () => {
     expect(workflow).toContain("pnpm install --frozen-lockfile");
     expect(workflow).toContain("pnpm build");
     expect(workflow).toContain("pnpm test");
-    expect(workflow).toContain("pnpm pack --pack-destination artifacts");
-    expect(workflow).toContain("npm publish --access public --provenance");
+    expect(workflow).toContain("pnpm release:stage");
+    expect(workflow).toContain("npm pack artifacts/npm-packages/admin --pack-destination artifacts");
+    expect(workflow).toContain("npm pack artifacts/npm-packages/worker --pack-destination artifacts");
+    expect(workflow).toContain("npm publish artifacts/npm-packages/admin --access public --provenance");
+    expect(workflow).toContain("npm publish artifacts/npm-packages/worker --access public --provenance");
     expect(workflow).toContain("NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}");
-    expect(workflow).toContain("agent-session-broker-npm-package");
+    expect(workflow).toContain("agent-session-broker-admin-npm-package");
+    expect(workflow).toContain("agent-session-broker-worker-npm-package");
   });
 });

--- a/test/npm-package-deployment.test.ts
+++ b/test/npm-package-deployment.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("npm package deployment contract", () => {
+  it("documents the package release target and privacy-safe test shape", async () => {
+    const doc = await fs.readFile(new URL("../docs/npm-package-deployment.md", import.meta.url), "utf8");
+    expect(doc).toContain("Ship broker releases as built npm packages");
+    expect(doc).toContain("The package is named `agent-session-broker`, not after Slack or Codex");
+    expect(doc).toContain("Production must not be a build machine");
+    expect(doc).toContain("Rollback only activates a release that is already installed locally");
+    expect(doc).toContain("Avoid tests like");
+    expect(doc).toContain("where `X` is a real private value");
+  });
+
+  it("defines an explicit runtime package boundary for public releases", async () => {
+    const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      readonly repository?: { readonly url?: string };
+      readonly bugs?: { readonly url?: string };
+      readonly homepage?: string;
+      readonly publishConfig?: Record<string, string>;
+      readonly files?: readonly string[];
+      readonly scripts?: Record<string, string>;
+    };
+
+    expect(packageJson).toMatchObject({
+      name: "agent-session-broker",
+      bin: {
+        "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"
+      }
+    });
+    expect(packageJson.repository?.url).toBe("git+https://github.com/HOOLC/slack-codex-broker.git");
+    expect(packageJson.bugs?.url).toBe("https://github.com/HOOLC/slack-codex-broker/issues");
+    expect(packageJson.homepage).toBe("https://github.com/HOOLC/slack-codex-broker#readme");
+    expect(packageJson.publishConfig).toMatchObject({
+      access: "public",
+      registry: "https://registry.npmjs.org/"
+    });
+    expect(packageJson.files).toEqual(expect.arrayContaining([
+      "dist/src/",
+      "dist/admin-ui/",
+      "scripts/ops/*.mjs"
+    ]));
+    expect(packageJson.files).not.toEqual(expect.arrayContaining([
+      "src/",
+      "test/",
+      "dist/test/",
+      ".data/",
+      ".data-agent-trace-preview/"
+    ]));
+    expect(packageJson.scripts?.["release:pack"]).toContain("pnpm build");
+    expect(packageJson.scripts?.["release:pack"]).toContain("pnpm pack");
+  });
+
+  it("makes CI produce the same packed artifact that deployment consumes", async () => {
+    const workflow = await fs.readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+    expect(workflow).toContain("pnpm build");
+    expect(workflow).toContain("pnpm test");
+    expect(workflow).toContain("pnpm pack --pack-destination artifacts");
+    expect(workflow).toContain("actions/upload-artifact");
+  });
+
+  it("publishes npm releases only through an explicit release workflow", async () => {
+    const workflow = await fs.readFile(new URL("../.github/workflows/npm-publish.yml", import.meta.url), "utf8");
+    expect(workflow).toContain("workflow_dispatch");
+    expect(workflow).toContain("tags:");
+    expect(workflow).toContain("v*");
+    expect(workflow).toContain("id-token: write");
+    expect(workflow).toContain("registry-url: https://registry.npmjs.org");
+    expect(workflow).toContain("pnpm install --frozen-lockfile");
+    expect(workflow).toContain("pnpm build");
+    expect(workflow).toContain("pnpm test");
+    expect(workflow).toContain("pnpm pack --pack-destination artifacts");
+    expect(workflow).toContain("npm publish --access public --provenance");
+    expect(workflow).toContain("NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}");
+    expect(workflow).toContain("agent-session-broker-npm-package");
+  });
+});

--- a/test/release-deployment-service.test.ts
+++ b/test/release-deployment-service.test.ts
@@ -28,7 +28,7 @@ describe("ReleaseDeploymentService", () => {
     expect(DEFAULT_HEALTH_CHECK_TIMEOUT_MS).toBeGreaterThanOrEqual(90_000);
   });
 
-  it("deploys npm package releases without building source on the live host", async () => {
+  it("deploys split npm package releases without building source on the live host", async () => {
     const fixture = await createDeploymentFixture("worker-package-deploy-");
     const commands: string[] = [];
     let launchdLoaded = false;
@@ -45,37 +45,82 @@ describe("ReleaseDeploymentService", () => {
 
     const service = new ReleaseDeploymentService({
       ...fixture.options,
-      packageName: "agent-session-broker",
+      packages: {
+        admin: "@agent-session-broker/admin",
+        worker: "@agent-session-broker/worker"
+      },
       exec
     });
 
-    const firstStatus = await service.deploy({ version: "0.2.0" });
-    expect(firstStatus.packageName).toBe("agent-session-broker");
-    expect(firstStatus.recentPackageVersions[0]).toMatchObject({
+    const workerStatus = await service.deploy({ target: "worker", version: "0.2.0" });
+    expect(workerStatus.targets.worker.packageName).toBe("@agent-session-broker/worker");
+    expect(workerStatus.targets.worker.recentPackageVersions[0]).toMatchObject({
       version: "0.2.0",
-      packageSpec: "agent-session-broker@0.2.0"
+      packageSpec: "@agent-session-broker/worker@0.2.0"
     });
-    const currentAfterFirstDeploy = path.resolve(path.dirname(fixture.currentReleasePath), await fs.readlink(fixture.currentReleasePath));
-    expect(currentAfterFirstDeploy).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.2.0"));
-    await expect(fs.readlink(fixture.previousReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    const currentWorkerAfterDeploy = path.resolve(
+      path.dirname(fixture.currentWorkerReleasePath),
+      await fs.readlink(fixture.currentWorkerReleasePath)
+    );
+    expect(currentWorkerAfterDeploy).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "worker",
+      "@agent-session-broker/worker",
+      "0.2.0"
+    ));
+    await expect(fs.readlink(fixture.currentAdminReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readlink(fixture.previousWorkerReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
 
-    await service.deploy({ version: "0.1.0" });
-    const currentAfterSecondDeploy = path.resolve(path.dirname(fixture.currentReleasePath), await fs.readlink(fixture.currentReleasePath));
-    const previousAfterSecondDeploy = path.resolve(path.dirname(fixture.previousReleasePath), await fs.readlink(fixture.previousReleasePath));
-    expect(currentAfterSecondDeploy).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.1.0"));
-    expect(previousAfterSecondDeploy).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.2.0"));
+    await service.deploy({ target: "worker", version: "0.1.0" });
+    const currentAfterSecondDeploy = path.resolve(
+      path.dirname(fixture.currentWorkerReleasePath),
+      await fs.readlink(fixture.currentWorkerReleasePath)
+    );
+    const previousAfterSecondDeploy = path.resolve(
+      path.dirname(fixture.previousWorkerReleasePath),
+      await fs.readlink(fixture.previousWorkerReleasePath)
+    );
+    expect(currentAfterSecondDeploy).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "worker",
+      "@agent-session-broker/worker",
+      "0.1.0"
+    ));
+    expect(previousAfterSecondDeploy).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "worker",
+      "@agent-session-broker/worker",
+      "0.2.0"
+    ));
 
-    await service.rollback();
-    const currentAfterRollback = path.resolve(path.dirname(fixture.currentReleasePath), await fs.readlink(fixture.currentReleasePath));
-    const previousAfterRollback = path.resolve(path.dirname(fixture.previousReleasePath), await fs.readlink(fixture.previousReleasePath));
-    expect(currentAfterRollback).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.2.0"));
-    expect(previousAfterRollback).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.1.0"));
+    await service.rollback({ target: "worker" });
+    const currentAfterRollback = path.resolve(
+      path.dirname(fixture.currentWorkerReleasePath),
+      await fs.readlink(fixture.currentWorkerReleasePath)
+    );
+    const previousAfterRollback = path.resolve(
+      path.dirname(fixture.previousWorkerReleasePath),
+      await fs.readlink(fixture.previousWorkerReleasePath)
+    );
+    expect(currentAfterRollback).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "worker",
+      "@agent-session-broker/worker",
+      "0.2.0"
+    ));
+    expect(previousAfterRollback).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "worker",
+      "@agent-session-broker/worker",
+      "0.1.0"
+    ));
 
     expect(commands.some((command) => command.startsWith("git "))).toBe(false);
     expect(commands.some((command) => command.startsWith("corepack "))).toBe(false);
     expect(commands.some((command) => command.includes("pnpm"))).toBe(false);
     expect(commands.some((command) => command.includes(" build"))).toBe(false);
     expect(commands.some((command) => command.startsWith("npm install "))).toBe(true);
+    expect(commands.some((command) => command.includes("@agent-session-broker/worker@0.2.0"))).toBe(true);
   });
 
   it("waits through transient worker health failures during package deploy", async () => {
@@ -109,16 +154,23 @@ describe("ReleaseDeploymentService", () => {
 
     const service = new ReleaseDeploymentService({
       ...fixture.options,
-      packageName: "agent-session-broker",
+      packages: {
+        admin: "@agent-session-broker/admin",
+        worker: "@agent-session-broker/worker"
+      },
       healthCheckTimeoutMs: 50,
       healthCheckIntervalMs: 1,
       exec
     });
 
-    await expect(service.deploy({ version: "0.3.0" })).resolves.toMatchObject({
-      currentRelease: {
-        metadata: {
-          packageVersion: "0.3.0"
+    await expect(service.deploy({ target: "worker", version: "0.3.0" })).resolves.toMatchObject({
+      targets: {
+        worker: {
+          currentRelease: {
+            metadata: {
+              packageVersion: "0.3.0"
+            }
+          }
         }
       },
       worker: {
@@ -127,35 +179,72 @@ describe("ReleaseDeploymentService", () => {
       }
     });
     expect(fetchCalls).toBeGreaterThanOrEqual(3);
-    await expect(fs.readlink(fixture.failedReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readlink(fixture.failedWorkerReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("schedules the admin launchd restart from the installed package current symlink", async () => {
-    const fixture = await createDeploymentFixture("release-package-admin-");
-    const adminPlistPath = path.join(fixture.serviceRoot, "admin.plist");
-    await fs.writeFile(adminPlistPath, "<plist/>", "utf8");
+  it("deploys admin releases without restarting worker", async () => {
+    const fixture = await createDeploymentFixture("release-package-admin-only-");
+    const commands: string[] = [];
+    let launchdLoaded = false;
+    const scheduledAdminRestarts: Array<() => Promise<void>> = [];
 
-    let workerLoaded = false;
+    stubHealthyRuntime();
+    const exec = createPackageExec({
+      commands,
+      versions: ["0.5.0"],
+      setLaunchdLoaded: (loaded) => {
+        launchdLoaded = loaded;
+      },
+      isLaunchdLoaded: () => launchdLoaded
+    });
+
+    const service = new ReleaseDeploymentService({
+      ...fixture.options,
+      packages: {
+        admin: "@agent-session-broker/admin",
+        worker: "@agent-session-broker/worker"
+      },
+      scheduleAdminRestart: (restart) => {
+        scheduledAdminRestarts.push(restart);
+      },
+      exec
+    });
+
+    const status = await service.deploy({ target: "admin", version: "0.5.0" });
+    expect(status.targets.admin.currentRelease.targetPath).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "admin",
+      "@agent-session-broker/admin",
+      "0.5.0"
+    ));
+    expect(status.targets.worker.currentRelease.targetPath).toBeNull();
+    expect(scheduledAdminRestarts).toHaveLength(1);
+    expect(commands.some((command) => command.includes(fixture.workerPlistPath))).toBe(false);
+  });
+
+  it("schedules the admin launchd restart from the installed admin package current symlink", async () => {
+    const fixture = await createDeploymentFixture("release-package-admin-");
     const scheduledAdminRestarts: Array<() => Promise<void>> = [];
     const detachedCommands: string[] = [];
     const commands: string[] = [];
+    let launchdLoaded = false;
 
     stubHealthyRuntime();
     const exec = createPackageExec({
       commands,
       versions: ["0.4.0"],
       setLaunchdLoaded: (loaded) => {
-        workerLoaded = loaded;
+        launchdLoaded = loaded;
       },
-      isLaunchdLoaded: () => workerLoaded
+      isLaunchdLoaded: () => launchdLoaded
     });
 
     const service = new ReleaseDeploymentService({
       ...fixture.options,
-      adminPlistPath,
-      adminLaunchdLabel: "test.admin",
-      adminBaseUrl: "http://127.0.0.1:3000",
-      packageName: "agent-session-broker",
+      packages: {
+        admin: "@agent-session-broker/admin",
+        worker: "@agent-session-broker/worker"
+      },
       scheduleAdminRestart: (restart) => {
         scheduledAdminRestarts.push(restart);
       },
@@ -165,53 +254,88 @@ describe("ReleaseDeploymentService", () => {
       exec
     });
 
-    const status = await service.deploy({ version: "0.4.0" });
-    expect(status.currentRelease.targetPath).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.4.0"));
-    expect(status.worker.launchdLoaded).toBe(true);
+    const status = await service.deploy({ target: "admin", version: "0.4.0" });
+    expect(status.targets.admin.currentRelease.targetPath).toBe(packageRootFor(
+      fixture.releasesRoot,
+      "admin",
+      "@agent-session-broker/admin",
+      "0.4.0"
+    ));
     expect(scheduledAdminRestarts).toHaveLength(1);
-    expect(commands.some((command) => command.includes(`${fixture.currentReleasePath}`))).toBe(false);
+    expect(commands.some((command) => command.includes(`${fixture.currentAdminReleasePath}`))).toBe(false);
 
     await scheduledAdminRestarts[0]!();
-    expect(commands.some((command) => command.includes(adminPlistPath))).toBe(false);
+    expect(commands.some((command) => command.includes(fixture.adminPlistPath))).toBe(false);
     expect(detachedCommands).toHaveLength(1);
     expect(detachedCommands[0]).toContain("macos-launchd-restart.mjs");
-    expect(detachedCommands[0]).toContain("--plist " + adminPlistPath);
+    expect(detachedCommands[0]).toContain("--plist " + fixture.adminPlistPath);
     expect(detachedCommands[0]).toContain("--label test.admin");
     expect(detachedCommands[0]).toContain("--domain gui/");
+  });
+
+  it("keeps legacy single-package deploy options out of the service contract", async () => {
+    const serviceSource = await fs.readFile(
+      new URL("../src/services/deploy/release-deployment-service.ts", import.meta.url),
+      "utf8"
+    );
+    expect(serviceSource).toContain("readonly target: ReleaseTarget");
+    expect(serviceSource).not.toContain("readonly packageName?: string");
+    expect(serviceSource).not.toContain("DEFAULT_RELEASE_PACKAGE_NAME");
   });
 });
 
 async function createDeploymentFixture(prefix: string): Promise<{
   readonly serviceRoot: string;
   readonly releasesRoot: string;
-  readonly currentReleasePath: string;
-  readonly previousReleasePath: string;
-  readonly failedReleasePath: string;
+  readonly currentAdminReleasePath: string;
+  readonly previousAdminReleasePath: string;
+  readonly failedAdminReleasePath: string;
+  readonly currentWorkerReleasePath: string;
+  readonly previousWorkerReleasePath: string;
+  readonly failedWorkerReleasePath: string;
+  readonly adminPlistPath: string;
+  readonly workerPlistPath: string;
   readonly options: ConstructorParameters<typeof ReleaseDeploymentService>[0];
 }> {
   const serviceRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   tempDirs.push(serviceRoot);
 
   const releasesRoot = path.join(serviceRoot, "releases");
-  const currentReleasePath = path.join(serviceRoot, "current");
-  const previousReleasePath = path.join(serviceRoot, "previous");
-  const failedReleasePath = path.join(serviceRoot, "failed");
+  const currentAdminReleasePath = path.join(serviceRoot, "current-admin");
+  const previousAdminReleasePath = path.join(serviceRoot, "previous-admin");
+  const failedAdminReleasePath = path.join(serviceRoot, "failed-admin");
+  const currentWorkerReleasePath = path.join(serviceRoot, "current-worker");
+  const previousWorkerReleasePath = path.join(serviceRoot, "previous-worker");
+  const failedWorkerReleasePath = path.join(serviceRoot, "failed-worker");
+  const adminPlistPath = path.join(serviceRoot, "admin.plist");
   const workerPlistPath = path.join(serviceRoot, "worker.plist");
   await fs.mkdir(releasesRoot, { recursive: true });
+  await fs.writeFile(adminPlistPath, "<plist/>", "utf8");
   await fs.writeFile(workerPlistPath, "<plist/>", "utf8");
 
   return {
     serviceRoot,
     releasesRoot,
-    currentReleasePath,
-    previousReleasePath,
-    failedReleasePath,
+    currentAdminReleasePath,
+    previousAdminReleasePath,
+    failedAdminReleasePath,
+    currentWorkerReleasePath,
+    previousWorkerReleasePath,
+    failedWorkerReleasePath,
+    adminPlistPath,
+    workerPlistPath,
     options: {
       serviceRoot,
       releasesRoot,
-      currentReleasePath,
-      previousReleasePath,
-      failedReleasePath,
+      currentAdminReleasePath,
+      previousAdminReleasePath,
+      failedAdminReleasePath,
+      currentWorkerReleasePath,
+      previousWorkerReleasePath,
+      failedWorkerReleasePath,
+      adminPlistPath,
+      adminLaunchdLabel: "test.admin",
+      adminBaseUrl: "http://127.0.0.1:3000",
       workerPlistPath,
       workerLaunchdLabel: "test.worker",
       workerBaseUrl: "http://127.0.0.1:3001",
@@ -236,9 +360,8 @@ function createPackageExec(options: {
     if (command === "npm" && args[0] === "install") {
       const prefixIndex = args.indexOf("--prefix");
       const prefix = String(args[prefixIndex + 1]);
-      const packageSpec = String(args[args.length - 1]);
-      const version = packageSpec.slice(packageSpec.lastIndexOf("@") + 1);
-      await writeInstalledPackage(prefix, "agent-session-broker", version);
+      const parsed = parsePackageSpec(String(args[args.length - 1]));
+      await writeInstalledPackage(prefix, parsed.packageName, parsed.version);
       return { stdout: "", stderr: "" };
     }
 
@@ -272,8 +395,15 @@ async function writeInstalledPackage(prefix: string, packageName: string, versio
   const packageRoot = path.join(prefix, "node_modules", ...packageName.split("/"));
   await fs.mkdir(path.join(packageRoot, "dist", "src"), { recursive: true });
   await fs.mkdir(path.join(packageRoot, "scripts", "ops"), { recursive: true });
-  await fs.writeFile(path.join(packageRoot, "dist", "src", "admin-index.js"), "", "utf8");
-  await fs.writeFile(path.join(packageRoot, "dist", "src", "worker-index.js"), "", "utf8");
+  if (packageName.endsWith("/admin")) {
+    await fs.mkdir(path.join(packageRoot, "dist", "admin-ui"), { recursive: true });
+    await fs.writeFile(path.join(packageRoot, "dist", "src", "admin-index.js"), "", "utf8");
+    await fs.writeFile(path.join(packageRoot, "dist", "admin-ui", "index.html"), "", "utf8");
+    await fs.writeFile(path.join(packageRoot, "scripts", "ops", "macos-bootstrap.mjs"), "", "utf8");
+  }
+  if (packageName.endsWith("/worker")) {
+    await fs.writeFile(path.join(packageRoot, "dist", "src", "worker-index.js"), "", "utf8");
+  }
   await fs.writeFile(path.join(packageRoot, "scripts", "ops", "macos-launchd-launcher.mjs"), "", "utf8");
   await fs.writeFile(path.join(packageRoot, "scripts", "ops", "macos-launchd-restart.mjs"), "", "utf8");
   await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
@@ -282,8 +412,16 @@ async function writeInstalledPackage(prefix: string, packageName: string, versio
   }), "utf8");
 }
 
-function packageRootFor(releasesRoot: string, packageName: string, version: string): string {
-  return path.join(releasesRoot, `npm-${version}`, "node_modules", ...packageName.split("/"));
+function packageRootFor(releasesRoot: string, target: string, packageName: string, version: string): string {
+  return path.join(releasesRoot, target, `npm-${version}`, "node_modules", ...packageName.split("/"));
+}
+
+function parsePackageSpec(spec: string): { readonly packageName: string; readonly version: string } {
+  const versionSeparator = spec.lastIndexOf("@");
+  return {
+    packageName: spec.slice(0, versionSeparator),
+    version: spec.slice(versionSeparator + 1)
+  };
 }
 
 function stubHealthyRuntime(): void {

--- a/test/release-deployment-service.test.ts
+++ b/test/release-deployment-service.test.ts
@@ -9,9 +9,9 @@ import {
   ReleaseDeploymentService
 } from "../src/services/deploy/release-deployment-service.js";
 
-describe("ReleaseDeploymentService", () => {
-  const tempDirs: string[] = [];
+const tempDirs: string[] = [];
 
+describe("ReleaseDeploymentService", () => {
   afterEach(async () => {
     vi.unstubAllGlobals();
     await Promise.all(
@@ -28,165 +28,58 @@ describe("ReleaseDeploymentService", () => {
     expect(DEFAULT_HEALTH_CHECK_TIMEOUT_MS).toBeGreaterThanOrEqual(90_000);
   });
 
-  it("deploys git-backed releases and rolls back to the previous release", async () => {
-    const serviceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "worker-deploy-"));
-    tempDirs.push(serviceRoot);
-
-    const repoRoot = path.join(serviceRoot, "repo");
-    const releasesRoot = path.join(serviceRoot, "releases");
-    const currentReleasePath = path.join(serviceRoot, "current");
-    const previousReleasePath = path.join(serviceRoot, "previous");
-    const failedReleasePath = path.join(serviceRoot, "failed");
-    const workerPlistPath = path.join(serviceRoot, "worker.plist");
-    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
-    await fs.mkdir(releasesRoot, { recursive: true });
-    await fs.writeFile(workerPlistPath, "<plist/>", "utf8");
-
-    const refs = new Map([
-      ["main", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
-      ["previous", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]
-    ]);
+  it("deploys npm package releases without building source on the live host", async () => {
+    const fixture = await createDeploymentFixture("worker-package-deploy-");
+    const commands: string[] = [];
     let launchdLoaded = false;
 
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
-      text: async () => JSON.stringify({ ok: true })
-    })));
-    vi.stubGlobal(
-      "WebSocket",
-      class FakeWebSocket {
-        readonly #listeners = new Map<string, Array<() => void>>();
-
-        constructor() {
-          queueMicrotask(() => {
-            for (const listener of this.#listeners.get("open") ?? []) {
-              listener();
-            }
-          });
-        }
-
-        addEventListener(type: string, listener: () => void) {
-          const existing = this.#listeners.get(type) ?? [];
-          existing.push(listener);
-          this.#listeners.set(type, existing);
-        }
-
-        close() {}
-      }
-    );
-
-    const exec = vi.fn(async (command: string, args: readonly string[], options?: { readonly cwd?: string | undefined }) => {
-      if (command === "git" && args[0] === "-C" && args[2] === "fetch") {
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "remote") {
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "rev-parse" && args[3] === "HEAD") {
-        const cwd = String(args[1]);
-        const revision = await fs.readFile(path.join(cwd, ".revision"), "utf8");
-        return { stdout: revision, stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        const ref = String(args[3]).replace(/\^\{commit\}$/, "");
-        const revision = refs.get(ref);
-        if (!revision) {
-          throw new Error(`unknown ref ${ref}`);
-        }
-        return { stdout: `${revision}\n`, stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "branch") {
-        return { stdout: "main\n", stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "worktree" && args[3] === "add") {
-        const releaseRoot = String(args[5]);
-        const revision = String(args[6]);
-        await fs.mkdir(path.join(releaseRoot, ".git"), { recursive: true });
-        await fs.writeFile(path.join(releaseRoot, ".revision"), `${revision}\n`, "utf8");
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "corepack") {
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && args[0] === "bootout") {
-        launchdLoaded = false;
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && args[0] === "bootstrap") {
-        launchdLoaded = true;
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && args[0] === "kickstart") {
-        launchdLoaded = true;
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && args[0] === "print") {
-        if (!launchdLoaded) {
-          throw new Error("not loaded");
-        }
-        return { stdout: "loaded\n", stderr: "" };
-      }
-
-      throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+    stubHealthyRuntime();
+    const exec = createPackageExec({
+      commands,
+      versions: ["0.1.0", "0.2.0"],
+      setLaunchdLoaded: (loaded) => {
+        launchdLoaded = loaded;
+      },
+      isLaunchdLoaded: () => launchdLoaded
     });
 
     const service = new ReleaseDeploymentService({
-      serviceRoot,
-      repoRoot,
-      releasesRoot,
-      currentReleasePath,
-      previousReleasePath,
-      failedReleasePath,
-      workerPlistPath,
-      workerLaunchdLabel: "test.worker",
-      workerBaseUrl: "http://127.0.0.1:3001",
-      codexAppServerPort: 4590,
-      releaseRepoUrl: "https://example.com/repo.git",
+      ...fixture.options,
+      packageName: "agent-session-broker",
       exec
     });
 
-    await service.deploy({ ref: "main" });
-    const currentAfterFirstDeploy = path.resolve(path.dirname(currentReleasePath), await fs.readlink(currentReleasePath));
-    expect(currentAfterFirstDeploy).toBe(path.join(releasesRoot, refs.get("main")!));
-    await expect(fs.readlink(previousReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    const firstStatus = await service.deploy({ version: "0.2.0" });
+    expect(firstStatus.packageName).toBe("agent-session-broker");
+    expect(firstStatus.recentPackageVersions[0]).toMatchObject({
+      version: "0.2.0",
+      packageSpec: "agent-session-broker@0.2.0"
+    });
+    const currentAfterFirstDeploy = path.resolve(path.dirname(fixture.currentReleasePath), await fs.readlink(fixture.currentReleasePath));
+    expect(currentAfterFirstDeploy).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.2.0"));
+    await expect(fs.readlink(fixture.previousReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
 
-    await service.deploy({ ref: "previous" });
-    const currentAfterSecondDeploy = path.resolve(path.dirname(currentReleasePath), await fs.readlink(currentReleasePath));
-    const previousAfterSecondDeploy = path.resolve(path.dirname(previousReleasePath), await fs.readlink(previousReleasePath));
-    expect(currentAfterSecondDeploy).toBe(path.join(releasesRoot, refs.get("previous")!));
-    expect(previousAfterSecondDeploy).toBe(path.join(releasesRoot, refs.get("main")!));
+    await service.deploy({ version: "0.1.0" });
+    const currentAfterSecondDeploy = path.resolve(path.dirname(fixture.currentReleasePath), await fs.readlink(fixture.currentReleasePath));
+    const previousAfterSecondDeploy = path.resolve(path.dirname(fixture.previousReleasePath), await fs.readlink(fixture.previousReleasePath));
+    expect(currentAfterSecondDeploy).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.1.0"));
+    expect(previousAfterSecondDeploy).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.2.0"));
 
     await service.rollback();
-    const currentAfterRollback = path.resolve(path.dirname(currentReleasePath), await fs.readlink(currentReleasePath));
-    const previousAfterRollback = path.resolve(path.dirname(previousReleasePath), await fs.readlink(previousReleasePath));
-    expect(currentAfterRollback).toBe(path.join(releasesRoot, refs.get("main")!));
-    expect(previousAfterRollback).toBe(path.join(releasesRoot, refs.get("previous")!));
+    const currentAfterRollback = path.resolve(path.dirname(fixture.currentReleasePath), await fs.readlink(fixture.currentReleasePath));
+    const previousAfterRollback = path.resolve(path.dirname(fixture.previousReleasePath), await fs.readlink(fixture.previousReleasePath));
+    expect(currentAfterRollback).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.2.0"));
+    expect(previousAfterRollback).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.1.0"));
+
+    expect(commands.some((command) => command.startsWith("git "))).toBe(false);
+    expect(commands.some((command) => command.startsWith("corepack "))).toBe(false);
+    expect(commands.some((command) => command.includes("pnpm"))).toBe(false);
+    expect(commands.some((command) => command.includes(" build"))).toBe(false);
+    expect(commands.some((command) => command.startsWith("npm install "))).toBe(true);
   });
 
-  it("waits through transient worker health failures during deploy", async () => {
-    const serviceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "worker-deploy-health-"));
-    tempDirs.push(serviceRoot);
-
-    const repoRoot = path.join(serviceRoot, "repo");
-    const releasesRoot = path.join(serviceRoot, "releases");
-    const currentReleasePath = path.join(serviceRoot, "current");
-    const previousReleasePath = path.join(serviceRoot, "previous");
-    const failedReleasePath = path.join(serviceRoot, "failed");
-    const workerPlistPath = path.join(serviceRoot, "worker.plist");
-    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
-    await fs.mkdir(releasesRoot, { recursive: true });
-    await fs.writeFile(workerPlistPath, "<plist/>", "utf8");
-
+  it("waits through transient worker health failures during package deploy", async () => {
+    const fixture = await createDeploymentFixture("worker-package-health-");
     let launchdLoaded = false;
     let fetchCalls = 0;
 
@@ -198,113 +91,34 @@ describe("ReleaseDeploymentService", () => {
           text: async () => "fetch failed"
         };
       }
-
       return {
         ok: true,
         text: async () => JSON.stringify({ ok: true })
       };
     }));
-    vi.stubGlobal(
-      "WebSocket",
-      class FakeWebSocket {
-        readonly #listeners = new Map<string, Array<() => void>>();
+    stubOpenWebSocket();
 
-        constructor() {
-          queueMicrotask(() => {
-            for (const listener of this.#listeners.get("open") ?? []) {
-              listener();
-            }
-          });
-        }
-
-        addEventListener(type: string, listener: () => void) {
-          const existing = this.#listeners.get(type) ?? [];
-          existing.push(listener);
-          this.#listeners.set(type, existing);
-        }
-
-        close() {}
-      }
-    );
-
-    const exec = vi.fn(async (command: string, args: readonly string[]) => {
-      if (command === "git" && args[0] === "-C" && args[2] === "fetch") {
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "remote") {
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        if (args[3] === "main^{commit}") {
-          return { stdout: "cccccccccccccccccccccccccccccccccccccccc\n", stderr: "" };
-        }
-
-        if (args[3] === "HEAD") {
-          const cwd = String(args[1]);
-          const revision = await fs.readFile(path.join(cwd, ".revision"), "utf8");
-          return { stdout: revision, stderr: "" };
-        }
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "branch") {
-        return { stdout: "main\n", stderr: "" };
-      }
-
-      if (command === "git" && args[0] === "-C" && args[2] === "worktree" && args[3] === "add") {
-        const releaseRoot = String(args[5]);
-        const revision = String(args[6]);
-        await fs.mkdir(path.join(releaseRoot, ".git"), { recursive: true });
-        await fs.writeFile(path.join(releaseRoot, ".revision"), `${revision}\n`, "utf8");
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "corepack") {
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && args[0] === "bootout") {
-        launchdLoaded = false;
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && (args[0] === "bootstrap" || args[0] === "kickstart")) {
-        launchdLoaded = true;
-        return { stdout: "", stderr: "" };
-      }
-
-      if (command === "launchctl" && args[0] === "print") {
-        if (!launchdLoaded) {
-          throw new Error("not loaded");
-        }
-        return { stdout: "loaded\n", stderr: "" };
-      }
-
-      throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+    const exec = createPackageExec({
+      commands: [],
+      versions: ["0.3.0"],
+      setLaunchdLoaded: (loaded) => {
+        launchdLoaded = loaded;
+      },
+      isLaunchdLoaded: () => launchdLoaded
     });
 
     const service = new ReleaseDeploymentService({
-      serviceRoot,
-      repoRoot,
-      releasesRoot,
-      currentReleasePath,
-      previousReleasePath,
-      failedReleasePath,
-      workerPlistPath,
-      workerLaunchdLabel: "test.worker",
-      workerBaseUrl: "http://127.0.0.1:3001",
-      codexAppServerPort: 4590,
-      releaseRepoUrl: "https://example.com/repo.git",
+      ...fixture.options,
+      packageName: "agent-session-broker",
       healthCheckTimeoutMs: 50,
       healthCheckIntervalMs: 1,
       exec
     });
 
-    await expect(service.deploy({ ref: "main" })).resolves.toMatchObject({
+    await expect(service.deploy({ version: "0.3.0" })).resolves.toMatchObject({
       currentRelease: {
         metadata: {
-          shortRevision: "cccccccccccc"
+          packageVersion: "0.3.0"
         }
       },
       worker: {
@@ -313,123 +127,35 @@ describe("ReleaseDeploymentService", () => {
       }
     });
     expect(fetchCalls).toBeGreaterThanOrEqual(3);
-    await expect(fs.readlink(failedReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readlink(fixture.failedReleasePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("activates a release for worker immediately and schedules the admin launchd restart from the same current symlink", async () => {
-    const serviceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "release-deploy-admin-"));
-    tempDirs.push(serviceRoot);
-
-    const repoRoot = path.join(serviceRoot, "repo");
-    const releasesRoot = path.join(serviceRoot, "releases");
-    const currentReleasePath = path.join(serviceRoot, "current");
-    const previousReleasePath = path.join(serviceRoot, "previous");
-    const failedReleasePath = path.join(serviceRoot, "failed");
-    const adminPlistPath = path.join(serviceRoot, "admin.plist");
-    const workerPlistPath = path.join(serviceRoot, "worker.plist");
-    await fs.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+  it("schedules the admin launchd restart from the installed package current symlink", async () => {
+    const fixture = await createDeploymentFixture("release-package-admin-");
+    const adminPlistPath = path.join(fixture.serviceRoot, "admin.plist");
     await fs.writeFile(adminPlistPath, "<plist/>", "utf8");
-    await fs.writeFile(workerPlistPath, "<plist/>", "utf8");
 
     let workerLoaded = false;
     const scheduledAdminRestarts: Array<() => Promise<void>> = [];
     const detachedCommands: string[] = [];
     const commands: string[] = [];
 
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
-      text: async () => JSON.stringify({ ok: true })
-    })));
-    vi.stubGlobal(
-      "WebSocket",
-      class FakeWebSocket {
-        readonly #listeners = new Map<string, Array<() => void>>();
-
-        constructor() {
-          queueMicrotask(() => {
-            for (const listener of this.#listeners.get("open") ?? []) {
-              listener();
-            }
-          });
-        }
-
-        addEventListener(type: string, listener: () => void) {
-          const existing = this.#listeners.get(type) ?? [];
-          existing.push(listener);
-          this.#listeners.set(type, existing);
-        }
-
-        close() {}
-      }
-    );
-
-    const exec = vi.fn(async (command: string, args: readonly string[]) => {
-      commands.push(`${command} ${args.join(" ")}`);
-
-      if (command === "git" && args[0] === "-C" && args[2] === "fetch") {
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "git" && args[0] === "-C" && args[2] === "remote") {
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "git" && args[0] === "-C" && args[2] === "rev-parse" && args[3] === "main^{commit}") {
-        return { stdout: "dddddddddddddddddddddddddddddddddddddddd\n", stderr: "" };
-      }
-      if (command === "git" && args[0] === "-C" && args[2] === "branch") {
-        return { stdout: "main\n", stderr: "" };
-      }
-      if (command === "git" && args[0] === "-C" && args[2] === "worktree" && args[3] === "add") {
-        const releaseRoot = String(args[5]);
-        const revision = String(args[6]);
-        await fs.mkdir(path.join(releaseRoot, ".git"), { recursive: true });
-        await fs.mkdir(path.join(releaseRoot, "scripts", "ops"), { recursive: true });
-        await fs.writeFile(path.join(releaseRoot, ".revision"), `${revision}\n`, "utf8");
-        await fs.writeFile(path.join(releaseRoot, "scripts", "ops", "macos-launchd-restart.mjs"), "", "utf8");
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "corepack") {
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "launchctl" && args[0] === "bootout") {
-        if (args[2] === workerPlistPath) {
-          workerLoaded = false;
-        }
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "launchctl" && args[0] === "bootstrap") {
-        if (args[2] === workerPlistPath) {
-          workerLoaded = true;
-        }
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "launchctl" && args[0] === "kickstart") {
-        return { stdout: "", stderr: "" };
-      }
-      if (command === "launchctl" && args[0] === "print") {
-        const domain = String(args[1]);
-        if (domain.endsWith("/test.worker") && workerLoaded) {
-          return { stdout: "loaded\n", stderr: "" };
-        }
-        throw new Error("not loaded");
-      }
-
-      throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+    stubHealthyRuntime();
+    const exec = createPackageExec({
+      commands,
+      versions: ["0.4.0"],
+      setLaunchdLoaded: (loaded) => {
+        workerLoaded = loaded;
+      },
+      isLaunchdLoaded: () => workerLoaded
     });
 
     const service = new ReleaseDeploymentService({
-      serviceRoot,
-      repoRoot,
-      releasesRoot,
-      currentReleasePath,
-      previousReleasePath,
-      failedReleasePath,
+      ...fixture.options,
       adminPlistPath,
       adminLaunchdLabel: "test.admin",
       adminBaseUrl: "http://127.0.0.1:3000",
-      workerPlistPath,
-      workerLaunchdLabel: "test.worker",
-      workerBaseUrl: "http://127.0.0.1:3001",
-      codexAppServerPort: 4590,
+      packageName: "agent-session-broker",
       scheduleAdminRestart: (restart) => {
         scheduledAdminRestarts.push(restart);
       },
@@ -439,11 +165,11 @@ describe("ReleaseDeploymentService", () => {
       exec
     });
 
-    const status = await service.deploy({ ref: "main" });
-    expect(status.currentRelease.targetPath).toBe(path.join(releasesRoot, "dddddddddddddddddddddddddddddddddddddddd"));
+    const status = await service.deploy({ version: "0.4.0" });
+    expect(status.currentRelease.targetPath).toBe(packageRootFor(fixture.releasesRoot, "agent-session-broker", "0.4.0"));
     expect(status.worker.launchdLoaded).toBe(true);
     expect(scheduledAdminRestarts).toHaveLength(1);
-    expect(commands.some((command) => command.includes(`${currentReleasePath}`))).toBe(false);
+    expect(commands.some((command) => command.includes(`${fixture.currentReleasePath}`))).toBe(false);
 
     await scheduledAdminRestarts[0]!();
     expect(commands.some((command) => command.includes(adminPlistPath))).toBe(false);
@@ -454,3 +180,141 @@ describe("ReleaseDeploymentService", () => {
     expect(detachedCommands[0]).toContain("--domain gui/");
   });
 });
+
+async function createDeploymentFixture(prefix: string): Promise<{
+  readonly serviceRoot: string;
+  readonly releasesRoot: string;
+  readonly currentReleasePath: string;
+  readonly previousReleasePath: string;
+  readonly failedReleasePath: string;
+  readonly options: ConstructorParameters<typeof ReleaseDeploymentService>[0];
+}> {
+  const serviceRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(serviceRoot);
+
+  const releasesRoot = path.join(serviceRoot, "releases");
+  const currentReleasePath = path.join(serviceRoot, "current");
+  const previousReleasePath = path.join(serviceRoot, "previous");
+  const failedReleasePath = path.join(serviceRoot, "failed");
+  const workerPlistPath = path.join(serviceRoot, "worker.plist");
+  await fs.mkdir(releasesRoot, { recursive: true });
+  await fs.writeFile(workerPlistPath, "<plist/>", "utf8");
+
+  return {
+    serviceRoot,
+    releasesRoot,
+    currentReleasePath,
+    previousReleasePath,
+    failedReleasePath,
+    options: {
+      serviceRoot,
+      releasesRoot,
+      currentReleasePath,
+      previousReleasePath,
+      failedReleasePath,
+      workerPlistPath,
+      workerLaunchdLabel: "test.worker",
+      workerBaseUrl: "http://127.0.0.1:3001",
+      codexAppServerPort: 4590
+    }
+  };
+}
+
+function createPackageExec(options: {
+  readonly commands: string[];
+  readonly versions: readonly string[];
+  readonly setLaunchdLoaded: (loaded: boolean) => void;
+  readonly isLaunchdLoaded: () => boolean;
+}) {
+  return vi.fn(async (command: string, args: readonly string[]) => {
+    options.commands.push(`${command} ${args.join(" ")}`);
+
+    if (command === "npm" && args[0] === "view") {
+      return { stdout: JSON.stringify(options.versions), stderr: "" };
+    }
+
+    if (command === "npm" && args[0] === "install") {
+      const prefixIndex = args.indexOf("--prefix");
+      const prefix = String(args[prefixIndex + 1]);
+      const packageSpec = String(args[args.length - 1]);
+      const version = packageSpec.slice(packageSpec.lastIndexOf("@") + 1);
+      await writeInstalledPackage(prefix, "agent-session-broker", version);
+      return { stdout: "", stderr: "" };
+    }
+
+    if (command === "launchctl" && args[0] === "bootout") {
+      options.setLaunchdLoaded(false);
+      return { stdout: "", stderr: "" };
+    }
+
+    if (command === "launchctl" && args[0] === "bootstrap") {
+      options.setLaunchdLoaded(true);
+      return { stdout: "", stderr: "" };
+    }
+
+    if (command === "launchctl" && args[0] === "kickstart") {
+      options.setLaunchdLoaded(true);
+      return { stdout: "", stderr: "" };
+    }
+
+    if (command === "launchctl" && args[0] === "print") {
+      if (!options.isLaunchdLoaded()) {
+        throw new Error("not loaded");
+      }
+      return { stdout: "loaded\n", stderr: "" };
+    }
+
+    throw new Error(`Unexpected command: ${command} ${args.join(" ")}`);
+  });
+}
+
+async function writeInstalledPackage(prefix: string, packageName: string, version: string): Promise<void> {
+  const packageRoot = path.join(prefix, "node_modules", ...packageName.split("/"));
+  await fs.mkdir(path.join(packageRoot, "dist", "src"), { recursive: true });
+  await fs.mkdir(path.join(packageRoot, "scripts", "ops"), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, "dist", "src", "admin-index.js"), "", "utf8");
+  await fs.writeFile(path.join(packageRoot, "dist", "src", "worker-index.js"), "", "utf8");
+  await fs.writeFile(path.join(packageRoot, "scripts", "ops", "macos-launchd-launcher.mjs"), "", "utf8");
+  await fs.writeFile(path.join(packageRoot, "scripts", "ops", "macos-launchd-restart.mjs"), "", "utf8");
+  await fs.writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+    name: packageName,
+    version
+  }), "utf8");
+}
+
+function packageRootFor(releasesRoot: string, packageName: string, version: string): string {
+  return path.join(releasesRoot, `npm-${version}`, "node_modules", ...packageName.split("/"));
+}
+
+function stubHealthyRuntime(): void {
+  vi.stubGlobal("fetch", vi.fn(async () => ({
+    ok: true,
+    text: async () => JSON.stringify({ ok: true })
+  })));
+  stubOpenWebSocket();
+}
+
+function stubOpenWebSocket(): void {
+  vi.stubGlobal(
+    "WebSocket",
+    class FakeWebSocket {
+      readonly #listeners = new Map<string, Array<() => void>>();
+
+      constructor() {
+        queueMicrotask(() => {
+          for (const listener of this.#listeners.get("open") ?? []) {
+            listener();
+          }
+        });
+      }
+
+      addEventListener(type: string, listener: () => void) {
+        const existing = this.#listeners.get(type) ?? [];
+        existing.push(listener);
+        this.#listeners.set(type, existing);
+      }
+
+      close() {}
+    }
+  );
+}


### PR DESCRIPTION
## Summary

- add a documented npm-package deployment target for the broker runtime
- switch admin release deployment from Git refs/worktrees to npm package versions
- add a GitHub Actions publish workflow for `agent-session-broker`
- keep the packed package runtime-only and verify it excludes source/test trees

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm pack --pack-destination <tmp>` with package-name and source/test-tree checks
- workflow YAML parse check
