### PR TITLE
Include bootstrap helper deps in npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ There is no host-side code sync or production build step in the normal path.
 ### First bootstrap on the VM
 
 ```bash
-npm install -g @agent-session-broker/admin@0.1.1
-agent-session-broker-macos-bootstrap --service-root ~/services/slack-codex-broker --package-version 0.1.1 --start-worker
+npm install -g @agent-session-broker/admin@0.1.2
+agent-session-broker-macos-bootstrap --service-root ~/services/slack-codex-broker --package-version 0.1.2 --start-worker
 ```
 
 The bootstrap script installs `@agent-session-broker/admin@<version>` and

--- a/docs/npm-package-deployment.md
+++ b/docs/npm-package-deployment.md
@@ -71,6 +71,7 @@ Package contents are runtime-only:
 - `dist/src/`;
 - `dist/admin-ui/` only for the admin package;
 - launchd helper scripts needed by installed services;
+- direct script dependencies needed by exported package binaries;
 - README and license.
 
 Source files, tests, local state, generated preview data, and private operator

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-session-broker-repo",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Slack Socket Mode broker that routes Slack threads into Codex app-server sessions with isolated workspaces.",
   "license": "MIT",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/admin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Admin service and UI for the agent session broker.",
   "license": "MIT",
   "repository": {
@@ -22,6 +22,7 @@
   "files": [
     "dist/src/",
     "dist/admin-ui/",
+    "scripts/ops/lib.mjs",
     "scripts/ops/macos-bootstrap.mjs",
     "scripts/ops/macos-launchd-launcher.mjs",
     "scripts/ops/macos-launchd-restart.mjs",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/worker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Worker runtime for the agent session broker.",
   "license": "MIT",
   "repository": {

--- a/scripts/build/stage-npm-packages.mjs
+++ b/scripts/build/stage-npm-packages.mjs
@@ -13,6 +13,7 @@ const packageTargets = [
     destination: path.join(stageRoot, "admin"),
     includeAdminUi: true,
     scripts: [
+      "lib.mjs",
       "macos-bootstrap.mjs",
       "macos-launchd-launcher.mjs",
       "macos-launchd-restart.mjs"

--- a/test/npm-package-deployment.test.ts
+++ b/test/npm-package-deployment.test.ts
@@ -62,6 +62,7 @@ describe("npm package deployment contract", () => {
     expect(adminPackageJson.files).toEqual(expect.arrayContaining([
       "dist/src/",
       "dist/admin-ui/",
+      "scripts/ops/lib.mjs",
       "scripts/ops/macos-bootstrap.mjs",
       "scripts/ops/macos-launchd-launcher.mjs",
       "scripts/ops/macos-launchd-restart.mjs"
@@ -90,6 +91,12 @@ describe("npm package deployment contract", () => {
     expect(packageJson.scripts?.["release:pack"]).toContain("pnpm build");
     expect(packageJson.scripts?.["release:pack"]).toContain("npm pack artifacts/npm-packages/admin");
     expect(packageJson.scripts?.["release:pack"]).toContain("npm pack artifacts/npm-packages/worker");
+  });
+
+  it("stages script dependencies needed by published package binaries", async () => {
+    const stageScript = await fs.readFile(new URL("../scripts/build/stage-npm-packages.mjs", import.meta.url), "utf8");
+    expect(stageScript).toContain('"lib.mjs"');
+    expect(stageScript).toContain('"macos-bootstrap.mjs"');
   });
 
   it("makes CI produce the same packed artifacts that deployment consumes", async () => {


### PR DESCRIPTION
## Summary\n- include scripts/ops/lib.mjs in the admin runtime package so the exported macOS bootstrap binary can import its helper module\n- add a package contract regression for staged script dependencies\n- bump admin/worker packages to 0.1.2 for the deployable npm release\n\n## Validation\n- pnpm vitest run test/npm-package-deployment.test.ts test/macos-bootstrap.test.ts\n- pnpm release:pack