### PR TITLE
[codex] admin live ops followups

### DIFF
--- a/docs/admin-live-ops-followups.md
+++ b/docs/admin-live-ops-followups.md
@@ -1,0 +1,124 @@
+# Admin Live Operations Followups
+
+## Goal
+
+Make the post-npm-deployment admin workflow usable and safe in day-to-day
+operations.
+
+This batch covers four concrete gaps:
+
+1. Local admin UI preview against the live admin API must be one command.
+2. Slack missed-message recovery must be a bounded safety net, not a 15-second
+   scan that can wake many sessions and hit Slack 429 repeatedly.
+3. The React admin shell must keep showing the session index even when overview
+   or logs are slow.
+4. The old Git-worktree deployment shape must stop being the active runtime
+   contract after npm package deployment is stable.
+
+## Current State
+
+The npm split deployment is live: admin and worker run from separate installed
+package release directories and `current-admin` / `current-worker` symlinks.
+
+Remaining problems:
+
+- `pnpm dev:admin-ui` only starts Vite. It does not establish a live API tunnel
+  or set `ADMIN_API_PROXY_ORIGIN`, so a local preview can render without data.
+- The Vite development proxy reads request bodies with `data` / `end` handlers.
+  For body-less GET requests it must resume the incoming request stream, or the
+  forwarded API request can hang.
+- Missed Slack thread recovery runs on the active-turn reconciler cadence by
+  default. In production that meant scanning many candidate sessions roughly
+  every 15 seconds. When Slack responds with 429, the worker currently treats it
+  as a normal failure and will try the same broad scan again on the next
+  interval.
+- The admin shell already fetches `/admin/api/sessions` before overview and logs.
+  That ordering is part of the required contract because overview and logs are
+  secondary data.
+- The live machine still has old Git-worktree release symlinks around for
+  rollback context. Those links must not be the active deploy path.
+
+## Target Design
+
+### Local Live Preview
+
+`pnpm dev:admin:remote` starts a local admin UI on `127.0.0.1:5173` and connects
+it to the live admin API through a local SSH tunnel.
+
+Defaults:
+
+- SSH host: `admin@100.67.4.27`
+- SSH proxy command:
+  `/Applications/Tailscale.app/Contents/MacOS/Tailscale nc %h %p`
+- local API tunnel: `127.0.0.1:3000 -> 127.0.0.1:3000`
+- Vite admin UI: `127.0.0.1:5173`
+
+The script may reuse an existing local API tunnel if `/readyz` already answers.
+It must not kill processes by port. In particular, it must never use
+`lsof -ti -iTCP:<port> | xargs kill`.
+
+### Slack Missed-Message Recovery
+
+Missed-message recovery is a fallback for socket gaps and reconnects. It should
+not be the normal way to discover every message.
+
+Rules:
+
+- The default periodic recovery interval is minutes, not seconds.
+- `socket_ready` recovery still runs after socket connection.
+- Periodic recovery respects the configured interval for tests and controlled
+  deployments.
+- A Slack 429 from `conversations.replies` pauses the recovery scan immediately.
+- The worker uses Slack `Retry-After` when available and otherwise exponential
+  bounded backoff.
+- During backoff, periodic recovery skips work instead of repeating the same
+  broad API scan.
+- One rate-limited thread check must not wake additional sessions in the same
+  recovery pass.
+
+### Admin Shell Loading
+
+The React shell treats the session index as the primary page data:
+
+1. fetch `/admin/api/sessions`;
+2. publish it immediately;
+3. open realtime from that cursor;
+4. fetch `/admin/api/overview` and `/admin/api/logs` as secondary data.
+
+If overview or logs are slow or unavailable, the session list must still be
+visible and usable.
+
+### Deployment Shape Cleanup
+
+The npm package shape is the active runtime contract:
+
+- admin deploy/rollback targets `@agent-session-broker/admin`;
+- worker deploy/rollback targets `@agent-session-broker/worker`;
+- launchd points at `current-admin` and `current-worker`;
+- old root-level Git-worktree `current` / `previous` symlinks are legacy rollback
+  artifacts only, not the deploy source of truth.
+
+Cleanup must preserve the ability to roll back the newly deployed npm package
+versions. It may archive or rename obsolete Git-worktree pointers, but must not
+delete runtime state or secrets.
+
+## Acceptance Criteria
+
+- `docs/admin-live-ops-followups.md` records this goal and these acceptance
+  criteria.
+- `package.json` exposes `dev:admin:remote`.
+- `scripts/dev/admin-remote.mjs` starts or reuses the SSH tunnel, waits for live
+  `/readyz`, then starts Vite with `ADMIN_API_PROXY_ORIGIN`.
+- The remote preview script contains no port-killing logic.
+- The Vite dev proxy resumes body-less requests so `/admin/api/sessions` and
+  `/admin/api/overview` complete through the proxy.
+- `SLACK_MISSED_THREAD_RECOVERY_INTERVAL_MS` defaults to at least five minutes.
+- Slack API 429 errors carry retry-after metadata.
+- Missed-message recovery stops the current scan on Slack 429 and skips further
+  periodic scans until the backoff expires.
+- Admin React bootstrap continues to publish `/admin/api/sessions` before
+  overview/logs.
+- The live deployment is verified after the changes.
+- Obsolete Git-worktree symlinks are no longer presented as active runtime
+  symlinks after package deployment verification.
+- `pnpm test` and `pnpm build` pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-session-broker-repo",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Slack Socket Mode broker that routes Slack threads into Codex app-server sessions with isolated workspaces.",
   "license": "MIT",
@@ -22,6 +22,7 @@
     "build:admin-ui": "vp build",
     "dev": "tsx watch src/index.ts",
     "dev:admin": "node scripts/dev/admin.mjs",
+    "dev:admin:remote": "node scripts/dev/admin-remote.mjs",
     "dev:admin:server": "tsx watch src/admin-index.ts",
     "dev:admin-ui": "vp dev --host 127.0.0.1 --port 5173",
     "dev:worker": "tsx watch src/worker-index.ts",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/admin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Admin service and UI for the agent session broker.",
   "license": "MIT",
   "repository": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/worker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Worker runtime for the agent session broker.",
   "license": "MIT",
   "repository": {

--- a/scripts/dev/admin-remote.mjs
+++ b/scripts/dev/admin-remote.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const sshHost = process.env.ADMIN_REMOTE_SSH_HOST || "admin@100.67.4.27";
+const sshProxyCommand =
+  process.env.ADMIN_REMOTE_SSH_PROXY_COMMAND ||
+  "/Applications/Tailscale.app/Contents/MacOS/Tailscale nc %h %p";
+const localApiPort = process.env.ADMIN_REMOTE_LOCAL_API_PORT || "3000";
+const remoteApiPort = process.env.ADMIN_REMOTE_API_PORT || "3000";
+const adminUiPort = process.env.ADMIN_UI_DEV_PORT || "5173";
+const apiOrigin = process.env.ADMIN_API_PROXY_ORIGIN || `http://127.0.0.1:${localApiPort}`;
+const readyUrl = `${apiOrigin}/readyz`;
+const children = [];
+let stopping = false;
+
+main().catch((error) => {
+  console.error(`[admin-remote] ${error instanceof Error ? error.message : String(error)}`);
+  stopAll("SIGTERM");
+  process.exitCode = 1;
+});
+
+async function main() {
+  if (await isReady(readyUrl)) {
+    console.log(`[admin-remote] reusing local API tunnel at ${apiOrigin}`);
+  } else {
+    spawnManaged("ssh", [
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ExitOnForwardFailure=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-o",
+      "ServerAliveInterval=15",
+      "-o",
+      `ProxyCommand=${sshProxyCommand}`,
+      "-N",
+      "-L",
+      `127.0.0.1:${localApiPort}:127.0.0.1:${remoteApiPort}`,
+      sshHost
+    ]);
+    await waitForReady(readyUrl, 15_000);
+  }
+
+  console.log(`[admin-remote] admin UI: http://127.0.0.1:${adminUiPort}/admin/`);
+  console.log(`[admin-remote] proxying /admin/api to ${apiOrigin}`);
+  spawnManaged("pnpm", ["exec", "vp", "dev", "--host", "127.0.0.1", "--port", adminUiPort, "--strictPort"], {
+    env: {
+      ...process.env,
+      ADMIN_API_PROXY_ORIGIN: apiOrigin,
+      ADMIN_UI_DEV_PORT: adminUiPort
+    }
+  });
+}
+
+function spawnManaged(command, args, options = {}) {
+  const child = spawn(command, args, {
+    stdio: "inherit",
+    ...options
+  });
+  children.push(child);
+  child.on("exit", (code, signal) => {
+    if (stopping) {
+      return;
+    }
+    stopAll("SIGTERM");
+    process.exitCode = code ?? (signal ? 1 : 0);
+  });
+  child.on("error", (error) => {
+    if (stopping) {
+      return;
+    }
+    console.error(`[admin-remote] failed to start ${command}: ${error.message}`);
+    stopAll("SIGTERM");
+    process.exitCode = 1;
+  });
+  return child;
+}
+
+async function waitForReady(url, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await isReady(url)) {
+      return;
+    }
+    await delay(300);
+  }
+  throw new Error(`live admin API did not become ready at ${url}`);
+}
+
+async function isReady(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1_000);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stopAll(signal) {
+  if (stopping) {
+    return;
+  }
+  stopping = true;
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  }
+}
+
+process.on("SIGINT", () => {
+  stopAll("SIGINT");
+});
+process.on("SIGTERM", () => {
+  stopAll("SIGTERM");
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -185,7 +185,7 @@ export function loadConfig(env = process.env): AppConfig {
     slackMissedThreadRecoveryIntervalMs: getNumber(
       env,
       "SLACK_MISSED_THREAD_RECOVERY_INTERVAL_MS",
-      15_000
+      5 * 60_000
     ),
     stateDir,
     jobsRoot,

--- a/src/services/slack/slack-api.ts
+++ b/src/services/slack/slack-api.ts
@@ -40,6 +40,31 @@ export interface SlackConversationInfo {
   readonly channelType?: string | undefined;
 }
 
+export class SlackApiError extends Error {
+  readonly path: string;
+  readonly status: number;
+  readonly statusText: string;
+  readonly retryAfterMs?: number | undefined;
+
+  constructor(options: {
+    readonly path: string;
+    readonly status: number;
+    readonly statusText: string;
+    readonly retryAfterMs?: number | undefined;
+  }) {
+    super(`Slack API request failed (${options.status} ${options.statusText}) for ${options.path}`);
+    this.name = "SlackApiError";
+    this.path = options.path;
+    this.status = options.status;
+    this.statusText = options.statusText;
+    this.retryAfterMs = options.retryAfterMs;
+  }
+}
+
+export function isSlackRateLimitError(error: unknown): error is SlackApiError {
+  return error instanceof SlackApiError && error.status === 429;
+}
+
 export class SlackApi {
   readonly #baseUrl: string;
   readonly #appToken: string;
@@ -540,7 +565,12 @@ export class SlackApi {
     });
 
     if (!response.ok) {
-      throw new Error(`Slack API request failed (${response.status} ${response.statusText}) for ${path}`);
+      throw new SlackApiError({
+        path,
+        status: response.status,
+        statusText: response.statusText,
+        retryAfterMs: parseRetryAfterMs(response.headers.get("retry-after"))
+      });
     }
 
     const payload = await response.json() as SlackApiResponse<T> & T;
@@ -551,6 +581,17 @@ export class SlackApi {
 
     return payload;
   }
+}
+
+function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return undefined;
+  }
+  return Math.ceil(seconds * 1_000);
 }
 
 export function normalizeSlackFileAttachments(files: unknown): SlackImageAttachment[] {

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -23,6 +23,7 @@ import {
 import { AgentTraceRecorder } from "../agent-runtime/agent-trace-recorder.js";
 import {
   SlackApi,
+  isSlackRateLimitError,
   type SlackUploadedFile
 } from "./slack-api.js";
 import { SlackAssistantStatusController } from "./slack-assistant-status.js";
@@ -80,6 +81,8 @@ interface PendingDispatchRequest {
 
 const AUTO_RESUME_AFTER_FAILURE_MS = 5_000;
 const NONRECOVERABLE_DISPATCH_RETRY_COOLDOWN_MS = 5 * 60 * 1_000;
+const MISSED_THREAD_RECOVERY_RATE_LIMIT_MIN_BACKOFF_MS = 60_000;
+const MISSED_THREAD_RECOVERY_RATE_LIMIT_MAX_BACKOFF_MS = 10 * 60_000;
 
 export class SlackConversationService {
   readonly #config: AppConfig;
@@ -105,6 +108,8 @@ export class SlackConversationService {
   #activeTurnReconcileTimer: NodeJS.Timeout | undefined;
   #catchUpPromise: Promise<void> | undefined;
   #lastMissedThreadRecoveryAtMs = 0;
+  #missedThreadRecoveryRateLimitBackoffMs = 0;
+  #missedThreadRecoveryRateLimitUntilMs = 0;
 
   constructor(options: {
     readonly config: AppConfig;
@@ -762,8 +767,16 @@ export class SlackConversationService {
   }
 
   async #runMissedThreadRecovery(reason: "socket_ready" | "periodic"): Promise<void> {
-    this.#lastMissedThreadRecoveryAtMs = Date.now();
     const now = Date.now();
+    this.#lastMissedThreadRecoveryAtMs = now;
+    if (now < this.#missedThreadRecoveryRateLimitUntilMs) {
+      logger.info("Skipping Slack missed-message recovery during rate-limit backoff", {
+        reason,
+        retryInMs: this.#missedThreadRecoveryRateLimitUntilMs - now
+      });
+      return;
+    }
+
     const sessions = this.#sessions
       .listSessions()
       .filter((session) => shouldAutoRecoverSession(session, now))
@@ -780,12 +793,35 @@ export class SlackConversationService {
 
     let recoveredBatchCount = 0;
     let recoveredMessageCount = 0;
+    let skippedByRateLimit = false;
 
     for (let session of sessions) {
-      const messages = await this.#slackApi.listThreadMessages({
-        channelId: session.channelId,
-        rootThreadTs: session.rootThreadTs
-      });
+      let messages: SlackThreadMessage[];
+      try {
+        messages = await this.#slackApi.listThreadMessages({
+          channelId: session.channelId,
+          rootThreadTs: session.rootThreadTs
+        });
+      } catch (error) {
+        if (isSlackRateLimitError(error)) {
+          const retryInMs = this.#deferMissedThreadRecoveryAfterRateLimit(error.retryAfterMs);
+          skippedByRateLimit = true;
+          logger.warn("Paused Slack missed-message recovery after Slack rate limit", {
+            reason,
+            sessionKey: session.key,
+            retryInMs,
+            retryAfterMs: error.retryAfterMs ?? null
+          });
+          break;
+        }
+
+        logger.warn("Failed to check Slack thread for missed messages", {
+          reason,
+          sessionKey: session.key,
+          error: error instanceof Error ? error.message : String(error)
+        });
+        continue;
+      }
       const latestPersistedMessageTs =
         this.#sessions.getLatestSlackInboundMessageTs(session.channelId, session.rootThreadTs) ??
         session.lastObservedMessageTs;
@@ -819,10 +855,16 @@ export class SlackConversationService {
       }
     }
 
+    if (!skippedByRateLimit) {
+      this.#missedThreadRecoveryRateLimitBackoffMs = 0;
+      this.#missedThreadRecoveryRateLimitUntilMs = 0;
+    }
+
     logger.info("Finished Slack missed-message recovery", {
       reason,
       recoveredBatchCount,
-      recoveredMessageCount
+      recoveredMessageCount,
+      skippedByRateLimit
     });
   }
 
@@ -1602,6 +1644,23 @@ export class SlackConversationService {
       this.#config.slackActiveTurnReconcileIntervalMs
     );
     return Date.now() - this.#lastMissedThreadRecoveryAtMs >= intervalMs;
+  }
+
+  #deferMissedThreadRecoveryAfterRateLimit(retryAfterMs: number | undefined): number {
+    const nextExponentialBackoffMs = this.#missedThreadRecoveryRateLimitBackoffMs > 0
+      ? Math.min(
+        this.#missedThreadRecoveryRateLimitBackoffMs * 2,
+        MISSED_THREAD_RECOVERY_RATE_LIMIT_MAX_BACKOFF_MS
+      )
+      : MISSED_THREAD_RECOVERY_RATE_LIMIT_MIN_BACKOFF_MS;
+    const requestedBackoffMs = retryAfterMs ?? 0;
+    const nextBackoffMs = Math.min(
+      Math.max(nextExponentialBackoffMs, requestedBackoffMs, MISSED_THREAD_RECOVERY_RATE_LIMIT_MIN_BACKOFF_MS),
+      MISSED_THREAD_RECOVERY_RATE_LIMIT_MAX_BACKOFF_MS
+    );
+    this.#missedThreadRecoveryRateLimitBackoffMs = nextBackoffMs;
+    this.#missedThreadRecoveryRateLimitUntilMs = Date.now() + nextBackoffMs;
+    return nextBackoffMs;
   }
 
   #setAssistantThinking(session: SlackSessionRecord): void {

--- a/test/admin-live-ops-followups.test.ts
+++ b/test/admin-live-ops-followups.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("admin live operations followups", () => {
+  it("documents the live-preview, recovery, loading, and cleanup acceptance criteria", async () => {
+    const doc = await fs.readFile(new URL("../docs/admin-live-ops-followups.md", import.meta.url), "utf8");
+
+    expect(doc).toContain("Local admin UI preview against the live admin API must be one command.");
+    expect(doc).toContain("Slack missed-message recovery must be a bounded safety net");
+    expect(doc).toContain("fetch `/admin/api/sessions`");
+    expect(doc).toContain("old Git-worktree deployment shape");
+    expect(doc).toContain("The remote preview script contains no port-killing logic.");
+  });
+
+  it("provides a one-command local admin preview wired to the live API tunnel", async () => {
+    const packageJson = JSON.parse(await fs.readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    const script = await fs.readFile(new URL("../scripts/dev/admin-remote.mjs", import.meta.url), "utf8");
+    const viteConfig = await fs.readFile(new URL("../vite.config.ts", import.meta.url), "utf8");
+
+    expect(packageJson.scripts?.["dev:admin:remote"]).toBe("node scripts/dev/admin-remote.mjs");
+    expect(script).toContain("ADMIN_API_PROXY_ORIGIN");
+    expect(script).toContain("ExitOnForwardFailure=yes");
+    expect(script).toContain("waitForReady");
+    expect(script).toContain("/readyz");
+    expect(script).not.toContain("lsof");
+    expect(script).not.toContain("kill -");
+    expect(script).not.toContain("xargs");
+    expect(viteConfig).toContain("request.resume()");
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -25,6 +25,7 @@ describe("loadConfig", () => {
     expect(config.slackInitialThreadHistoryCount).toBe(8);
     expect(config.slackHistoryApiMaxLimit).toBe(50);
     expect(config.slackActiveTurnReconcileIntervalMs).toBe(15_000);
+    expect(config.slackMissedThreadRecoveryIntervalMs).toBe(5 * 60_000);
     expect(config.logLevel).toBe("info");
     expect(config.logRawSlackEvents).toBe(true);
     expect(config.logRawCodexRpc).toBe(true);

--- a/test/slack-conversation-service.test.ts
+++ b/test/slack-conversation-service.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppConfig } from "../src/config.js";
 import { AuthProfileUnavailableError } from "../src/services/agent-runtime/session-auth-profile-runtime.js";
 import { SlackConversationService } from "../src/services/slack/slack-conversation-service.js";
+import { SlackApiError } from "../src/services/slack/slack-api.js";
 import { SessionManager } from "../src/services/session-manager.js";
 import { StateStore } from "../src/store/state-store.js";
 import type { PersistedAgentTraceEvent, PersistedInboundMessage, SlackSessionRecord } from "../src/types.js";
@@ -327,6 +328,67 @@ describe("SlackConversationService", () => {
       kind: "final"
     }));
     expect(setActiveTurnId).not.toHaveBeenCalled();
+
+    await service.stop();
+  });
+
+  it("stops missed-message recovery on Slack rate limit and backs off the next periodic scan", async () => {
+    const agentRuntime = new EventEmitter();
+    const sessions = [
+      {
+        ...TEST_SESSION,
+        activeTurnId: undefined,
+        lastObservedMessageTs: "111.223",
+        updatedAt: new Date().toISOString()
+      },
+      {
+        ...TEST_SESSION,
+        key: "C123:222.333",
+        rootThreadTs: "222.333",
+        activeTurnId: undefined,
+        lastObservedMessageTs: "222.334",
+        updatedAt: new Date().toISOString()
+      }
+    ];
+    const listThreadMessages = vi.fn(async () => {
+      throw new SlackApiError({
+        path: "conversations.replies",
+        status: 429,
+        statusText: "Too Many Requests",
+        retryAfterMs: 120_000
+      });
+    });
+
+    const service = new SlackConversationService({
+      config: {
+        ...TEST_CONFIG,
+        slackMissedThreadRecoveryIntervalMs: 100,
+        slackActiveTurnReconcileIntervalMs: 100
+      } as AppConfig,
+      sessions: {
+        listSessions: vi.fn(() => sessions),
+        getLatestSlackInboundMessageTs: vi.fn()
+      } as never,
+      agentRuntime: agentRuntime as never,
+      slackApi: {
+        listThreadMessages,
+        setAssistantThreadStatus: vi.fn(),
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      selfMessageFilter: {
+        shouldIgnoreThreadMessage: vi.fn(() => false)
+      } as never
+    });
+
+    await service.recoverMissedThreadMessages("periodic");
+    await service.recoverMissedThreadMessages("periodic");
+
+    expect(listThreadMessages).toHaveBeenCalledTimes(1);
+    expect(listThreadMessages).toHaveBeenCalledWith(expect.objectContaining({
+      channelId: "C123",
+      rootThreadTs: "111.222"
+    }));
 
     await service.stop();
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
                 child.stdin.end();
               }
             });
+            request.resume();
           });
         }
       }


### PR DESCRIPTION
## Summary
- document the live admin followup scope and acceptance criteria
- add a one-command remote admin preview script and fix the Vite dev API proxy stream drain
- slow default missed-message recovery cadence and add Slack 429 retry-after backoff
- bump admin and worker package versions to 0.1.3

## Validation
- pnpm test
- pnpm build
- ADMIN_UI_DEV_PORT=5183 node scripts/dev/admin-remote.mjs, then curl /admin/api/sessions through the preview proxy