### PR TITLE
Add admin session delete API

### DIFF
--- a/docs/session-delete-api-plan.md
+++ b/docs/session-delete-api-plan.md
@@ -1,0 +1,40 @@
+# Session delete API plan
+
+## Goal
+Add a broker admin API that can stop and delete one Slack/Codex session by session key.
+
+## Current state
+- Admin APIs can reset a session and cancel a single background job.
+- Worker APIs can reset/resume a session and cancel an individual job from admin.
+- `SessionManager.deleteSessionByKey` already removes persisted session state and the session workspace.
+- Disk-pressure cleanup already removes session/job log artifacts, but only for inactive cleanup.
+
+## Proposed changes
+1. Add an admin route: `DELETE /admin/api/sessions/:sessionKey`.
+2. Add an internal worker route: `DELETE /slack/sessions/:sessionKey`.
+3. Add worker-side session deletion that:
+   - clears queued runtime work,
+   - interrupts any active turn,
+   - marks pending/inflight inbound messages done,
+   - clears assistant status,
+   - deletes session state/workspace.
+4. Add admin orchestration that:
+   - finds the session and related background jobs,
+   - best-effort cancels any registered/running jobs through the worker job cancel API and records per-job failures,
+   - asks the worker to stop/delete the session,
+   - removes session/job log and job working-directory artifacts after checking each path stays under managed roots,
+   - records an admin operation/audit event.
+
+## If we do not change it
+Operators must keep using reset/cancel/cleanup internals manually, which leaves no single safe API to remove a bad or obsolete session.
+
+## After the change
+An authorized admin caller can delete a specific session in one request without waiting for disk cleanup and without leaving active turns or running broker-managed jobs behind.
+
+## Acceptance criteria
+- API returns `ok: true` with the deleted session key, cancelled job count, and worker delete result.
+- Missing session returns a failed admin operation/error with HTTP 404.
+- Active turns are interrupted before state deletion.
+- Registered/running jobs for the session are best-effort cancelled before deletion; cancel failures are included in the response.
+- Session state, workspace, session logs, job logs, and job directories are removed.
+- Tests cover admin route forwarding and end-to-end admin-to-worker deletion behavior.

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -212,6 +212,22 @@ export async function handleAdminRequest(
     return true;
   }
 
+  if (method === "DELETE" && url.pathname.startsWith("/admin/api/sessions/")) {
+    const sessionKey = decodeURIComponent(url.pathname.slice("/admin/api/sessions/".length));
+    if (!sessionKey || sessionKey.includes("/")) {
+      return false;
+    }
+
+    await runAdminOperation(response, () =>
+      options.adminService.deleteSession({
+        sessionKey
+      }), {
+        errorStatus: (error) => isSessionNotFoundError(error) ? 404 : 500
+      }
+    );
+    return true;
+  }
+
   const sessionJobCancel = matchSessionJobCancelPath(url.pathname);
   if (method === "POST" && sessionJobCancel) {
     await runAdminOperation(response, () =>
@@ -625,16 +641,24 @@ function readReleaseTarget(value: unknown): "admin" | "worker" | undefined {
 
 async function runAdminOperation(
   response: http.ServerResponse,
-  operation: () => Promise<Record<string, unknown>>
+  operation: () => Promise<Record<string, unknown>>,
+  options?: {
+    readonly errorStatus?: ((error: unknown) => number) | undefined;
+  }
 ): Promise<void> {
   try {
     respondJson(response, 200, await operation());
   } catch (error) {
-    respondJson(response, 500, {
+    respondJson(response, options?.errorStatus?.(error) ?? 500, {
       ok: false,
       error: error instanceof Error ? error.message : String(error)
     });
   }
+}
+
+function isSessionNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.startsWith("Session not found:");
 }
 
 function streamAdminEvents(

--- a/src/http/slack-routes.ts
+++ b/src/http/slack-routes.ts
@@ -46,6 +46,12 @@ export async function handleSlackRequest(
     return true;
   }
 
+  const matchedDeleteSession = matchDeleteSessionPath(url.pathname);
+  if (method === "DELETE" && matchedDeleteSession) {
+    await handleSlackDeleteSessionRequest(response, options, matchedDeleteSession.sessionKey);
+    return true;
+  }
+
   if (method === "POST" && url.pathname === "/slack/post-message") {
     await handleSlackPostMessageRequest(request, response, options);
     return true;
@@ -124,6 +130,29 @@ async function handleSlackResetSessionRequest(
     respondJson(response, 500, {
       ok: false,
       error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+async function handleSlackDeleteSessionRequest(
+  response: http.ServerResponse,
+  options: {
+    readonly bridge: SlackAgentBridge;
+  },
+  sessionKey: string
+): Promise<void> {
+  try {
+    const deleted = await options.bridge.deleteSession(sessionKey);
+    respondJson(response, 200, {
+      ok: true,
+      sessionKey,
+      delete: deleted
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    respondJson(response, message.includes("Unknown session") ? 404 : 500, {
+      ok: false,
+      error: message
     });
   }
 }
@@ -674,6 +703,22 @@ function matchResetSessionPath(pathname: string): { readonly sessionKey: string 
 
   const encodedKey = pathname.slice(prefix.length, -suffix.length);
   if (!encodedKey) {
+    return null;
+  }
+
+  return {
+    sessionKey: decodeURIComponent(encodedKey)
+  };
+}
+
+function matchDeleteSessionPath(pathname: string): { readonly sessionKey: string } | null {
+  const prefix = "/slack/sessions/";
+  if (!pathname.startsWith(prefix)) {
+    return null;
+  }
+
+  const encodedKey = pathname.slice(prefix.length);
+  if (!encodedKey || encodedKey.includes("/")) {
     return null;
   }
 

--- a/src/services/admin-service.ts
+++ b/src/services/admin-service.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import type { AppConfig } from "../config.js";
-import { getBrokerLogDirectory, logger } from "../logger.js";
+import { getBrokerLogDirectory, getJobLogDirectory, getSessionLogDirectory, logger } from "../logger.js";
 import type {
   AdminOperationKind,
   JsonLike,
@@ -680,6 +680,73 @@ export class AdminService {
           workerCancel: {
             ok: workerCancel.ok !== false
           }
+        };
+      }
+    );
+  }
+
+  async deleteSession(options: {
+    readonly sessionKey: string;
+  }): Promise<Record<string, unknown>> {
+    return await this.#runTrackedOperation(
+      "session_delete",
+      {
+        sessionKey: options.sessionKey
+      },
+      async () => {
+        await this.#refreshSessions();
+        const session = this.options.sessions.getSessionByKey(options.sessionKey);
+        if (!session) {
+          throw new Error(`Session not found: ${options.sessionKey}`);
+        }
+
+        const jobs = this.options.sessions.listBackgroundJobs({
+          channelId: session.channelId,
+          rootThreadTs: session.rootThreadTs
+        });
+        const cancellableJobs = jobs.filter(isAdminCancellableJob);
+        const cancelledJobs = [];
+        for (const job of cancellableJobs) {
+          try {
+            const workerCancel = await this.#cancelWorkerBackgroundJob(session.key, job.id);
+            cancelledJobs.push({
+              id: job.id,
+              kind: job.kind,
+              ok: workerCancel.ok !== false,
+              workerCancel: {
+                ok: workerCancel.ok !== false
+              }
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            logger.warn("Failed to cancel background job before session delete; continuing delete", {
+              sessionKey: session.key,
+              jobId: job.id,
+              error: message
+            });
+            cancelledJobs.push({
+              id: job.id,
+              kind: job.kind,
+              ok: false,
+              error: message
+            });
+          }
+        }
+
+        const workerDelete = await this.#deleteWorkerSession(session.key);
+        const removedArtifacts = await this.#removeDeletedSessionArtifacts(session.key, jobs);
+        await this.#refreshSessions();
+
+        return {
+          ok: true,
+          sessionKey: session.key,
+          deleted: readNestedBoolean(workerDelete, ["delete", "deleted"]),
+          backgroundJobCount: jobs.length,
+          cancelledJobCount: cancelledJobs.filter((job) => job.ok).length,
+          failedJobCancelCount: cancelledJobs.filter((job) => !job.ok).length,
+          cancelledJobs,
+          removedArtifacts,
+          workerDelete
         };
       }
     );
@@ -1832,6 +1899,21 @@ export class AdminService {
     return payload;
   }
 
+  async #deleteWorkerSession(sessionKey: string): Promise<Record<string, unknown>> {
+    const url = new URL(
+      `/slack/sessions/${encodeURIComponent(sessionKey)}`,
+      this.options.config.workerBaseUrl
+    );
+    const response = await fetch(url, {
+      method: "DELETE"
+    });
+    const payload = await response.json().catch(() => ({})) as Record<string, unknown>;
+    if (!response.ok || payload.ok === false) {
+      throw new Error(String(payload.error || response.statusText || "worker_session_delete_failed"));
+    }
+    return payload;
+  }
+
   async #resetWorkerSession(sessionKey: string): Promise<Record<string, unknown>> {
     const url = new URL(
       `/slack/sessions/${encodeURIComponent(sessionKey)}/reset`,
@@ -1866,6 +1948,41 @@ export class AdminService {
       throw new Error(String(payload.error || response.statusText || "worker_job_cancel_failed"));
     }
     return payload;
+  }
+
+  async #removeDeletedSessionArtifacts(
+    sessionKey: string,
+    jobs: readonly PersistedBackgroundJob[]
+  ): Promise<Record<string, unknown>> {
+    const pathSpecs = [
+      {
+        root: this.options.config.logDir,
+        path: getSessionLogDirectory(this.options.config.logDir, sessionKey)
+      },
+      ...jobs.map((job) => ({
+        root: this.options.config.jobsRoot,
+        path: path.join(this.options.config.jobsRoot, job.id)
+      })),
+      ...jobs.map((job) => ({
+        root: this.options.config.logDir,
+        path: getJobLogDirectory(this.options.config.logDir, job.id)
+      }))
+    ];
+
+    for (const spec of pathSpecs) {
+      assertSubpathOf(spec.root, spec.path);
+    }
+
+    await Promise.all(pathSpecs.map((spec) =>
+      fs.rm(spec.path, {
+        recursive: true,
+        force: true
+      })
+    ));
+
+    return {
+      pathCount: pathSpecs.length
+    };
   }
 }
 
@@ -2693,6 +2810,27 @@ function readStringField(value: JsonLike | undefined, key: string): string | und
   }
   const candidate = value[key];
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : undefined;
+}
+
+function readNestedBoolean(value: unknown, path: readonly string[]): boolean {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return false;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current === true;
+}
+
+function assertSubpathOf(rootPath: string, targetPath: string): void {
+  const resolvedRoot = path.resolve(rootPath);
+  const resolvedTarget = path.resolve(targetPath);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+    return;
+  }
+  throw new Error(`Refusing to delete artifact outside managed root: ${resolvedTarget}`);
 }
 
 function isAdminCancellableJob(job: PersistedBackgroundJob): boolean {

--- a/src/services/slack/slack-agent-bridge.ts
+++ b/src/services/slack/slack-agent-bridge.ts
@@ -147,6 +147,10 @@ export class SlackAgentBridge {
     return await this.#conversations.resetSession(sessionKey);
   }
 
+  async deleteSession(sessionKey: string) {
+    return await this.#conversations.deleteSession(sessionKey);
+  }
+
   async acceptBackgroundJobEvent(options: {
     readonly channelId: string;
     readonly rootThreadTs: string;

--- a/src/services/slack/slack-conversation-service.ts
+++ b/src/services/slack/slack-conversation-service.ts
@@ -409,6 +409,70 @@ export class SlackConversationService {
     };
   }
 
+  async deleteSession(sessionKey: string): Promise<{
+    readonly deleted: boolean;
+    readonly interruptedActiveTurn: boolean;
+    readonly previousAgentSessionId: string | null;
+    readonly previousActiveTurnId: string | null;
+    readonly clearedInboundCount: number;
+    readonly interruptError?: string | undefined;
+  }> {
+    const session = this.#findSessionByKey(sessionKey);
+    const previousAgentSessionId = session.agentSessionId ?? null;
+    const previousActiveTurnId = session.activeTurnId ?? null;
+    let interruptedActiveTurn = false;
+    let interruptError: string | undefined;
+
+    this.#resetRuntimeForManualSessionReset(session.key);
+
+    if (session.activeTurnId && session.agentSessionId) {
+      try {
+        await this.#turnRunner.interrupt(session);
+        interruptedActiveTurn = true;
+      } catch (error) {
+        interruptError = error instanceof Error ? error.message : String(error);
+        logger.warn("Failed to interrupt active turn during session delete", {
+          sessionKey: session.key,
+          agentSessionId: session.agentSessionId,
+          turnId: session.activeTurnId,
+          error: interruptError
+        });
+      }
+    }
+
+    const openMessages = this.#sessions.listInboundMessages({
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      status: ["pending", "inflight"]
+    });
+    if (openMessages.length > 0) {
+      await this.#sessions.updateInboundMessagesForBatch(
+        session.channelId,
+        session.rootThreadTs,
+        openMessages.map((message) => message.messageTs),
+        {
+          status: "done",
+          batchId: undefined
+        }
+      );
+    }
+
+    this.#clearAssistantStatus(session.channelId, session.rootThreadTs);
+    await this.#statusControllers.get(session.key)?.stop();
+    this.#statusControllers.delete(session.key);
+    this.#runtimeSessions.delete(session.key);
+
+    const deleted = await this.#sessions.deleteSessionByKey(session.key);
+    return {
+      deleted,
+      interruptedActiveTurn,
+      previousAgentSessionId,
+      previousActiveTurnId,
+      clearedInboundCount: openMessages.length,
+      interruptError
+    };
+  }
+
   async acceptBackgroundJobEvent(options: {
     readonly channelId: string;
     readonly rootThreadTs: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,7 @@ export type AdminOperationKind =
   | "auth_profile_delete"
   | "session_auth_profile_switch"
   | "session_reset"
+  | "session_delete"
   | "session_job_cancel"
   | "github_author_upsert"
   | "github_author_delete"

--- a/test/admin-routes.test.ts
+++ b/test/admin-routes.test.ts
@@ -837,6 +837,65 @@ describe("admin routes", () => {
       }
     ]);
   });
+
+  it("forwards session delete requests to the admin service", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      getStatus: async () => ({ ok: true }),
+      addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      activateAuthProfile: async () => ({ ok: true }),
+      deployRelease: async () => ({ ok: true }),
+      rollbackRelease: async () => ({ ok: true }),
+      deleteSession: async (payload: Record<string, unknown>) => {
+        calls.push(payload);
+        return { ok: true };
+      }
+    });
+
+    const response = await fetch(`${baseUrl}/admin/api/sessions/${encodeURIComponent("C123:111.222")}`, {
+      method: "DELETE"
+    });
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([
+      {
+        sessionKey: "C123:111.222"
+      }
+    ]);
+  });
+
+  it("maps missing session delete failures to 404", async () => {
+    const baseUrl = await startAdminServer({
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test"
+    } as NodeJS.ProcessEnv, {
+      getStatus: async () => ({ ok: true }),
+      addAuthProfile: async () => ({ ok: true }),
+      upsertGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteGitHubAuthorMapping: async () => ({ ok: true }),
+      deleteAuthProfile: async () => ({ ok: true }),
+      activateAuthProfile: async () => ({ ok: true }),
+      deployRelease: async () => ({ ok: true }),
+      rollbackRelease: async () => ({ ok: true }),
+      deleteSession: async () => {
+        throw new Error("Session not found: C123:missing");
+      }
+    });
+
+    const response = await fetch(`${baseUrl}/admin/api/sessions/${encodeURIComponent("C123:missing")}`, {
+      method: "DELETE"
+    });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "Session not found: C123:missing"
+    });
+  });
 });
 
 async function waitFor(predicate: () => boolean, label: string): Promise<void> {

--- a/test/admin-session-delete-e2e.test.ts
+++ b/test/admin-session-delete-e2e.test.ts
@@ -1,0 +1,291 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadConfig } from "../src/config.js";
+import { createHttpHandler } from "../src/http/router.js";
+import { getJobLogDirectory, getSessionLogDirectory } from "../src/logger.js";
+import { AdminService } from "../src/services/admin-service.js";
+import { SessionManager } from "../src/services/session-manager.js";
+import { StateStore } from "../src/store/state-store.js";
+
+describe("admin session delete API e2e", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("cancels jobs through the worker, stops the worker session, and removes persisted artifacts", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "admin-session-delete-e2e-"));
+    cleanups.push(async () => {
+      await fs.rm(dataRoot, {
+        recursive: true,
+        force: true
+      });
+    });
+
+    const baseEnv = {
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      DATA_ROOT: dataRoot
+    } as NodeJS.ProcessEnv;
+    const workerConfig = loadConfig(baseEnv);
+    const stateStore = new StateStore(workerConfig.stateDir, workerConfig.sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot: workerConfig.sessionsRoot
+    });
+    await sessions.load();
+
+    const session = await sessions.ensureSession("C123", "111.222");
+    await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "agent-session-1");
+    await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-1");
+    await fs.writeFile(path.join(session.workspacePath, "marker.txt"), "owned workspace", "utf8");
+    await sessions.upsertInboundMessage({
+      key: `${session.key}:111.223`,
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      messageTs: "111.223",
+      source: "thread_reply",
+      userId: "U123",
+      text: "pending work",
+      status: "pending",
+      createdAt: "2026-05-18T00:00:01.000Z",
+      updatedAt: "2026-05-18T00:00:01.000Z"
+    });
+
+    const jobDir = path.join(workerConfig.jobsRoot, "job-1");
+    await fs.mkdir(jobDir, { recursive: true });
+    await fs.writeFile(path.join(jobDir, "run.sh"), "#!/bin/sh\nsleep 60\n", "utf8");
+    await sessions.upsertBackgroundJob({
+      id: "job-1",
+      token: "token-1",
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      kind: "watch_ci",
+      shell: "sh",
+      cwd: session.workspacePath,
+      scriptPath: path.join(jobDir, "run.sh"),
+      restartOnBoot: true,
+      status: "running",
+      createdAt: "2026-05-18T00:00:00.000Z",
+      updatedAt: "2026-05-18T00:00:00.000Z"
+    });
+    const failedCancelJobDir = path.join(workerConfig.jobsRoot, "job-cancel-fails");
+    await fs.mkdir(failedCancelJobDir, { recursive: true });
+    await fs.writeFile(path.join(failedCancelJobDir, "run.sh"), "#!/bin/sh\nsleep 60\n", "utf8");
+    await sessions.upsertBackgroundJob({
+      id: "job-cancel-fails",
+      token: "token-2",
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      kind: "watch_review",
+      shell: "sh",
+      cwd: session.workspacePath,
+      scriptPath: path.join(failedCancelJobDir, "run.sh"),
+      restartOnBoot: true,
+      status: "running",
+      createdAt: "2026-05-18T00:00:00.000Z",
+      updatedAt: "2026-05-18T00:00:00.000Z"
+    });
+
+    const sessionLogDir = getSessionLogDirectory(workerConfig.logDir, session.key);
+    const jobLogDir = getJobLogDirectory(workerConfig.logDir, "job-1");
+    const failedCancelJobLogDir = getJobLogDirectory(workerConfig.logDir, "job-cancel-fails");
+    await fs.mkdir(sessionLogDir, { recursive: true });
+    await fs.mkdir(jobLogDir, { recursive: true });
+    await fs.mkdir(failedCancelJobLogDir, { recursive: true });
+    await fs.writeFile(path.join(sessionLogDir, "2026-05-18-00.jsonl"), "{}\n", "utf8");
+    await fs.writeFile(path.join(jobLogDir, "2026-05-18-00.jsonl"), "{}\n", "utf8");
+    await fs.writeFile(path.join(failedCancelJobLogDir, "2026-05-18-00.jsonl"), "{}\n", "utf8");
+
+    const workerCalls: Array<Record<string, unknown>> = [];
+    const workerBaseUrl = await startServer(createHttpHandler({
+      bridge: {
+        deleteSession: async (sessionKey: string) => {
+          workerCalls.push({
+            type: "deleteSession",
+            sessionKey
+          });
+          const existing = sessions.getSessionByKey(sessionKey);
+          const deleted = await sessions.deleteSessionByKey(sessionKey);
+          return {
+            deleted,
+            interruptedActiveTurn: Boolean(existing?.activeTurnId),
+            previousAgentSessionId: existing?.agentSessionId ?? null,
+            previousActiveTurnId: existing?.activeTurnId ?? null,
+            clearedInboundCount: 1
+          };
+        }
+      } as never,
+      jobManager: {
+        cancelJobFromAdmin: async (jobId: string, options: { sessionKey: string }) => {
+          workerCalls.push({
+            type: "cancelJob",
+            jobId,
+            sessionKey: options.sessionKey
+          });
+          if (jobId === "job-cancel-fails") {
+            throw new Error("simulated_cancel_failure");
+          }
+          const job = sessions.getBackgroundJob(jobId);
+          if (!job || job.sessionKey !== options.sessionKey) {
+            throw new Error("job_session_mismatch");
+          }
+          const updated = {
+            ...job,
+            status: "cancelled" as const,
+            cancelledAt: "2026-05-18T00:00:01.000Z",
+            completedAt: "2026-05-18T00:00:01.000Z"
+          };
+          await sessions.upsertBackgroundJob(updated);
+          return updated;
+        }
+      } as never,
+      config: workerConfig
+    }));
+    cleanups.push(async () => {
+      await stopServer(workerBaseUrl.server);
+    });
+
+    const adminConfig = loadConfig({
+      ...baseEnv,
+      WORKER_BASE_URL: workerBaseUrl.baseUrl
+    } as NodeJS.ProcessEnv);
+    const adminService = new AdminService({
+      config: adminConfig,
+      startedAt: new Date("2026-05-18T00:00:00.000Z"),
+      sessions,
+      authProfiles: {
+        listProfilesStatus: async () => ({
+          managedRoot: path.join(dataRoot, "auth-profiles"),
+          profilesRoot: path.join(dataRoot, "auth-profiles", "profiles"),
+          activeProfile: null,
+          activeAuthPath: path.join(adminConfig.codexHome, "auth.json"),
+          profiles: []
+        })
+      } as never,
+      githubAuthorMappings: {
+        load: async () => {},
+        listMappings: () => []
+      } as never,
+      runtime: {
+        restartRuntime: async () => {},
+        readAccountSummary: async () => ({
+          account: {
+            email: "ops@example.com",
+            type: "chatgpt",
+            planType: "team"
+          },
+          requiresOpenaiAuth: false
+        }),
+        readAccountRateLimits: async () => ({
+          rateLimits: null,
+          rateLimitsByLimitId: {}
+        })
+      } as never
+    });
+    const adminBaseUrl = await startServer(createHttpHandler({
+      adminService,
+      config: adminConfig
+    }));
+    cleanups.push(async () => {
+      await stopServer(adminBaseUrl.server);
+    });
+
+    const response = await fetch(`${adminBaseUrl.baseUrl}/admin/api/sessions/${encodeURIComponent(session.key)}`, {
+      method: "DELETE"
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      sessionKey: session.key,
+      cancelledJobCount: 1,
+      failedJobCancelCount: 1,
+      cancelledJobs: [
+        {
+          id: "job-1",
+          ok: true
+        },
+        {
+          id: "job-cancel-fails",
+          ok: false,
+          error: "simulated_cancel_failure"
+        }
+      ],
+      workerDelete: {
+        ok: true,
+        delete: {
+          interruptedActiveTurn: true,
+          previousAgentSessionId: "agent-session-1",
+          previousActiveTurnId: "turn-1"
+        }
+      }
+    });
+    expect(workerCalls).toEqual([
+      {
+        type: "cancelJob",
+        jobId: "job-1",
+        sessionKey: session.key
+      },
+      {
+        type: "cancelJob",
+        jobId: "job-cancel-fails",
+        sessionKey: session.key
+      },
+      {
+        type: "deleteSession",
+        sessionKey: session.key
+      }
+    ]);
+    expect(sessions.getSessionByKey(session.key)).toBeUndefined();
+    expect(sessions.getBackgroundJob("job-1")).toBeUndefined();
+    expect(sessions.getBackgroundJob("job-cancel-fails")).toBeUndefined();
+    await expect(fs.access(path.dirname(session.workspacePath))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(jobDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(failedCancelJobDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(sessionLogDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(jobLogDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(failedCancelJobLogDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+async function startServer(handler: http.RequestListener): Promise<{
+  readonly server: http.Server;
+  readonly baseUrl: string;
+}> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to start test server");
+  }
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`
+  };
+}
+
+async function stopServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/test/slack-conversation-service.test.ts
+++ b/test/slack-conversation-service.test.ts
@@ -621,6 +621,62 @@ describe("SlackConversationService", () => {
     await fs.rm(sessionsRoot, { force: true, recursive: true });
   });
 
+  it("deletes a session without ensuring a new agent session first", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-conversation-delete-state-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-conversation-delete-sessions-"));
+    const stateStore = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore,
+      sessionsRoot
+    });
+    await sessions.load();
+    let session = await sessions.ensureSession("C123", "111.222");
+    session = await sessions.setAgentSessionId(session.channelId, session.rootThreadTs, "thread-old");
+    session = await sessions.setActiveTurnId(session.channelId, session.rootThreadTs, "turn-old");
+
+    const agentRuntime = Object.assign(new EventEmitter(), {
+      ensureSession: vi.fn(async () => {
+        throw new Error("delete should not ensure a replacement session");
+      }),
+      interrupt: vi.fn(async () => undefined),
+      readSession: vi.fn(),
+      readTurn: vi.fn()
+    });
+    const setAssistantThreadStatus = vi.fn(async () => undefined);
+    const service = new SlackConversationService({
+      config: TEST_CONFIG,
+      sessions,
+      agentRuntime: agentRuntime as never,
+      slackApi: {
+        setAssistantThreadStatus,
+        addReaction: vi.fn(),
+        removeReaction: vi.fn()
+      } as never,
+      selfMessageFilter: {} as never
+    });
+
+    const deleted = await service.deleteSession(session.key);
+
+    expect(deleted).toMatchObject({
+      deleted: true,
+      interruptedActiveTurn: true,
+      previousAgentSessionId: "thread-old",
+      previousActiveTurnId: "turn-old",
+      clearedInboundCount: 0
+    });
+    expect(agentRuntime.ensureSession).not.toHaveBeenCalled();
+    expect(agentRuntime.interrupt).toHaveBeenCalledWith(expect.objectContaining({
+      agentSessionId: "thread-old",
+      activeTurnId: "turn-old"
+    }));
+    expect(sessions.getSessionByKey(session.key)).toBeUndefined();
+
+    await service.stop();
+    stateStore.close();
+    await fs.rm(stateDir, { force: true, recursive: true });
+    await fs.rm(sessionsRoot, { force: true, recursive: true });
+  });
+
   it("keeps Slack input pending and posts one session link when auth profile is unavailable", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-conversation-auth-block-state-"));
     const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-conversation-auth-block-sessions-"));

--- a/test/slack-routes.test.ts
+++ b/test/slack-routes.test.ts
@@ -47,6 +47,68 @@ function createResponse() {
 }
 
 describe("handleSlackRequest", () => {
+  it("routes internal session delete requests through the bridge", async () => {
+    const deleteSession = vi.fn(async () => ({
+      deleted: true,
+      interruptedActiveTurn: true,
+      clearedInboundCount: 2
+    }));
+    const response = createResponse();
+
+    const handled = await handleSlackRequest(
+      "DELETE",
+      new URL(`http://localhost/slack/sessions/${encodeURIComponent("C123:111.222")}`),
+      createJsonRequest({}) as never,
+      response as never,
+      {
+        bridge: {
+          deleteSession
+        } as never,
+        config: {} as never
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(deleteSession).toHaveBeenCalledWith("C123:111.222");
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.bodyText || "{}")).toMatchObject({
+      ok: true,
+      sessionKey: "C123:111.222",
+      delete: {
+        deleted: true,
+        interruptedActiveTurn: true,
+        clearedInboundCount: 2
+      }
+    });
+  });
+
+  it("returns 404 for internal session delete requests when the worker session is unknown", async () => {
+    const deleteSession = vi.fn(async () => {
+      throw new Error("Unknown session runtime key: C123:missing");
+    });
+    const response = createResponse();
+
+    const handled = await handleSlackRequest(
+      "DELETE",
+      new URL(`http://localhost/slack/sessions/${encodeURIComponent("C123:missing")}`),
+      createJsonRequest({}) as never,
+      response as never,
+      {
+        bridge: {
+          deleteSession
+        } as never,
+        config: {} as never
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(response.statusCode).toBe(404);
+    expect(JSON.parse(response.bodyText || "{}")).toMatchObject({
+      ok: false,
+      error: "Unknown session runtime key: C123:missing"
+    });
+  });
+
   it("treats blank co-author arrays as omitted in configure-session", async () => {
     const configureSessionCoauthors = vi.fn(async () => ({
       sessionKey: "session-key",


### PR DESCRIPTION
## Summary
- add `DELETE /admin/api/sessions/:sessionKey` to stop/delete a session through admin
- add internal worker `DELETE /slack/sessions/:sessionKey` to clear runtime queue, interrupt active turns, clear inbound/status, and remove session state/workspace
- cancel running/registered session background jobs and remove session/job artifacts as part of delete orchestration

## Tests
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vitest run test/admin-routes.test.ts test/slack-routes.test.ts test/admin-session-delete-e2e.test.ts`
- `pnpm build`
- Manual smoke: started local in-memory admin/worker HTTP servers and issued `DELETE /admin/api/sessions/:sessionKey`; verified 200, job cancellation count, active turn metadata, and session removal.

## Note
- A full `pnpm test -- ...` invocation accidentally ran the whole suite and hit an unrelated `test/macos-bootstrap.test.ts` environment expectation (`ADMIN_BASE_URL` inherited as codex-3720-bot-admin.afk.surf instead of the test value). Targeted tests above passed.
