### PR TITLE
Fix admin SSE reconnect refresh state

### DIFF
--- a/src/admin-ui/admin-shell.tsx
+++ b/src/admin-ui/admin-shell.tsx
@@ -15,6 +15,7 @@ import {
 import {
   connectAdminRealtime,
   getAdminStatusSnapshot,
+  mergeAdminStatusSnapshot,
   publishAdminStatus,
   subscribeAdminStatus
 } from "./admin-status-store";
@@ -1054,25 +1055,7 @@ async function loadAdminLogs(): Promise<Record<string, any>> {
 }
 
 function mergeStatusOverview(status: unknown, overview: unknown): AdminStatus {
-  const current = status && typeof status === "object" && !Array.isArray(status)
-    ? status as AdminStatus
-    : {};
-  const next = overview && typeof overview === "object" && !Array.isArray(overview)
-    ? overview as AdminStatus
-    : {};
-  return {
-    ...current,
-    ...next,
-    state: {
-      ...(current.state || {}),
-      ...(next.state || {}),
-      sessions: Array.isArray(next.state?.sessions)
-        ? next.state.sessions
-        : Array.isArray(current.state?.sessions)
-          ? current.state.sessions
-          : []
-    }
-  };
+  return mergeAdminStatusSnapshot(status, overview) as AdminStatus;
 }
 
 function mergeStatusLogs(status: unknown, logs: unknown): AdminStatus {

--- a/src/admin-ui/admin-status-store.ts
+++ b/src/admin-ui/admin-status-store.ts
@@ -34,13 +34,23 @@ const timelineSnapshots = new Map<string, TimelineSnapshot>();
 const timelineListeners = new Map<string, Set<Listener>>();
 
 export function publishAdminStatus(status: unknown): void {
-  lastEventSequence = Math.max(lastEventSequence, readRealtimeCursor(status));
-  snapshot = { status, version: snapshot.version + 1 };
+  if (statusIncludesSessionSnapshot(status)) {
+    lastEventSequence = Math.max(lastEventSequence, readRealtimeCursor(status));
+  }
+  snapshot = {
+    status: mergeAdminStatusSnapshot(snapshot.status, status),
+    version: snapshot.version + 1
+  };
   listeners.forEach((listener) => listener());
 }
 
 export function applyAdminRealtimeEvent(event: AdminRealtimeEvent): void {
-  lastEventSequence = Math.max(lastEventSequence, Number(event.sequence || 0));
+  const eventSequence = readEventSequence(event);
+  if (eventSequence > 0 && lastEventSequence >= eventSequence) {
+    return;
+  }
+
+  lastEventSequence = Math.max(lastEventSequence, eventSequence);
   snapshot = {
     status: applyAdminRealtimeEventToStatus(snapshot.status, event),
     version: snapshot.version + 1
@@ -138,6 +148,56 @@ export function getTimelineSnapshot(sessionKey: string): TimelineSnapshot {
   return timelineSnapshots.get(sessionKey) ?? emptyTimelineSnapshot;
 }
 
+export function mergeAdminStatusSnapshot(currentStatus: unknown, incomingStatus: unknown): unknown {
+  if (!incomingStatus || typeof incomingStatus !== "object" || Array.isArray(incomingStatus)) {
+    return incomingStatus;
+  }
+
+  const current = currentStatus && typeof currentStatus === "object" && !Array.isArray(currentStatus)
+    ? currentStatus as Record<string, any>
+    : {};
+  const incoming = incomingStatus as Record<string, any>;
+  const currentState = current.state && typeof current.state === "object" && !Array.isArray(current.state)
+    ? current.state as Record<string, any>
+    : {};
+  const incomingState = incoming.state && typeof incoming.state === "object" && !Array.isArray(incoming.state)
+    ? incoming.state as Record<string, any>
+    : {};
+  const currentSessions = Array.isArray(currentState.sessions) ? currentState.sessions : [];
+  const incomingHasSessions = Array.isArray(incomingState.sessions);
+  const currentRealtime = current.realtime && typeof current.realtime === "object" && !Array.isArray(current.realtime)
+    ? current.realtime as Record<string, unknown>
+    : {};
+  const incomingRealtime = incoming.realtime && typeof incoming.realtime === "object" && !Array.isArray(incoming.realtime)
+    ? incoming.realtime as Record<string, unknown>
+    : {};
+  const mergedState: Record<string, unknown> = {
+    ...currentState,
+    ...incomingState,
+    sessions: incomingHasSessions ? incomingState.sessions : currentSessions
+  };
+
+  if (!incomingHasSessions && currentSessions.length > 0) {
+    for (const key of sessionDerivedStateKeys) {
+      if (currentState[key] !== undefined) {
+        mergedState[key] = currentState[key];
+      }
+    }
+  }
+
+  return {
+    ...current,
+    ...incoming,
+    realtime: incomingHasSessions || Object.keys(currentRealtime).length === 0
+      ? {
+        ...currentRealtime,
+        ...incomingRealtime
+      }
+      : currentRealtime,
+    state: mergedState
+  };
+}
+
 export function applyAdminRealtimeEventToStatus(status: unknown, event: AdminRealtimeEvent): unknown {
   if (!status || typeof status !== "object" || Array.isArray(status)) {
     return status;
@@ -211,12 +271,36 @@ function upsertSessionSummary(
       return existing;
     }
     replaced = true;
-    return session;
+    return mergeSessionSummary(existing, session);
   });
   if (!replaced) {
     next.push(session);
   }
   return next;
+}
+
+function mergeSessionSummary(
+  existing: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    ...existing,
+    ...incoming,
+    usage: mergeNestedObject(existing.usage, incoming.usage)
+  };
+}
+
+function mergeNestedObject(current: unknown, incoming: unknown): unknown {
+  if (!incoming || typeof incoming !== "object" || Array.isArray(incoming)) {
+    return incoming ?? current;
+  }
+  if (!current || typeof current !== "object" || Array.isArray(current)) {
+    return incoming;
+  }
+  return {
+    ...(current as Record<string, unknown>),
+    ...(incoming as Record<string, unknown>)
+  };
 }
 
 function upsertById(
@@ -352,3 +436,29 @@ function readRealtimeCursor(status: unknown): number {
   const cursor = Number((status as Record<string, any>).realtime?.cursor || 0);
   return Number.isFinite(cursor) ? cursor : 0;
 }
+
+function readEventSequence(event: Pick<AdminRealtimeEvent, "sequence">): number {
+  const sequence = Number(event.sequence || 0);
+  return Number.isFinite(sequence) ? sequence : 0;
+}
+
+function statusIncludesSessionSnapshot(status: unknown): boolean {
+  if (!status || typeof status !== "object" || Array.isArray(status)) {
+    return false;
+  }
+  const state = (status as Record<string, any>).state;
+  return Boolean(state && typeof state === "object" && !Array.isArray(state) && Array.isArray(state.sessions));
+}
+
+const sessionDerivedStateKeys = [
+  "sessionCount",
+  "activeCount",
+  "openInboundCount",
+  "openHumanInboundCount",
+  "openSystemInboundCount",
+  "backgroundJobCount",
+  "runningBackgroundJobCount",
+  "failedBackgroundJobCount",
+  "activeSessions",
+  "openInbound"
+];

--- a/src/http/admin-routes.ts
+++ b/src/http/admin-routes.ts
@@ -703,14 +703,15 @@ function streamAdminEvents(
 }
 
 function readEventCursor(url: URL, request: http.IncomingMessage): number {
-  const fromQuery = Number(url.searchParams.get("after") ?? "");
-  if (Number.isFinite(fromQuery) && fromQuery >= 0) {
-    return Math.floor(fromQuery);
-  }
   const fromHeader = request.headers["last-event-id"];
   const value = Array.isArray(fromHeader) ? fromHeader.at(-1) : fromHeader;
-  const parsed = Number(value ?? 0);
-  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0;
+  const parsed = value == null || value === "" ? NaN : Number(value);
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return Math.floor(parsed);
+  }
+
+  const fromQuery = Number(url.searchParams.get("after") ?? "");
+  return Number.isFinite(fromQuery) && fromQuery >= 0 ? Math.floor(fromQuery) : 0;
 }
 
 async function respondTracedAdminJson(

--- a/test/admin-realtime-store.test.ts
+++ b/test/admin-realtime-store.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyAdminRealtimeEventToStatus,
   applyTimelineRealtimeEvent,
+  mergeAdminStatusSnapshot,
   type AdminRealtimeEvent
 } from "../src/admin-ui/admin-status-store.js";
 
@@ -46,6 +47,112 @@ describe("admin realtime client store", () => {
     } satisfies AdminRealtimeEvent);
 
     expect((appended as Record<string, any>).state.sessions.map((session: Record<string, unknown>) => session.key)).toEqual(["C1:1", "C2:2", "C3:3"]);
+  });
+
+  it("keeps session-derived counts while overview-only refresh data is loading", () => {
+    const current = {
+      realtime: { cursor: 4 },
+      state: {
+        sessions: [
+          { key: "C1:1", runningBackgroundJobCount: 1 }
+        ],
+        sessionCount: 1,
+        activeCount: 1,
+        openInboundCount: 2,
+        openHumanInboundCount: 1,
+        openSystemInboundCount: 1,
+        backgroundJobCount: 1,
+        runningBackgroundJobCount: 1,
+        failedBackgroundJobCount: 0
+      }
+    };
+
+    const merged = mergeAdminStatusSnapshot(current, {
+      ok: true,
+      realtime: { cursor: 5 },
+      deployment: { ok: true },
+      state: {
+        sessionCount: 1,
+        activeCount: 0,
+        openInboundCount: 0,
+        openHumanInboundCount: 0,
+        openSystemInboundCount: 0,
+        backgroundJobCount: 0,
+        runningBackgroundJobCount: 0,
+        failedBackgroundJobCount: 0
+      }
+    }) as Record<string, any>;
+
+    expect(merged.deployment).toEqual({ ok: true });
+    expect(merged.realtime).toEqual({ cursor: 4 });
+    expect(merged.state.sessions).toEqual(current.state.sessions);
+    expect(merged.state).toMatchObject({
+      activeCount: 1,
+      openInboundCount: 2,
+      runningBackgroundJobCount: 1
+    });
+  });
+
+  it("lets a session snapshot overwrite preserved counts after a refresh completes", () => {
+    const current = {
+      state: {
+        sessions: [
+          { key: "C1:1", runningBackgroundJobCount: 1 }
+        ],
+        sessionCount: 1,
+        activeCount: 1,
+        runningBackgroundJobCount: 1
+      }
+    };
+
+    const merged = mergeAdminStatusSnapshot(current, {
+      state: {
+        sessions: [],
+        sessionCount: 0,
+        activeCount: 0,
+        runningBackgroundJobCount: 0
+      }
+    }) as Record<string, any>;
+
+    expect(merged.state.sessions).toEqual([]);
+    expect(merged.state).toMatchObject({
+      sessionCount: 0,
+      activeCount: 0,
+      runningBackgroundJobCount: 0
+    });
+  });
+
+  it("merges partial realtime session summaries over existing rows", () => {
+    const updated = applyAdminRealtimeEventToStatus({
+      realtime: { cursor: 1 },
+      state: {
+        sessions: [
+          { key: "C1:1", runningBackgroundJobCount: 1, backgroundJobCount: 1 }
+        ],
+        runningBackgroundJobCount: 1,
+        backgroundJobCount: 1
+      }
+    }, {
+      sequence: 2,
+      kind: "session.upsert",
+      scope: "session",
+      sessionKey: "C1:1",
+      entityId: "C1:1",
+      createdAt: "2026-05-09T00:00:02.000Z",
+      payload: {},
+      session: { key: "C1:1", updatedAt: "2026-05-09T00:00:02.000Z" }
+    } satisfies AdminRealtimeEvent) as Record<string, any>;
+
+    expect(updated.state.sessions[0]).toMatchObject({
+      key: "C1:1",
+      updatedAt: "2026-05-09T00:00:02.000Z",
+      runningBackgroundJobCount: 1,
+      backgroundJobCount: 1
+    });
+    expect(updated.state).toMatchObject({
+      runningBackgroundJobCount: 1,
+      backgroundJobCount: 1
+    });
   });
 
   it("appends realtime timeline events and updates trace counts", () => {

--- a/test/admin-realtime.e2e.test.ts
+++ b/test/admin-realtime.e2e.test.ts
@@ -148,6 +148,38 @@ describe("admin realtime e2e", () => {
     expect(event.session).toBeUndefined();
   });
 
+  it("uses Last-Event-ID instead of the original after query on SSE reconnect", async () => {
+    const fixture = await startAdminFixture();
+    await fixture.sessions.ensureSession("COLD1", "100.000", {
+      channelName: "old-one"
+    });
+    await fixture.sessions.ensureSession("COLD2", "200.000", {
+      channelName: "old-two"
+    });
+
+    const controller = new AbortController();
+    const eventPromise = readSseEvent(`${fixture.baseUrl}/admin/api/events?after=1`, controller.signal, {
+      "last-event-id": "2"
+    });
+
+    await delay(25);
+    await fixture.sessions.ensureSession("CNEW", "300.000", {
+      channelName: "new"
+    });
+
+    const message = await eventPromise;
+    controller.abort();
+    expect(message.id).toBe("3");
+    expect(message.data).toMatchObject({
+      ok: true,
+      event: {
+        sequence: 3,
+        kind: "session.upsert",
+        sessionKey: "CNEW:300.000"
+      }
+    });
+  });
+
   async function startAdminFixture(): Promise<{
     readonly baseUrl: string;
     readonly config: AppConfig;
@@ -255,14 +287,15 @@ describe("admin realtime e2e", () => {
   }
 });
 
-async function readSseEvent(url: string, signal: AbortSignal): Promise<{
+async function readSseEvent(url: string, signal: AbortSignal, extraHeaders: Record<string, string> = {}): Promise<{
   readonly event: string;
   readonly id: string;
   readonly data: Record<string, unknown>;
 }> {
   const response = await fetch(url, {
     headers: {
-      accept: "text/event-stream"
+      accept: "text/event-stream",
+      ...extraHeaders
     },
     signal
   });


### PR DESCRIPTION
## Summary\n- Preserve existing session-derived counts and rows while overview-only refresh data arrives during SSE reconnects\n- Avoid advancing the client realtime cursor from overview-only payloads before the corresponding events are applied\n- Honor Last-Event-ID on SSE reconnects so stale after query params cannot replay already-applied events\n\n## Tests\n- pnpm vitest run test/admin-realtime-store.test.ts test/admin-realtime.e2e.test.ts\n- pnpm build\n- manual smoke via built admin-status-store helpers: overview preserves old count/cursor, live event applies, fresh session snapshot overwrites\n- env -u ADMIN_BASE_URL -u GH_TOKEN -u GITHUB_TOKEN pnpm test