### PR TITLE
Disable Codex apps in broker app server

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ volumes:
 
 At startup the broker copies that file into its own `CODEX_HOME`/data directory and uses it to authenticate the embedded Codex app-server.
 
-The main Codex runtime disables all built-in MCP servers by default. Keep tool access outside the main runtime and use broker-managed integrations instead. This only removes those MCP servers from the broker's container-local Codex config. It does not modify your host `~/.codex/config.toml`.
+The main Codex runtime disables all built-in MCP servers by default, and starts the Codex app-server with the `apps` feature disabled so Apps/Connectors are not exposed to model turns. Keep tool access outside the main runtime and use broker-managed integrations instead. MCP removal only affects the broker's container-local Codex config. It does not modify your host `~/.codex/config.toml`.
 
 ## Reuse Global Codex Memory
 

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -623,10 +623,10 @@ function parsePidList(output: string): number[] {
   )];
 }
 
-function parseCodexAppServerPidsFromPsOutput(output: string, port: number): number[] {
+export function parseCodexAppServerPidsFromPsOutput(output: string, port: number): number[] {
   const listenPatterns = [
-    `app-server --listen ws://127.0.0.1:${port}`,
-    `app-server --listen ws://localhost:${port}`
+    `--listen ws://127.0.0.1:${port}`,
+    `--listen ws://localhost:${port}`
   ];
 
   return [...new Set(
@@ -634,7 +634,7 @@ function parseCodexAppServerPidsFromPsOutput(output: string, port: number): numb
       .split("\n")
       .map((line) => line.trim())
       .filter(Boolean)
-      .filter((line) => listenPatterns.some((pattern) => line.includes(pattern)))
+      .filter((line) => line.includes("app-server") && listenPatterns.some((pattern) => line.includes(pattern)))
       .map((line) => Number.parseInt(line.split(/\s+/, 2)[0] ?? "", 10))
       .filter((value) => Number.isInteger(value) && value > 0)
   )];

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -12,6 +12,7 @@ import { syncUserCodexHome } from "./codex-home.js";
 import { syncGeminiHome } from "./gemini-home.js";
 
 const ALL_MCP_SERVERS = "*";
+const DISABLED_CODEX_APP_SERVER_FEATURES = ["apps"] as const;
 
 export class AppServerProcess {
   readonly #brokerHttpBaseUrl: string;
@@ -127,7 +128,14 @@ export class AppServerProcess {
   }
 
   async #startProcess(env: NodeJS.ProcessEnv, allowPortRecovery: boolean): Promise<void> {
-    this.#child = spawn("codex", ["app-server", "--listen", this.url], {
+    const args = [
+      "app-server",
+      ...DISABLED_CODEX_APP_SERVER_FEATURES.flatMap((feature) => ["--disable", feature]),
+      "--listen",
+      this.url
+    ];
+
+    this.#child = spawn("codex", args, {
       detached: true,
       env,
       stdio: ["ignore", "pipe", "pipe"]

--- a/test/app-server-process.test.ts
+++ b/test/app-server-process.test.ts
@@ -11,6 +11,10 @@ async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 async function startHealthyHttpServer(): Promise<{
   readonly close: () => Promise<void>;
   readonly url: string;
@@ -61,6 +65,7 @@ describe("AppServerProcess", () => {
     const tempadServer = await startHealthyHttpServer();
     const fakeBinDir = path.join(tempRoot, "bin");
     const fakeCodexPath = path.join(fakeBinDir, "codex");
+    const argsFile = path.join(tempRoot, "codex-args.txt");
     const hostCodexHomePath = path.join(tempRoot, "host-codex-home");
     const hostGeminiHomePath = path.join(tempRoot, "host-gemini-home");
     const codexHome = path.join(tempRoot, "codex-home");
@@ -82,6 +87,7 @@ describe("AppServerProcess", () => {
         "#!/usr/bin/env bash",
         "set -euo pipefail",
         "if [ \"${1:-}\" = \"app-server\" ]; then",
+        `  printf '%s\\n' "$@" > ${shellQuote(argsFile)}`,
         "  printf '%s\\n' 'codex app-server (WebSockets)' >&2",
         "  printf '%s\\n' '  listening on: ws://127.0.0.1:4590' >&2",
         "  sleep 0.1",
@@ -119,6 +125,8 @@ describe("AppServerProcess", () => {
     try {
       await processManager.start();
       await delay(300);
+      const observedArgs = (await fs.readFile(argsFile, "utf8")).trim().split("\n");
+      expect(observedArgs.slice(0, 4)).toEqual(["app-server", "--disable", "apps", "--listen"]);
     } finally {
       await processManager.stop().catch(() => {});
       await tempadServer.close().catch(() => {});

--- a/test/app-server-process.test.ts
+++ b/test/app-server-process.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { AppServerProcess } from "../src/services/codex/app-server-process.js";
+import {
+  AppServerProcess,
+  parseCodexAppServerPidsFromPsOutput
+} from "../src/services/codex/app-server-process.js";
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -126,7 +129,13 @@ describe("AppServerProcess", () => {
       await processManager.start();
       await delay(300);
       const observedArgs = (await fs.readFile(argsFile, "utf8")).trim().split("\n");
-      expect(observedArgs.slice(0, 4)).toEqual(["app-server", "--disable", "apps", "--listen"]);
+      expect(observedArgs).toEqual([
+        "app-server",
+        "--disable",
+        "apps",
+        "--listen",
+        "ws://127.0.0.1:4590"
+      ]);
     } finally {
       await processManager.stop().catch(() => {});
       await tempadServer.close().catch(() => {});
@@ -139,5 +148,17 @@ describe("AppServerProcess", () => {
     expect(observedWrites.join("")).toContain(
       "disconnecting slow connection after outbound queue filled: ConnectionId(1)"
     );
+  });
+
+  it("finds app-server listeners in ps output when feature flags appear before --listen", () => {
+    const output = [
+      "123 /opt/homebrew/bin/codex app-server --disable apps --listen ws://127.0.0.1:4590",
+      "124 /opt/homebrew/bin/codex app-server --listen ws://localhost:4590",
+      "125 /opt/homebrew/bin/codex app-server --disable apps --listen ws://127.0.0.1:4591",
+      "126 /opt/homebrew/bin/codex exec --listen ws://127.0.0.1:4590",
+      "123 /opt/homebrew/bin/codex app-server --disable apps --listen ws://127.0.0.1:4590"
+    ].join("\n");
+
+    expect(parseCodexAppServerPidsFromPsOutput(output, 4590)).toEqual([123, 124]);
   });
 });


### PR DESCRIPTION
## Summary
- start the broker-managed Codex app-server with `--disable apps`
- add a regression assertion for the spawned Codex CLI arguments
- document that Apps/Connectors are disabled in the main Codex runtime

## Test plan
- `pnpm build`
- `pnpm exec vitest run test/app-server-process.test.ts`
- `env -u ADMIN_BASE_URL -u GH_TOKEN -u GITHUB_TOKEN pnpm test`
- Manual: compared `codex debug prompt-input` with and without `--disable apps`; the disabled run removed both `Apps (Connectors)` and `codex_apps` from the model-visible prompt.
