### PR TITLE
Stop background jobs after five hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Notes:
 
 - Raw logs are intentionally verbose and can grow quickly during long sessions. Oversized raw payloads are truncated to `LOG_RAW_MAX_BYTES` before they are written.
 - Admin status reads only a bounded tail of recent broker JSONL files; it does not decode entire log files into memory.
+- Broker-managed background jobs are automatically cancelled once they exceed five hours of runtime, including restartable jobs that are already over the limit when the worker boots.
 - When free space falls below `DISK_CLEANUP_MIN_FREE_BYTES`, the worker removes old hourly log files first. If space is still below `DISK_CLEANUP_TARGET_FREE_BYTES`, it removes sessions inactive for at least `DISK_CLEANUP_INACTIVE_SESSION_MS`, oldest activity first. Active turns, pending inbound work, and running jobs protect sessions only until `DISK_CLEANUP_JOB_PROTECTION_MS`; older sessions can be removed with their jobs.
 - `/slack/post-file` request logging redacts inline `content_base64` payloads into a size marker instead of writing the full blob.
 - Session and job log files are written independently, so one noisy thread no longer forces the entire broker state or log history into one giant file.

--- a/src/services/job-manager.ts
+++ b/src/services/job-manager.ts
@@ -16,15 +16,19 @@ import { SessionManager } from "./session-manager.js";
 
 interface RuntimeBackgroundJob {
   readonly process: ChildProcessByStdio<null, Readable, Readable>;
+  readonly timeoutTimer: ReturnType<typeof setTimeout>;
   stderrTail: string;
   stopping: boolean;
 }
+
+const DEFAULT_BACKGROUND_JOB_MAX_RUNTIME_MS = 5 * 60 * 60 * 1000;
 
 export class JobManager {
   readonly #sessions: SessionManager;
   readonly #jobsRoot: string;
   readonly #reposRoot: string;
   readonly #brokerHttpBaseUrl: string;
+  readonly #maxRuntimeMs: number;
   readonly #runtimeJobs = new Map<string, RuntimeBackgroundJob>();
   readonly #onEvent: (event: {
     readonly channelId: string;
@@ -37,6 +41,7 @@ export class JobManager {
     readonly jobsRoot: string;
     readonly reposRoot: string;
     readonly brokerHttpBaseUrl: string;
+    readonly maxRuntimeMs?: number | undefined;
     readonly onEvent: (event: {
       readonly channelId: string;
       readonly rootThreadTs: string;
@@ -47,6 +52,7 @@ export class JobManager {
     this.#jobsRoot = options.jobsRoot;
     this.#reposRoot = options.reposRoot;
     this.#brokerHttpBaseUrl = options.brokerHttpBaseUrl;
+    this.#maxRuntimeMs = options.maxRuntimeMs ?? DEFAULT_BACKGROUND_JOB_MAX_RUNTIME_MS;
     this.#onEvent = options.onEvent;
   }
 
@@ -296,6 +302,11 @@ export class JobManager {
       return;
     }
 
+    if (this.#jobRuntimeRemainingMs(job) <= 0) {
+      await this.#cancelTimedOutJob(job);
+      return;
+    }
+
     await ensureDir(path.dirname(job.scriptPath));
     const env: NodeJS.ProcessEnv = {
       ...process.env,
@@ -316,6 +327,7 @@ export class JobManager {
       const child = spawn(job.scriptPath, [], {
         cwd: job.cwd,
         env,
+        detached: process.platform !== "win32",
         stdio: ["ignore", "pipe", "pipe"]
       });
       await new Promise<void>((resolve, reject) => {
@@ -325,6 +337,7 @@ export class JobManager {
 
       const runtime: RuntimeBackgroundJob = {
         process: child,
+        timeoutTimer: this.#createTimeoutTimer(job),
         stderrTail: "",
         stopping: false
       };
@@ -385,6 +398,9 @@ export class JobManager {
     signal: NodeJS.Signals | null
   ): Promise<void> {
     const runtime = this.#runtimeJobs.get(jobId);
+    if (runtime) {
+      clearTimeout(runtime.timeoutTimer);
+    }
     this.#runtimeJobs.delete(jobId);
 
     const job = this.#sessions.getBackgroundJob(jobId);
@@ -445,6 +461,7 @@ export class JobManager {
       return;
     }
 
+    clearTimeout(runtime.timeoutTimer);
     runtime.stopping = true;
     const child = runtime.process;
 
@@ -453,16 +470,80 @@ export class JobManager {
       return;
     }
 
-    child.kill("SIGTERM");
+    killRuntimeJobProcess(child, "SIGTERM");
     const exited = await waitForChildExit(child, 5_000);
     if (exited) {
       this.#runtimeJobs.delete(jobId);
       return;
     }
 
-    child.kill("SIGKILL");
+    killRuntimeJobProcess(child, "SIGKILL");
     await waitForChildExit(child, 2_000);
     this.#runtimeJobs.delete(jobId);
+  }
+
+  #createTimeoutTimer(job: PersistedBackgroundJob): ReturnType<typeof setTimeout> {
+    const delayMs = Math.max(0, this.#jobRuntimeRemainingMs(job));
+    const timeoutTimer = setTimeout(() => {
+      void this.#handleJobTimeout(job.id);
+    }, delayMs);
+    timeoutTimer.unref?.();
+    return timeoutTimer;
+  }
+
+  async #handleJobTimeout(jobId: string): Promise<void> {
+    try {
+      const job = this.#sessions.getBackgroundJob(jobId);
+      if (!job || !isCancellableJobStatus(job.status)) {
+        return;
+      }
+
+      await this.#cancelTimedOutJob(job);
+    } catch (error) {
+      logger.warn("Failed to stop background job after runtime limit", {
+        jobId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  async #cancelTimedOutJob(job: PersistedBackgroundJob): Promise<PersistedBackgroundJob> {
+    if (!isCancellableJobStatus(job.status)) {
+      return job;
+    }
+
+    const now = new Date().toISOString();
+    const summary = `Background job ${job.id} exceeded the runtime limit (${formatRuntimeLimit(this.#maxRuntimeMs)}) and was cancelled.`;
+    const updated = await this.#persistJob({
+      ...job,
+      status: "cancelled",
+      cancelledAt: now,
+      completedAt: now,
+      error: summary
+    });
+
+    if (!this.#shouldSuppressEventForFinalizedSession(updated)) {
+      await this.#emitEvent(updated, {
+        jobId: updated.id,
+        jobKind: updated.kind,
+        eventKind: "job_cancelled",
+        summary
+      });
+    }
+
+    await this.#stopRuntimeJob(updated.id);
+    return updated;
+  }
+
+  #jobRuntimeRemainingMs(job: PersistedBackgroundJob): number {
+    // Use createdAt rather than startedAt so restartable jobs that were already
+    // over the runtime limit while the broker was down are cancelled on boot.
+    const createdAtMs = Date.parse(job.createdAt);
+    if (!Number.isFinite(createdAtMs)) {
+      return this.#maxRuntimeMs;
+    }
+
+    return this.#maxRuntimeMs - (Date.now() - createdAtMs);
   }
 
   async #emitEvent(
@@ -544,6 +625,50 @@ function resolveJobCwd(workspacePath: string, cwd?: string | undefined): string 
 
 function isCancellableJobStatus(status: PersistedBackgroundJob["status"]): boolean {
   return status === "registered" || status === "running";
+}
+
+function formatRuntimeLimit(limitMs: number): string {
+  if (limitMs < 1000) {
+    return `${Math.max(0, limitMs)} ms`;
+  }
+
+  if (limitMs < 60_000) {
+    const seconds = Math.round(limitMs / 1000);
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+
+  const hours = limitMs / (60 * 60 * 1000);
+  if (Number.isInteger(hours)) {
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+
+  const minutes = Math.round(limitMs / 60_000);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+function killRuntimeJobProcess(
+  child: ChildProcessByStdio<null, Readable, Readable>,
+  signal: NodeJS.Signals
+): void {
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch (error) {
+      if (!isMissingProcessError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  child.kill(signal);
+}
+
+function isMissingProcessError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { readonly code?: unknown }).code === "ESRCH";
 }
 
 async function waitForChildExit(

--- a/test/job-manager.test.ts
+++ b/test/job-manager.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { SessionManager } from "../src/services/session-manager.js";
 import { JobManager } from "../src/services/job-manager.js";
 import { StateStore } from "../src/store/state-store.js";
+import type { PersistedBackgroundJob } from "../src/types.js";
 import { resolveRuntimeToolPath } from "../src/utils/runtime-paths.js";
 
 describe("JobManager", () => {
@@ -67,6 +68,125 @@ describe("JobManager", () => {
     ]);
 
     await jobs.cancelJob(job.id, job.token);
+    await jobs.stop();
+  });
+
+  it("automatically cancels jobs that exceed the runtime limit", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
+    const jobsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-jobs-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));
+    const reposRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-repos-"));
+    const store = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore: store,
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C123", "111.333");
+    await fs.mkdir(session.workspacePath, { recursive: true });
+    const childPidPath = path.join(session.workspacePath, "child.pid");
+
+    const seenEvents: Array<{ payload: { summary: string; jobId: string; eventKind: string } }> = [];
+    const jobs = new JobManager({
+      sessions,
+      jobsRoot,
+      reposRoot,
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      maxRuntimeMs: 100,
+      onEvent: async (event) => {
+        seenEvents.push({
+          payload: {
+            summary: event.payload.summary,
+            jobId: event.payload.jobId,
+            eventKind: event.payload.eventKind
+          }
+        });
+      }
+    });
+
+    const job = await jobs.registerJob({
+      channelId: "C123",
+      rootThreadTs: "111.333",
+      kind: "watch_ci",
+      script: `#!/usr/bin/env bash\nsleep 30 &\necho $! > ${shellQuote(childPidPath)}\nwait`
+    });
+
+    const childPid = Number(await waitForFileContents(childPidPath));
+    const timedOut = await waitForJobStatus(sessions, job.id, "cancelled");
+    expect(timedOut.cancelledAt).toEqual(expect.any(String));
+    expect(timedOut.completedAt).toEqual(expect.any(String));
+    expect(timedOut.error).toContain("runtime limit");
+    await waitForProcessExit(childPid);
+    expect(seenEvents).toEqual([
+      {
+        payload: {
+          summary: expect.stringContaining("runtime limit"),
+          jobId: job.id,
+          eventKind: "job_cancelled"
+        }
+      }
+    ]);
+
+    await jobs.stop();
+  });
+
+  it("cancels restartable jobs that are already past the runtime limit on startup", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-state-"));
+    const jobsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-jobs-"));
+    const sessionsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-sessions-"));
+    const reposRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-repos-"));
+    const store = new StateStore(stateDir, sessionsRoot);
+    const sessions = new SessionManager({
+      stateStore: store,
+      sessionsRoot
+    });
+    await sessions.load();
+    const session = await sessions.ensureSession("C123", "111.444");
+    await fs.mkdir(session.workspacePath, { recursive: true });
+    const jobDir = path.join(jobsRoot, "expired-job");
+    const scriptPath = path.join(jobDir, "run.sh");
+    await fs.mkdir(jobDir, { recursive: true });
+    await fs.writeFile(scriptPath, "#!/usr/bin/env bash\nsleep 30\n", { mode: 0o755 });
+
+    await sessions.upsertBackgroundJob({
+      id: "expired-job",
+      token: "job-token",
+      sessionKey: session.key,
+      channelId: session.channelId,
+      rootThreadTs: session.rootThreadTs,
+      kind: "watch_ci",
+      shell: "bash",
+      cwd: session.workspacePath,
+      scriptPath,
+      restartOnBoot: true,
+      status: "running",
+      createdAt: new Date(Date.now() - 1_000).toISOString(),
+      updatedAt: new Date(Date.now() - 1_000).toISOString()
+    });
+
+    const seenEvents: string[] = [];
+    const jobs = new JobManager({
+      sessions,
+      jobsRoot,
+      reposRoot,
+      brokerHttpBaseUrl: "http://127.0.0.1:3000",
+      maxRuntimeMs: 100,
+      onEvent: async (event) => {
+        seenEvents.push(event.payload.eventKind);
+      }
+    });
+
+    await jobs.start();
+
+    expect(sessions.getBackgroundJob("expired-job")).toMatchObject({
+      id: "expired-job",
+      status: "cancelled",
+      cancelledAt: expect.any(String),
+      completedAt: expect.any(String),
+      error: expect.stringContaining("runtime limit")
+    });
+    expect(seenEvents).toEqual(["job_cancelled"]);
+
     await jobs.stop();
   });
 
@@ -275,6 +395,44 @@ async function waitForFileContents(filePath: string): Promise<string> {
   throw new Error(`Timed out waiting for ${filePath}`);
 }
 
+async function waitForJobStatus(
+  sessions: SessionManager,
+  jobId: string,
+  status: string
+): Promise<PersistedBackgroundJob> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const job = sessions.getBackgroundJob(jobId);
+    if (job?.status === status) {
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Timed out waiting for ${jobId} to become ${status}`);
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Timed out waiting for pid ${pid} to exit`);
+}
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'\"'\"'`)}'`;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- add a five-hour broker-managed background job runtime cap
- cancel already-expired restartable jobs during worker startup
- terminate job process groups so timed-out jobs do not leave child processes behind

## Validation
- pnpm exec vitest run test/job-manager.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm build
- manual smoke: registered a job with a 200ms limit and confirmed it cancelled with a runtime-limit event and no live child process
- env -u ADMIN_BASE_URL -u GH_TOKEN -u GITHUB_TOKEN pnpm exec vitest run test/e2e-broker.test.ts -t "starts a fresh turn instead of resyncing back to an older active turn after a active input mismatch reset"

Note: full `pnpm test` was also run. The first run failed because the session environment overrode `ADMIN_BASE_URL`/GitHub token values expected by `test/macos-bootstrap.test.ts`; after unsetting those vars that test passed. A later full run hit one known-looking e2e timing failure, and the failed e2e passed when rerun directly.
