### PR TITLE
Use shared VM home for auth profile runtimes

### DIFF
--- a/docs/proposals/team-codex-home.md
+++ b/docs/proposals/team-codex-home.md
@@ -16,6 +16,13 @@ Separate OpenAI authentication/quota profiles from long-lived team-level Codex b
 
 Observed on the current machine: auth profiles have different `AGENT.md` files, and at least one profile has different `config.toml`. That means memory/config are currently isolated by auth profile, not by team or Slack user.
 
+The per-profile `HOME` is too broad for a broker-dedicated VM. Auth profiles
+only represent Codex account identity and quota. They must not create separate
+Unix user homes, because Go, npm/yarn, Gemini, Git, `gh`, macOS `Library`, and
+other tool caches are machine/runtime state. On the live VM this duplicates
+large caches under every profile and makes disk cleanup harder without adding a
+useful isolation boundary.
+
 ## Proposed state
 
 Add a team-level Codex home:
@@ -32,12 +39,32 @@ Add a team-level Codex home:
   - `superpowers/`
   - `vendor_imports/`
 - Per-profile `CODEX_HOME` remains the app-server home, but those shared entries are symlinked to `CODEX_TEAM_HOME`.
+- App-server processes inherit the VM operator `HOME`. The broker must not
+  derive `HOME` from the per-profile `CODEX_HOME`.
 - Per-profile state remains local to the auth profile:
   - `auth.json`
-  - logs/state/cache/session files
-  - generated images/model cache/runtime scratch files
+  - Codex state that is explicitly stored under that profile's `CODEX_HOME`
 - `CodexBroker` reads personal memory from `CODEX_TEAM_HOME/AGENT.md`, not the profile-local home.
-- `runtime-home/.codex/AGENT.md` points at the same team-level `AGENT.md`.
+- `$HOME/.codex/AGENT.md` points at the same team-level `AGENT.md`.
+- Git commit hooks, broker CLI wrappers, Gemini home, tool caches, and other
+  Unix-home state live in the VM operator home and are shared by all auth
+  profiles.
+
+## GitHub Identity Boundary
+
+Sharing `HOME` must not make all sessions share one GitHub PR account. GitHub PR
+identity is session state, not Unix home state:
+
+- The app-server `PATH` contains the broker-managed `gh` wrapper before the real
+  `gh`.
+- The wrapper resolves `cwd` to a Slack session, then resolves that session's
+  initiator GitHub OAuth binding or selected default PR account.
+- The wrapper execs the real `gh` with only the broker-resolved `GH_TOKEN`.
+- App-server child environments must not inherit global `GH_TOKEN`,
+  `GITHUB_TOKEN`, or `BROKER_DEFAULT_GITHUB_TOKEN`; those would let agent code
+  bypass session-aware identity resolution.
+- GitHub binding device-code login must use a temporary `GH_CONFIG_DIR` and must
+  not inherit global `GH_TOKEN` or `GITHUB_TOKEN`.
 
 ## Migration stance
 
@@ -51,8 +78,16 @@ If `CODEX_TEAM_HOME` is still empty while an existing profile/source home has sh
 
 - `CODEX_TEAM_HOME` is configurable and documented.
 - Different auth profiles resolve shared entries through the same team home.
-- `auth.json` and runtime state remain per-profile and are never linked to the team home.
+- `auth.json` and Codex state under profile `CODEX_HOME` remain per-profile and
+  are never linked to the team home.
+- Different auth profiles keep different `CODEX_HOME` paths but inherit the same
+  VM operator `HOME`.
 - `CodexBroker` injects personal memory from the team home.
 - If the team home is not seeded, existing profile/source memory is preserved and not replaced by empty team files.
 - Updating `CODEX_TEAM_HOME/AGENT.md` is visible to all profiles without editing profile-local files.
+- App-server, helper `codex`, helper `git`, and GitHub device-code child
+  processes do not leak global GitHub tokens into agent-visible environments.
+- Running `gh` from a session still resolves the PR token through the broker
+  wrapper by `cwd`, so session initiators can use different GitHub accounts even
+  though `HOME` is shared.
 - Tests cover team-home symlink cutover and memory path selection.

--- a/docs/session-github-pr-identity.md
+++ b/docs/session-github-pr-identity.md
@@ -173,6 +173,11 @@ Binding uses GitHub CLI:
 The broker must never run this flow against the global `gh` config, because
 binding one Slack user must not mutate the server's operator account.
 
+The broker may run all auth-profile app-servers with the VM operator `HOME`.
+That shared `HOME` is acceptable because GitHub PR identity must not be read
+from global `gh` state. Device-code OAuth uses a temporary `GH_CONFIG_DIR` and
+app-server children must not inherit `GH_TOKEN` or `GITHUB_TOKEN`.
+
 ## Runtime GitHub Identity Resolution
 
 The Codex app-server runtime receives a broker-managed `gh` wrapper before the
@@ -193,6 +198,11 @@ The wrapper:
 8. Execs the real `gh` with `GH_TOKEN` set.
 
 The wrapper must never print or log tokens.
+
+The wrapper must also remove inherited `GH_TOKEN` and `GITHUB_TOKEN` before it
+execs the real `gh`, then set `GH_TOKEN` to the token resolved for the current
+session. This keeps shared VM `HOME` compatible with different threads using
+different GitHub PR accounts.
 
 ## Commit Co-Authors
 
@@ -241,6 +251,10 @@ When a Slack participant is selected as a co-author:
   account when `U_A` is unbound and that default is available.
 - Running `gh` inside the session workspace uses the legacy env default token
   only when `U_A` is unbound and no selected default bound account exists.
+- Sharing the VM operator `HOME` across auth-profile app-servers does not change
+  PR identity selection.
+- Global `GH_TOKEN`/`GITHUB_TOKEN` values are not visible to app-server or
+  device-code child processes.
 - A revoked or invalid bound token blocks instead of silently using the default.
 - A revoked or invalid selected default account blocks instead of silently using
   the legacy env fallback.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-session-broker-repo",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "description": "Slack Socket Mode broker that routes Slack threads into Codex app-server sessions with isolated workspaces.",
   "license": "MIT",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/admin",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Admin service and UI for the agent session broker.",
   "license": "MIT",
   "repository": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/worker",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Worker runtime for the agent session broker.",
   "license": "MIT",
   "repository": {

--- a/src/services/codex/app-server-process.ts
+++ b/src/services/codex/app-server-process.ts
@@ -7,12 +7,18 @@ import type { Readable } from "node:stream";
 
 import { logger } from "../../logger.js";
 import { ensureDir, fileExists } from "../../utils/fs.js";
+import { withoutGlobalGitHubTokenEnv } from "../../utils/github-env.js";
 import { resolveRuntimeToolPath } from "../../utils/runtime-paths.js";
 import { syncUserCodexHome } from "./codex-home.js";
 import { syncGeminiHome } from "./gemini-home.js";
 
 const ALL_MCP_SERVERS = "*";
 const DISABLED_CODEX_APP_SERVER_FEATURES = ["apps"] as const;
+
+function resolveRuntimeHomePath(): string {
+  const envHome = process.env.HOME?.trim();
+  return envHome ? path.resolve(envHome) : os.homedir();
+}
 
 export class AppServerProcess {
   readonly #brokerHttpBaseUrl: string;
@@ -50,7 +56,7 @@ export class AppServerProcess {
     this.#brokerHttpBaseUrl = options.brokerHttpBaseUrl;
     this.#codexHome = options.codexHome;
     this.#teamCodexHomePath = options.teamCodexHomePath;
-    this.#runtimeHome = path.join(path.dirname(options.codexHome), "runtime-home");
+    this.#runtimeHome = resolveRuntimeHomePath();
     this.#port = options.port;
     this.#openAiApiKey = options.openAiApiKey;
     this.#authJsonPath = options.authJsonPath;
@@ -79,7 +85,7 @@ export class AppServerProcess {
     const githubCliWrapper = await this.#ensureGitHubCliWrapper();
     const tempadLinkServiceUrl = await this.#resolveTempadLinkServiceUrl();
 
-    const env: NodeJS.ProcessEnv = {
+    const env: NodeJS.ProcessEnv = withoutGlobalGitHubTokenEnv({
       ...process.env,
       CODEX_HOME: this.#codexHome,
       ...(this.#teamCodexHomePath ? { CODEX_TEAM_HOME: this.#teamCodexHomePath } : {}),
@@ -95,7 +101,7 @@ export class AppServerProcess {
       BROKER_GEMINI_UI_HELPER:
         process.env.BROKER_GEMINI_UI_HELPER?.trim() || resolveRuntimeToolPath("gemini-ui.js"),
       PATH: `${githubCliWrapper.binDir}:${process.env.PATH ?? ""}`
-    };
+    });
 
     if (this.#geminiHttpProxy) {
       env.BROKER_GEMINI_HTTP_PROXY = this.#geminiHttpProxy;
@@ -189,11 +195,7 @@ export class AppServerProcess {
       codexHome: this.#codexHome,
       teamCodexHomePath: this.#teamCodexHomePath,
       hostCodexHomePath: this.#hostCodexHomePath,
-      runtimeHomePath: this.#runtimeHome,
-      legacyPersonalMemoryPath:
-        path.resolve(this.#runtimeHome) === path.resolve(os.homedir())
-        ? undefined
-          : path.join(os.homedir(), ".codex", "AGENT.md")
+      runtimeHomePath: this.#runtimeHome
     });
     await syncGeminiHome({
       runtimeHomePath: this.#runtimeHome,
@@ -215,7 +217,7 @@ export class AppServerProcess {
     }
 
     const candidatePaths = [
-      path.join(os.homedir(), ".codex", "auth.json")
+      path.join(this.#runtimeHome, ".codex", "auth.json")
     ].filter((value): value is string => Boolean(value));
 
     for (const candidate of candidatePaths) {
@@ -305,12 +307,12 @@ export class AppServerProcess {
   }
 
   async #runCodex(args: string[]): Promise<string> {
-    const env: NodeJS.ProcessEnv = {
+    const env: NodeJS.ProcessEnv = withoutGlobalGitHubTokenEnv({
       ...process.env,
       CODEX_HOME: this.#codexHome,
       ...(this.#teamCodexHomePath ? { CODEX_TEAM_HOME: this.#teamCodexHomePath } : {}),
       HOME: this.#runtimeHome
-    };
+    });
 
     if (this.#openAiApiKey) {
       env.OPENAI_API_KEY = this.#openAiApiKey;
@@ -343,10 +345,10 @@ export class AppServerProcess {
   }
 
   async #runGit(args: string[]): Promise<string> {
-    const env: NodeJS.ProcessEnv = {
+    const env: NodeJS.ProcessEnv = withoutGlobalGitHubTokenEnv({
       ...process.env,
       HOME: this.#runtimeHome
-    };
+    });
 
     return await new Promise<string>((resolve, reject) => {
       const child = spawn("git", args, {

--- a/src/services/codex/gemini-home.ts
+++ b/src/services/codex/gemini-home.ts
@@ -42,6 +42,10 @@ export async function syncGeminiHome(options: {
     const sourcePath = path.join(sourceHome, entry);
     const targetPath = path.join(targetHome, entry);
 
+    if (path.resolve(sourcePath) === path.resolve(targetPath)) {
+      continue;
+    }
+
     if (await fileExists(sourcePath)) {
       await fs.copyFile(sourcePath, targetPath);
       continue;

--- a/src/services/github-pr-identity-service.ts
+++ b/src/services/github-pr-identity-service.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import type { SlackSessionRecord } from "../types.js";
 import { ensureDir } from "../utils/fs.js";
+import { withoutGlobalGitHubTokenEnv } from "../utils/github-env.js";
 
 export interface GitHubPrBindingRecord {
   readonly slackUserId: string;
@@ -372,7 +373,7 @@ export class GitHubPrIdentityService {
       this.#githubOAuthScopes.join(",")
     ], {
       env: {
-        ...process.env,
+        ...withoutGlobalGitHubTokenEnv(process.env),
         GH_BROWSER: "echo",
         GH_CONFIG_DIR: ghConfigDir,
         NO_COLOR: "1"
@@ -708,7 +709,7 @@ export class GitHubPrIdentityService {
     return await new Promise<string>((resolve, reject) => {
       const child = spawn(this.#ghPath, [...args], {
         env: {
-          ...process.env,
+          ...withoutGlobalGitHubTokenEnv(process.env),
           GH_CONFIG_DIR: ghConfigDir,
           GH_PROMPT_DISABLED: "1",
           NO_COLOR: "1"

--- a/src/tools/gh.ts
+++ b/src/tools/gh.ts
@@ -2,6 +2,8 @@
 import { spawn } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
+import { withoutGlobalGitHubTokenEnv } from "../utils/github-env.js";
+
 export interface GhWrapperOptions {
   readonly brokerApiBase: string;
   readonly realGhPath: string;
@@ -85,7 +87,7 @@ function runRealGh(options: GhWrapperOptions & {
     const child = spawn(options.realGhPath, [...options.argv], {
       cwd: options.cwd,
       env: {
-        ...options.env,
+        ...withoutGlobalGitHubTokenEnv(options.env),
         GH_TOKEN: options.token
       },
       stdio: ["ignore", "pipe", "pipe"]

--- a/src/utils/github-env.ts
+++ b/src/utils/github-env.ts
@@ -1,0 +1,13 @@
+const GLOBAL_GITHUB_TOKEN_ENV_KEYS = [
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "BROKER_DEFAULT_GITHUB_TOKEN"
+] as const;
+
+export function withoutGlobalGitHubTokenEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const sanitized: NodeJS.ProcessEnv = { ...env };
+  for (const key of GLOBAL_GITHUB_TOKEN_ENV_KEYS) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}

--- a/test/app-server-process.test.ts
+++ b/test/app-server-process.test.ts
@@ -66,13 +66,17 @@ describe("AppServerProcess", () => {
 
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-app-server-process-"));
     const tempadServer = await startHealthyHttpServer();
-    const fakeBinDir = path.join(tempRoot, "bin");
-    const fakeCodexPath = path.join(fakeBinDir, "codex");
-    const argsFile = path.join(tempRoot, "codex-args.txt");
-    const hostCodexHomePath = path.join(tempRoot, "host-codex-home");
-    const hostGeminiHomePath = path.join(tempRoot, "host-gemini-home");
-    const codexHome = path.join(tempRoot, "codex-home");
-    const observedWrites: string[] = [];
+	    const fakeBinDir = path.join(tempRoot, "bin");
+	    const fakeCodexPath = path.join(fakeBinDir, "codex");
+	    const fakeGitPath = path.join(fakeBinDir, "git");
+	    const fakeGhPath = path.join(fakeBinDir, "gh");
+	    const argsFile = path.join(tempRoot, "codex-args.txt");
+	    const hostCodexHomePath = path.join(tempRoot, "host-codex-home");
+	    const hostGeminiHomePath = path.join(tempRoot, "host-gemini-home");
+	    const codexHome = path.join(tempRoot, "codex-home");
+	    const operatorHome = path.join(tempRoot, "operator-home");
+	    const previousHome = process.env.HOME;
+	    const observedWrites: string[] = [];
 
     await fs.mkdir(fakeBinDir, {
       recursive: true
@@ -80,12 +84,15 @@ describe("AppServerProcess", () => {
     await fs.mkdir(hostCodexHomePath, {
       recursive: true
     });
-    await fs.mkdir(hostGeminiHomePath, {
-      recursive: true
-    });
+	    await fs.mkdir(hostGeminiHomePath, {
+	      recursive: true
+	    });
+	    await fs.mkdir(operatorHome, {
+	      recursive: true
+	    });
 
-    await fs.writeFile(
-      fakeCodexPath,
+	    await fs.writeFile(
+	      fakeCodexPath,
       [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
@@ -106,10 +113,15 @@ describe("AppServerProcess", () => {
       {
         mode: 0o755
       }
-    );
-    await fs.chmod(fakeCodexPath, 0o755);
+	    );
+	    await fs.writeFile(fakeGitPath, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+	    await fs.writeFile(fakeGhPath, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+	    await fs.chmod(fakeCodexPath, 0o755);
+	    await fs.chmod(fakeGitPath, 0o755);
+	    await fs.chmod(fakeGhPath, 0o755);
 
-    process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+	    process.env.PATH = `${fakeBinDir}:${originalPath ?? ""}`;
+	    process.env.HOME = operatorHome;
 
     vi.spyOn(process.stdout, "write").mockImplementation(((chunk: string | Uint8Array) => {
       observedWrites.push(typeof chunk === "string" ? chunk : chunk.toString());
@@ -136,11 +148,16 @@ describe("AppServerProcess", () => {
         "--listen",
         "ws://127.0.0.1:4590"
       ]);
-    } finally {
-      await processManager.stop().catch(() => {});
-      await tempadServer.close().catch(() => {});
-      await fs.rm(tempRoot, {
-        force: true,
+	    } finally {
+	      await processManager.stop().catch(() => {});
+	      await tempadServer.close().catch(() => {});
+	      if (previousHome === undefined) {
+	        delete process.env.HOME;
+	      } else {
+	        process.env.HOME = previousHome;
+	      }
+	      await fs.rm(tempRoot, {
+	        force: true,
         recursive: true
       });
     }
@@ -148,6 +165,136 @@ describe("AppServerProcess", () => {
     expect(observedWrites.join("")).toContain(
       "disconnecting slow connection after outbound queue filled: ConnectionId(1)"
     );
+  });
+
+  it("keeps per-profile CODEX_HOME but uses the VM HOME without leaking global GitHub tokens", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-app-server-process-"));
+    const tempadServer = await startHealthyHttpServer();
+    const fakeBinDir = path.join(tempRoot, "bin");
+    const fakeCodexPath = path.join(fakeBinDir, "codex");
+    const fakeGitPath = path.join(fakeBinDir, "git");
+    const fakeGhPath = path.join(fakeBinDir, "gh");
+    const appEnvFile = path.join(tempRoot, "app-env.txt");
+    const gitEnvFile = path.join(tempRoot, "git-env.txt");
+    const operatorHome = path.join(tempRoot, "operator-home");
+    const codexHome = path.join(tempRoot, "auth-profile-runtimes", "profile-a", "codex-home");
+    const hostCodexHomePath = path.join(tempRoot, "host-codex-home");
+    const hostGeminiHomePath = path.join(tempRoot, "host-gemini-home");
+    const previousEnv = {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      GH_TOKEN: process.env.GH_TOKEN,
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      BROKER_DEFAULT_GITHUB_TOKEN: process.env.BROKER_DEFAULT_GITHUB_TOKEN
+    };
+
+    await fs.mkdir(fakeBinDir, { recursive: true });
+    await fs.mkdir(operatorHome, { recursive: true });
+    await fs.mkdir(hostCodexHomePath, { recursive: true });
+    await fs.mkdir(hostGeminiHomePath, { recursive: true });
+
+    await fs.writeFile(
+      fakeCodexPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "if [ \"${1:-}\" = \"app-server\" ]; then",
+        `  { printf 'HOME=%s\\n' "\${HOME-}"; printf 'CODEX_HOME=%s\\n' "\${CODEX_HOME-}"; printf 'GH_TOKEN=%s\\n' "\${GH_TOKEN-}"; printf 'GITHUB_TOKEN=%s\\n' "\${GITHUB_TOKEN-}"; printf 'BROKER_DEFAULT_GITHUB_TOKEN=%s\\n' "\${BROKER_DEFAULT_GITHUB_TOKEN-}"; } > ${shellQuote(appEnvFile)}`,
+        "  printf '%s\\n' 'codex app-server (WebSockets)' >&2",
+        "  printf '%s\\n' '  listening on: ws://127.0.0.1:4592' >&2",
+        "  while true; do sleep 1; done",
+        "fi",
+        "printf 'unexpected fake codex args: %s\\n' \"$*\" >&2",
+        "exit 1",
+        ""
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+    await fs.writeFile(
+      fakeGitPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `printf 'HOME=%s\\nGH_TOKEN=%s\\nGITHUB_TOKEN=%s\\nBROKER_DEFAULT_GITHUB_TOKEN=%s\\n' "\${HOME-}" "\${GH_TOKEN-}" "\${GITHUB_TOKEN-}" "\${BROKER_DEFAULT_GITHUB_TOKEN-}" > ${shellQuote(gitEnvFile)}`,
+        "exit 0",
+        ""
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+    await fs.writeFile(fakeGhPath, "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    await fs.chmod(fakeCodexPath, 0o755);
+    await fs.chmod(fakeGitPath, 0o755);
+    await fs.chmod(fakeGhPath, 0o755);
+
+    process.env.PATH = `${fakeBinDir}:${previousEnv.PATH ?? ""}`;
+    process.env.HOME = operatorHome;
+    process.env.GH_TOKEN = "global-gh-token";
+    process.env.GITHUB_TOKEN = "global-github-token";
+    process.env.BROKER_DEFAULT_GITHUB_TOKEN = "default-pr-token";
+
+    const processManager = new AppServerProcess({
+      brokerHttpBaseUrl: "http://127.0.0.1:3001",
+      codexHome,
+      port: 4592,
+      hostCodexHomePath,
+      hostGeminiHomePath,
+      tempadLinkServiceUrl: tempadServer.url
+    });
+
+    try {
+      await processManager.start();
+      const appEnv = Object.fromEntries(
+        (await fs.readFile(appEnvFile, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => line.split("=", 2))
+      );
+      const gitEnv = Object.fromEntries(
+        (await fs.readFile(gitEnvFile, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => line.split("=", 2))
+      );
+
+      expect(appEnv).toMatchObject({
+        HOME: operatorHome,
+        CODEX_HOME: codexHome,
+        GH_TOKEN: "",
+        GITHUB_TOKEN: "",
+        BROKER_DEFAULT_GITHUB_TOKEN: ""
+      });
+      expect(gitEnv).toMatchObject({
+        HOME: operatorHome,
+        GH_TOKEN: "",
+        GITHUB_TOKEN: "",
+        BROKER_DEFAULT_GITHUB_TOKEN: ""
+      });
+    } finally {
+      await processManager.stop().catch(() => {});
+      await tempadServer.close().catch(() => {});
+      process.env.PATH = previousEnv.PATH;
+      if (previousEnv.HOME === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousEnv.HOME;
+      }
+      if (previousEnv.GH_TOKEN === undefined) {
+        delete process.env.GH_TOKEN;
+      } else {
+        process.env.GH_TOKEN = previousEnv.GH_TOKEN;
+      }
+      if (previousEnv.GITHUB_TOKEN === undefined) {
+        delete process.env.GITHUB_TOKEN;
+      } else {
+        process.env.GITHUB_TOKEN = previousEnv.GITHUB_TOKEN;
+      }
+      if (previousEnv.BROKER_DEFAULT_GITHUB_TOKEN === undefined) {
+        delete process.env.BROKER_DEFAULT_GITHUB_TOKEN;
+      } else {
+        process.env.BROKER_DEFAULT_GITHUB_TOKEN = previousEnv.BROKER_DEFAULT_GITHUB_TOKEN;
+      }
+      await fs.rm(tempRoot, { force: true, recursive: true });
+    }
   });
 
   it("finds app-server listeners in ps output when feature flags appear before --listen", () => {

--- a/test/gemini-home.test.ts
+++ b/test/gemini-home.test.ts
@@ -75,4 +75,19 @@ describe("syncGeminiHome", () => {
 
     await expect(fs.access(path.join(runtimeHome, ".gemini", "oauth_creds.json"))).rejects.toThrow();
   });
+
+  it("does not copy Gemini auth files onto themselves when the runtime HOME is the source HOME", async () => {
+    const runtimeHome = await makeTempDir("gemini-runtime-home-");
+    const geminiHome = path.join(runtimeHome, ".gemini");
+    await fs.mkdir(geminiHome, { recursive: true });
+    await fs.writeFile(path.join(geminiHome, "settings.json"), "{\"selectedAuthType\":\"oauth-personal\"}\n");
+
+    await expect(syncGeminiHome({
+      runtimeHomePath: runtimeHome,
+      hostGeminiHomePath: geminiHome
+    })).resolves.toBeUndefined();
+    await expect(fs.readFile(path.join(geminiHome, "settings.json"), "utf8")).resolves.toContain(
+      "selectedAuthType"
+    );
+  });
 });

--- a/test/gh-wrapper.test.ts
+++ b/test/gh-wrapper.test.ts
@@ -22,15 +22,16 @@ describe("broker gh wrapper", () => {
     cleanups.push(async () => fs.rm(tempRoot, { recursive: true, force: true }));
     const capturePath = path.join(tempRoot, "capture.json");
     const realGhPath = path.join(tempRoot, "real-gh.mjs");
-    await fs.writeFile(realGhPath, [
-      "#!/usr/bin/env node",
-      "import fs from 'node:fs/promises';",
-      "await fs.writeFile(process.env.CAPTURE_PATH, JSON.stringify({",
-      "  argv: process.argv.slice(2),",
-      "  ghToken: process.env.GH_TOKEN,",
-      "  cwd: process.cwd()",
-      "}));"
-    ].join("\n"));
+	    await fs.writeFile(realGhPath, [
+	      "#!/usr/bin/env node",
+	      "import fs from 'node:fs/promises';",
+	      "await fs.writeFile(process.env.CAPTURE_PATH, JSON.stringify({",
+	      "  argv: process.argv.slice(2),",
+	      "  ghToken: process.env.GH_TOKEN,",
+	      "  githubToken: process.env.GITHUB_TOKEN,",
+	      "  cwd: process.cwd()",
+	      "}));"
+	    ].join("\n"));
     await fs.chmod(realGhPath, 0o755);
 
     let resolveRequest: Record<string, unknown> | undefined;
@@ -62,24 +63,28 @@ describe("broker gh wrapper", () => {
       realGhPath,
       cwd: tempRoot,
       argv: ["pr", "create", "--fill"],
-      env: {
-        ...process.env,
-        CAPTURE_PATH: capturePath
-      }
-    });
+	      env: {
+	        ...process.env,
+	        CAPTURE_PATH: capturePath,
+	        GH_TOKEN: "inherited-gh-token",
+	        GITHUB_TOKEN: "inherited-github-token"
+	      }
+	    });
 
     expect(result.status).toBe(0);
     expect(resolveRequest).toMatchObject({
       cwd: tempRoot,
       command: ["pr", "create", "--fill"]
     });
-    const realTempRoot = await fs.realpath(tempRoot);
-    await expect(fs.readFile(capturePath, "utf8").then(JSON.parse)).resolves.toMatchObject({
-      argv: ["pr", "create", "--fill"],
-      ghToken: "starter-token",
-      cwd: realTempRoot
-    });
-  });
+	    const realTempRoot = await fs.realpath(tempRoot);
+	    const captured = JSON.parse(await fs.readFile(capturePath, "utf8")) as Record<string, unknown>;
+	    expect(captured).toMatchObject({
+	      argv: ["pr", "create", "--fill"],
+	      ghToken: "starter-token",
+	      cwd: realTempRoot
+	    });
+	    expect(captured).not.toHaveProperty("githubToken");
+	  });
 
   it("does not call the real gh when broker token resolution blocks", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-gh-wrapper-"));

--- a/test/github-pr-identity-service.test.ts
+++ b/test/github-pr-identity-service.test.ts
@@ -199,18 +199,36 @@ describe("GitHubPrIdentityService", () => {
     });
   });
 
-  it("binds a Slack user through isolated GitHub CLI device login", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-pr-identity-"));
-    cleanups.push(async () => fs.rm(stateDir, { recursive: true, force: true }));
-    const ghConfigPathFile = path.join(stateDir, "fake-gh-config-path");
-    const fakeGhPath = path.join(stateDir, "fake-gh.sh");
-    await fs.writeFile(fakeGhPath, `#!/bin/sh
-set -eu
-if [ "$1 $2" = "auth login" ]; then
-  printf "%s" "$GH_CONFIG_DIR" > ${JSON.stringify(ghConfigPathFile)}
-  echo "! First copy your one-time code: ABCD-EFGH"
-  echo "Open this URL to continue in your web browser: https://github.com/login/device"
-  while [ ! -f "$GH_CONFIG_DIR/complete" ]; do sleep 0.05; done
+	  it("binds a Slack user through isolated GitHub CLI device login", async () => {
+	    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "github-pr-identity-"));
+	    cleanups.push(async () => fs.rm(stateDir, { recursive: true, force: true }));
+	    const ghConfigPathFile = path.join(stateDir, "fake-gh-config-path");
+	    const ghLoginEnvFile = path.join(stateDir, "fake-gh-login-env.json");
+	    const fakeGhPath = path.join(stateDir, "fake-gh.sh");
+	    const previousGhToken = process.env.GH_TOKEN;
+	    const previousGitHubToken = process.env.GITHUB_TOKEN;
+	    process.env.GH_TOKEN = "global-gh-token";
+	    process.env.GITHUB_TOKEN = "global-github-token";
+	    cleanups.push(async () => {
+	      if (previousGhToken === undefined) {
+	        delete process.env.GH_TOKEN;
+	      } else {
+	        process.env.GH_TOKEN = previousGhToken;
+	      }
+	      if (previousGitHubToken === undefined) {
+	        delete process.env.GITHUB_TOKEN;
+	      } else {
+	        process.env.GITHUB_TOKEN = previousGitHubToken;
+	      }
+	    });
+	    await fs.writeFile(fakeGhPath, `#!/bin/sh
+	set -eu
+	if [ "$1 $2" = "auth login" ]; then
+	  printf "%s" "$GH_CONFIG_DIR" > ${JSON.stringify(ghConfigPathFile)}
+	  printf '{"ghToken":"%s","githubToken":"%s","ghConfigDir":"%s"}' "\${GH_TOKEN-}" "\${GITHUB_TOKEN-}" "$GH_CONFIG_DIR" > ${JSON.stringify(ghLoginEnvFile)}
+	  echo "! First copy your one-time code: ABCD-EFGH"
+	  echo "Open this URL to continue in your web browser: https://github.com/login/device"
+	  while [ ! -f "$GH_CONFIG_DIR/complete" ]; do sleep 0.05; done
   exit 0
 fi
 if [ "$1 $2" = "auth status" ]; then
@@ -268,8 +286,13 @@ exit 2
       status: "pending"
     });
 
-    const ghConfigDir = await fs.readFile(ghConfigPathFile, "utf8");
-    await fs.writeFile(path.join(ghConfigDir, "complete"), "ok");
+	    const ghConfigDir = await fs.readFile(ghConfigPathFile, "utf8");
+	    await expect(fs.readFile(ghLoginEnvFile, "utf8").then(JSON.parse)).resolves.toMatchObject({
+	      ghToken: "",
+	      githubToken: "",
+	      ghConfigDir
+	    });
+	    await fs.writeFile(path.join(ghConfigDir, "complete"), "ok");
     let completed: unknown;
     for (let index = 0; index < 20; index += 1) {
       const result = await service.pollDeviceAuthorization(started.id);


### PR DESCRIPTION
## Summary
- keep per-profile CODEX_HOME for auth profile identity while using the VM operator HOME for runtime state
- strip global GitHub token env from app-server/helper/device OAuth children so PR identity stays session-aware
- bump admin and worker packages to 0.1.26

## Verification
- pnpm test
- pnpm build
- pnpm release:pack