### PR TITLE
Fix weekly quota display for single-window responses

### DIFF
--- a/docs/plans/quota-window-role-normalization.md
+++ b/docs/plans/quota-window-role-normalization.md
@@ -1,0 +1,74 @@
+# Quota Window Role Normalization Plan
+
+## Goal
+
+Keep account-pool quota display and automatic auth-profile selection correct when
+ChatGPT returns either the legacy short-plus-weekly window pair or a single
+weekly window in `primary_window`.
+
+## Current state
+
+The upstream `wham/usage` response for the affected Pro account is healthy and
+contains a 10,080-minute window with 52 percent used, but it places that window
+in `primary_window` and returns `secondary_window: null`.
+
+The broker currently assigns meaning by response position:
+
+- `primary` is treated as the short window;
+- `secondary` is treated as the weekly window.
+
+That assumption makes the admin top bar and account card report unknown weekly
+quota even though the upstream response contains it. Auth-profile ranking also
+falls back to an unweighted primary percentage instead of the weekly refresh
+score.
+
+## Proposed changes
+
+1. Add an end-to-end regression that carries the live single-window response
+   shape from the ChatGPT usage adapter through the user-facing account-pool
+   formatter and auth-profile evaluator.
+2. Introduce one shared quota-window role resolver that recognizes a weekly
+   window from a valid `windowDurationMins` within five percent of 10,080
+   minutes before considering the legacy primary/secondary position:
+   - a unique duration-matched weekly window wins regardless of whether the
+     upstream response places it in `primary` or `secondary`;
+   - the other window, when present, is the short/other window;
+   - when neither or both windows match weekly, retain the legacy
+     `primary=short` and `secondary=weekly` fallback;
+   - a single primary daily, monthly, or otherwise non-weekly window is not
+     mislabeled or scored as weekly.
+3. Remove direct weekly reads from `secondary` in quota formatting, account
+   cards, top-bar items, and auth-profile scoring. Route those consumers through
+   the shared resolver instead.
+4. Preserve exhaustion checks for every raw upstream window so a depleted short
+   or weekly limit still makes a profile unavailable.
+
+## If we do not change it
+
+The admin UI will continue to show `账号池额度未知`, `7d 剩余 --`, score `0`,
+and an unknown reset time for valid single-weekly-window accounts. With multiple
+accounts, automatic profile selection may also rank those accounts using the
+wrong score.
+
+## Expected result
+
+The current single-weekly-window response displays the real remaining
+percentage, weighted score, and reset time. Legacy 5-hour plus 7-day responses
+keep their existing display and selection behavior, while generalized
+non-weekly windows are not relabeled as weekly. The external admin and upstream
+API contracts do not change.
+
+## Acceptance criteria
+
+- A live-shaped `primary=10,080 minutes`, `secondary=null` response renders 48
+  percent remaining and a known reset time instead of unknown quota.
+- The same response receives a weekly refresh-weighted selection score.
+- Legacy `primary=300 minutes`, `secondary=10,080 minutes` behavior remains
+  covered and unchanged.
+- Reversed duration-bearing window positions resolve by duration, not position.
+- A single monthly primary window does not become the weekly quota.
+- Exhausting either raw upstream window still marks the profile unavailable.
+- Targeted unit and end-to-end tests, lint, type checking/build, and a manual
+  local admin-page smoke test pass.
+- The change is delivered as a draft pull request and is not deployed
+  automatically.

--- a/src/admin-ui/admin-shell-helpers-3.tsx
+++ b/src/admin-ui/admin-shell-helpers-3.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
-import { formatAuthQuotaDisplay, formatWeightedWeeklyQuotaScore, remainingPercent, weightedWeeklyQuotaScore, daysUntilReset } from "../auth-profile-quota";
+import { formatAuthQuotaDisplayParts, formatWeightedWeeklyQuotaScore, remainingPercent, weightedWeeklyQuotaScore, daysUntilReset } from "../auth-profile-quota";
 
 import { profileAccountLabel, profilePlanLabel, profileTitle } from "./auth-profile-display";
 
@@ -133,23 +133,21 @@ export function profileQuotaSummary(rateLimits: any): ProfileQuotaSummary {
   }
 
   const snapshot = rateLimits.rateLimits || {};
-  const secondary = snapshot.secondary || {};
-  const fullLabel =
-    formatAuthQuotaDisplay({
-      primary: snapshot.primary,
-      secondary,
-    }) || "额度未知";
-  const [weeklyLabel, ...shortParts] = fullLabel.split(" | ");
-  const remaining = remainingPercent(secondary.usedPercent);
-  const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(secondary.resetsAt));
+  const display = formatAuthQuotaDisplayParts({
+    primary: snapshot.primary,
+    secondary: snapshot.secondary,
+  });
+  const weekly = display.windows.weekly;
+  const remaining = remainingPercent(weekly?.usedPercent);
+  const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(weekly?.resetsAt));
   return {
     ok: true,
-    fullLabel,
+    fullLabel: display.fullLabel || "额度未知",
     remainingLabel: remaining === undefined ? "--" : `${Math.round(remaining)}%`,
     scoreLabel: formatWeightedWeeklyQuotaScore(score),
-    resetLabel: formatResetTime(secondary.resetsAt),
-    shortLabel: shortParts.length ? shortParts.join(" | ") : null,
-    tone: quotaTone(remaining ?? 100) || (weeklyLabel ? "" : "warn"),
+    resetLabel: formatResetTime(weekly?.resetsAt),
+    shortLabel: display.shortLabel,
+    tone: quotaTone(remaining ?? 100) || (display.weeklyLabel ? "" : "warn"),
   };
 }
 
@@ -318,16 +316,16 @@ export function authProfileQuotaItems(profiles: readonly Record<string, any>[]):
       const rateLimits = profile.rateLimits || {};
       if (rateLimits.ok === false) return null;
       const limits = rateLimits.rateLimits || {};
-      const secondary = limits.secondary;
-      const label = formatAuthQuotaDisplay({
+      const display = formatAuthQuotaDisplayParts({
         primary: limits.primary,
-        secondary,
+        secondary: limits.secondary,
       });
-      if (!label) return null;
-      const remaining = remainingPercent(secondary?.usedPercent);
-      const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(secondary?.resetsAt));
+      if (!display.fullLabel) return null;
+      const weekly = display.windows.weekly;
+      const remaining = remainingPercent(weekly?.usedPercent);
+      const score = weightedWeeklyQuotaScore(remaining, daysUntilReset(weekly?.resetsAt));
       return {
-        label,
+        label: display.fullLabel,
         title: profileTitle(profile),
         score: score ?? -1,
         remaining: remaining ?? 0,

--- a/src/auth-profile-quota.ts
+++ b/src/auth-profile-quota.ts
@@ -4,6 +4,18 @@ export const MIN_REFRESH_DAYS = 1 / (24 * 60);
 export const DEFAULT_SHORT_WINDOW_MINS = 300;
 export const DEFAULT_WEEKLY_WINDOW_MINS = 10_080;
 export const SHORT_WINDOW_DISPLAY_SCORE_THRESHOLD = 0.5;
+const WEEKLY_WINDOW_DURATION_TOLERANCE = 0.05;
+
+export interface QuotaWindowLike {
+  readonly usedPercent?: unknown;
+  readonly resetsAt?: unknown;
+  readonly windowDurationMins?: unknown;
+}
+
+export interface QuotaWindowRoles<Window extends QuotaWindowLike = QuotaWindowLike> {
+  readonly weekly: Window | null;
+  readonly short: Window | null;
+}
 
 export function remainingPercent(usedPercent: unknown): number | undefined {
   const used = Number(usedPercent);
@@ -79,43 +91,68 @@ export function formatQuotaWindowDisplay(options: { readonly usedPercent: unknow
   return `${formatWindowDuration(windowMins)} ${Math.round(remaining)}% / ${formatWeightedWeeklyQuotaScore(score)}`;
 }
 
-export function formatAuthQuotaDisplay(options: {
-  readonly primary?:
-    | {
-        readonly usedPercent?: unknown;
-        readonly resetsAt?: unknown;
-        readonly windowDurationMins?: unknown;
-      }
-    | null
-    | undefined;
-  readonly secondary?:
-    | {
-        readonly usedPercent?: unknown;
-        readonly resetsAt?: unknown;
-        readonly windowDurationMins?: unknown;
-      }
-    | null
-    | undefined;
+export function resolveQuotaWindowRoles<Window extends QuotaWindowLike>(options: { readonly primary?: Window | null | undefined; readonly secondary?: Window | null | undefined }): QuotaWindowRoles<Window> {
+  const primary = options.primary ?? null;
+  const secondary = options.secondary ?? null;
+  const primaryIsWeekly = isWeeklyQuotaWindow(primary);
+  const secondaryIsWeekly = isWeeklyQuotaWindow(secondary);
+
+  if (primaryIsWeekly !== secondaryIsWeekly) {
+    return primaryIsWeekly
+      ? {
+          weekly: primary,
+          short: secondary,
+        }
+      : {
+          weekly: secondary,
+          short: primary,
+        };
+  }
+
+  return {
+    weekly: secondary,
+    short: primary,
+  };
+}
+
+export function formatAuthQuotaDisplayParts<Window extends QuotaWindowLike>(options: {
+  readonly primary?: Window | null | undefined;
+  readonly secondary?: Window | null | undefined;
   readonly now?: Date | number | string | undefined;
-}): string | null {
-  const weekly = formatQuotaWindowDisplay({
-    usedPercent: options.secondary?.usedPercent,
-    resetsAt: options.secondary?.resetsAt,
-    windowDurationMins: options.secondary?.windowDurationMins,
+}): {
+  readonly fullLabel: string | null;
+  readonly weeklyLabel: string | null;
+  readonly shortLabel: string | null;
+  readonly windows: QuotaWindowRoles<Window>;
+} {
+  const windows = resolveQuotaWindowRoles(options);
+  const weeklyLabel = formatQuotaWindowDisplay({
+    usedPercent: windows.weekly?.usedPercent,
+    resetsAt: windows.weekly?.resetsAt,
+    windowDurationMins: windows.weekly?.windowDurationMins,
     fallbackWindowDurationMins: DEFAULT_WEEKLY_WINDOW_MINS,
     now: options.now,
   });
-  const short = shouldShowShortWindowQuota(options.primary, options.now)
+  const shortLabel = shouldShowShortWindowQuota(windows.short, options.now)
     ? formatQuotaWindowDisplay({
-        usedPercent: options.primary?.usedPercent,
-        resetsAt: options.primary?.resetsAt,
-        windowDurationMins: options.primary?.windowDurationMins,
+        usedPercent: windows.short?.usedPercent,
+        resetsAt: windows.short?.resetsAt,
+        windowDurationMins: windows.short?.windowDurationMins,
         fallbackWindowDurationMins: DEFAULT_SHORT_WINDOW_MINS,
         now: options.now,
       })
     : null;
-  const parts = [weekly, short].filter(Boolean);
-  return parts.length ? parts.join(" | ") : null;
+  const parts = [weeklyLabel, shortLabel].filter(Boolean);
+  return {
+    fullLabel: parts.length ? parts.join(" | ") : null,
+    weeklyLabel,
+    shortLabel,
+    windows,
+  };
+}
+
+export function formatAuthQuotaDisplay(options: { readonly primary?: QuotaWindowLike | null | undefined; readonly secondary?: QuotaWindowLike | null | undefined; readonly now?: Date | number | string | undefined }): string | null {
+  return formatAuthQuotaDisplayParts(options).fullLabel;
 }
 
 export function shouldShowShortWindowQuota(
@@ -168,6 +205,16 @@ export function timestampMs(value: Date | number | string | undefined): number {
 function normalizeWindowDurationMins(value: unknown, fallback: number): number {
   const mins = Number(value);
   return Number.isFinite(mins) && mins > 0 ? mins : fallback;
+}
+
+function isWeeklyQuotaWindow(window: QuotaWindowLike | null): boolean {
+  const minutes = Number(window?.windowDurationMins);
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return false;
+  }
+
+  const tolerance = DEFAULT_WEEKLY_WINDOW_MINS * WEEKLY_WINDOW_DURATION_TOLERANCE;
+  return minutes >= DEFAULT_WEEKLY_WINDOW_MINS - tolerance && minutes <= DEFAULT_WEEKLY_WINDOW_MINS + tolerance;
 }
 
 function formatWindowDuration(windowMins: number): string {

--- a/src/services/session-auth-profile-selector.ts
+++ b/src/services/session-auth-profile-selector.ts
@@ -1,5 +1,5 @@
 import type { AuthProfileSummary, AuthProfilesStatus } from "./auth-profile-service.js";
-import { daysUntilReset, remainingPercent, timestampMs, weightedWeeklyQuotaScore } from "../auth-profile-quota.js";
+import { daysUntilReset, remainingPercent, resolveQuotaWindowRoles, timestampMs, weightedWeeklyQuotaScore } from "../auth-profile-quota.js";
 
 export type AuthProfileUnavailableReason = "profile_not_found" | "account_probe_failed" | "rate_limits_probe_failed" | "primary_quota_exhausted" | "secondary_quota_exhausted" | "credits_exhausted" | "no_usable_auth_profiles";
 
@@ -10,7 +10,10 @@ export interface AuthProfileEvaluation {
   readonly effectiveQuotaScore: number;
   readonly primaryRemainingPercent?: number | undefined;
   readonly secondaryRemainingPercent?: number | undefined;
+  readonly weeklyRemainingPercent?: number | undefined;
+  readonly shortRemainingPercent?: number | undefined;
   readonly secondaryRefreshDays?: number | undefined;
+  readonly weeklyRefreshDays?: number | undefined;
   readonly weightedWeeklyQuotaScore?: number | undefined;
 }
 
@@ -36,14 +39,14 @@ export function selectBestAuthProfile(status: AuthProfilesStatus, options: { rea
         return scoreDelta;
       }
 
-      const secondaryDelta = (right.evaluation.secondaryRemainingPercent ?? 100) - (left.evaluation.secondaryRemainingPercent ?? 100);
-      if (secondaryDelta) {
-        return secondaryDelta;
+      const weeklyDelta = (right.evaluation.weeklyRemainingPercent ?? 100) - (left.evaluation.weeklyRemainingPercent ?? 100);
+      if (weeklyDelta) {
+        return weeklyDelta;
       }
 
-      const primaryDelta = (right.evaluation.primaryRemainingPercent ?? 100) - (left.evaluation.primaryRemainingPercent ?? 100);
-      if (primaryDelta) {
-        return primaryDelta;
+      const shortDelta = (right.evaluation.shortRemainingPercent ?? 100) - (left.evaluation.shortRemainingPercent ?? 100);
+      if (shortDelta) {
+        return shortDelta;
       }
 
       return left.profile.name.localeCompare(right.profile.name);
@@ -68,8 +71,14 @@ export function evaluateAuthProfile(profile: AuthProfileSummary, options: { read
   const limits = profile.rateLimits.rateLimits;
   const primaryRemaining = remainingPercent(limits?.primary?.usedPercent);
   const secondaryRemaining = remainingPercent(limits?.secondary?.usedPercent);
-  const secondaryRefreshDays = daysUntilReset(limits?.secondary?.resetsAt, timestampMs(options.now));
-  const weightedWeeklyQuota = weightedWeeklyQuotaScore(secondaryRemaining, secondaryRefreshDays);
+  const windows = resolveQuotaWindowRoles({
+    primary: limits?.primary,
+    secondary: limits?.secondary,
+  });
+  const weeklyRemaining = remainingPercent(windows.weekly?.usedPercent);
+  const shortRemaining = remainingPercent(windows.short?.usedPercent);
+  const weeklyRefreshDays = daysUntilReset(windows.weekly?.resetsAt, timestampMs(options.now));
+  const weightedWeeklyQuota = weightedWeeklyQuotaScore(weeklyRemaining, weeklyRefreshDays);
   const credits = limits?.credits;
 
   if (primaryRemaining !== undefined && primaryRemaining <= 0) {
@@ -96,10 +105,13 @@ export function evaluateAuthProfile(profile: AuthProfileSummary, options: { read
   return {
     profileName: profile.name,
     usable: true,
-    effectiveQuotaScore: weightedWeeklyQuota ?? (secondaryRemaining !== undefined ? secondaryRemaining / 100 : undefined) ?? (primaryRemaining !== undefined ? primaryRemaining / 100 : undefined) ?? 1,
+    effectiveQuotaScore: weightedWeeklyQuota ?? (weeklyRemaining !== undefined ? weeklyRemaining / 100 : undefined) ?? (shortRemaining !== undefined ? shortRemaining / 100 : undefined) ?? 1,
     primaryRemainingPercent: primaryRemaining,
     secondaryRemainingPercent: secondaryRemaining,
-    secondaryRefreshDays,
+    weeklyRemainingPercent: weeklyRemaining,
+    shortRemainingPercent: shortRemaining,
+    secondaryRefreshDays: daysUntilReset(limits?.secondary?.resetsAt, timestampMs(options.now)),
+    weeklyRefreshDays,
     weightedWeeklyQuotaScore: weightedWeeklyQuota,
   };
 }

--- a/test/admin-quota-window.e2e.test.tsx
+++ b/test/admin-quota-window.e2e.test.tsx
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AuthProfilesPanel } from "../src/admin-ui/admin-shell-helpers-1.js";
+import { TopbarQuota } from "../src/admin-ui/admin-shell-helpers-2.js";
+import { authProfileQuotaItems, profileQuotaSummary } from "../src/admin-ui/admin-shell-helpers-3.js";
+import { profileQuotaLabel } from "../src/admin-ui/auth-profile-display.js";
+import { serializeRateLimits } from "../src/services/codex/account-status.js";
+import { readChatGptUsageSnapshot, type ChatGptUsageSnapshot } from "../src/services/codex/chatgpt-usage-api.js";
+import { evaluateAuthProfile } from "../src/services/session-auth-profile-selector.js";
+import type { AuthProfileSummary } from "../src/services/auth-profile-service.js";
+
+describe("admin quota window end to end", () => {
+  const tempDirs: string[] = [];
+  const now = new Date("2026-08-14T08:00:00.000Z");
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+  });
+
+  it("renders and scores a single weekly primary window from the live usage shape", async () => {
+    const authJsonPath = await writeAuthJson({
+      tokens: {
+        access_token: "active-access-token",
+        account_id: "account-1",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          email: "operator@example.com",
+          plan_type: "pro",
+          rate_limit: {
+            allowed: true,
+            limit_reached: false,
+            primary_window: {
+              used_percent: 52,
+              limit_window_seconds: 604_800,
+              reset_after_seconds: 509_396,
+              reset_at: 1_787_203_912,
+            },
+            secondary_window: null,
+          },
+          additional_rate_limits: [],
+        }),
+      ),
+    );
+
+    const usage = await readChatGptUsageSnapshot(authJsonPath);
+    const profile = authProfile(usage.account, serializeRateLimits(usage.rateLimits));
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    expect(profileQuotaLabel(profile, { now })).toBe("7d 48% / 0.57");
+    const quotaSummary = profileQuotaSummary(profile.rateLimits);
+    expect(quotaSummary).toEqual({
+      ok: true,
+      fullLabel: "7d 48% / 0.57",
+      remainingLabel: "48%",
+      scoreLabel: "0.57",
+      resetLabel: "6 天后",
+      shortLabel: null,
+      tone: "",
+    });
+    expect(authProfileQuotaItems([profile])).toMatchObject([
+      {
+        label: "7d 48% / 0.57",
+        remaining: 48,
+      },
+    ]);
+    const cardMarkup = renderToStaticMarkup(
+      <AuthProfilesPanel
+        status={{
+          authProfiles: {
+            profiles: [profile],
+          },
+        }}
+        message={null}
+        setMessage={() => {}}
+        onAdd={() => {}}
+      />,
+    );
+    expect(cardMarkup).toContain("账号池");
+    expect(cardMarkup).toContain("operator@example.com");
+    expect(cardMarkup).toContain("7d 剩余");
+    expect(cardMarkup).toContain("48%");
+    expect(cardMarkup).toContain("0.57");
+    expect(cardMarkup).toContain("6 天后");
+    expect(cardMarkup).not.toContain("--");
+    expect(cardMarkup).not.toContain("未知");
+
+    const topbarMarkup = renderToStaticMarkup(<TopbarQuota profiles={[profile]} />);
+    expect(topbarMarkup).toContain("7d 48% / 0.57");
+    expect(topbarMarkup).not.toContain("账号池额度未知");
+
+    const evaluation = evaluateAuthProfile(profile, { now });
+    expect(evaluation.usable).toBe(true);
+    expect(evaluation.weightedWeeklyQuotaScore).toBeCloseTo(0.57, 2);
+    expect(evaluation.effectiveQuotaScore).toBeCloseTo(0.57, 2);
+  });
+
+  async function writeAuthJson(content: Record<string, unknown>): Promise<string> {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "admin-quota-window-"));
+    tempDirs.push(directory);
+    const authJsonPath = path.join(directory, "auth.json");
+    await fs.writeFile(authJsonPath, JSON.stringify(content), "utf8");
+    return authJsonPath;
+  }
+});
+
+function authProfile(account: ChatGptUsageSnapshot["account"], rateLimits: AuthProfileSummary["rateLimits"]): AuthProfileSummary {
+  return {
+    name: "profile-1",
+    path: "/tmp/auth-profiles/profile-1.json",
+    source: "probe",
+    checkedAt: "2026-08-14T08:00:00.000Z",
+    account: {
+      ok: true,
+      account,
+      requiresOpenaiAuth: false,
+    },
+    rateLimits,
+  };
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/test/auth-profile-quota.test.ts
+++ b/test/auth-profile-quota.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_WEEKLY_WINDOW_MINS, resolveQuotaWindowRoles } from "../src/auth-profile-quota.js";
+
+describe("resolveQuotaWindowRoles", () => {
+  it("recognizes a single weekly primary window", () => {
+    const primary = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS);
+
+    expect(resolveQuotaWindowRoles({ primary, secondary: null })).toEqual({
+      weekly: primary,
+      short: null,
+    });
+  });
+
+  it("keeps the legacy short-primary and weekly-secondary pair", () => {
+    const primary = quotaWindow(300);
+    const secondary = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS);
+
+    expect(resolveQuotaWindowRoles({ primary, secondary })).toEqual({
+      weekly: secondary,
+      short: primary,
+    });
+  });
+
+  it("finds weekly and short windows when upstream reverses their positions", () => {
+    const primary = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS);
+    const secondary = quotaWindow(300);
+
+    expect(resolveQuotaWindowRoles({ primary, secondary })).toEqual({
+      weekly: primary,
+      short: secondary,
+    });
+  });
+
+  it("accepts the upstream weekly duration tolerance", () => {
+    const lowerBound = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS * 0.95);
+    const upperBound = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS * 1.05);
+
+    expect(resolveQuotaWindowRoles({ primary: lowerBound, secondary: null }).weekly).toBe(lowerBound);
+    expect(resolveQuotaWindowRoles({ primary: upperBound, secondary: null }).weekly).toBe(upperBound);
+  });
+
+  it("rejects durations immediately outside the weekly tolerance", () => {
+    const belowLowerBound = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS * 0.95 - 1);
+    const aboveUpperBound = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS * 1.05 + 1);
+
+    expect(resolveQuotaWindowRoles({ primary: belowLowerBound, secondary: null })).toEqual({
+      weekly: null,
+      short: belowLowerBound,
+    });
+    expect(resolveQuotaWindowRoles({ primary: aboveUpperBound, secondary: null })).toEqual({
+      weekly: null,
+      short: aboveUpperBound,
+    });
+  });
+
+  it("uses legacy positions when both windows look weekly", () => {
+    const primary = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS);
+    const secondary = quotaWindow(DEFAULT_WEEKLY_WINDOW_MINS);
+
+    expect(resolveQuotaWindowRoles({ primary, secondary })).toEqual({
+      weekly: secondary,
+      short: primary,
+    });
+  });
+
+  it("does not reinterpret a single monthly primary window as weekly", () => {
+    const primary = quotaWindow(30 * 24 * 60);
+
+    expect(resolveQuotaWindowRoles({ primary, secondary: null })).toEqual({
+      weekly: null,
+      short: primary,
+    });
+  });
+
+  it("falls back to legacy positions when durations do not identify weekly", () => {
+    const primary = quotaWindow(null);
+    const secondary = quotaWindow(null);
+
+    expect(resolveQuotaWindowRoles({ primary, secondary })).toEqual({
+      weekly: secondary,
+      short: primary,
+    });
+    expect(resolveQuotaWindowRoles({ primary, secondary: null })).toEqual({
+      weekly: null,
+      short: primary,
+    });
+    expect(resolveQuotaWindowRoles({ primary: null, secondary })).toEqual({
+      weekly: secondary,
+      short: null,
+    });
+  });
+});
+
+function quotaWindow(windowDurationMins: number | null) {
+  return {
+    usedPercent: 52,
+    windowDurationMins,
+    resetsAt: 1_787_203_912,
+  };
+}

--- a/test/session-auth-profile-selector.test.ts
+++ b/test/session-auth-profile-selector.test.ts
@@ -103,6 +103,29 @@ describe("session auth profile selector", () => {
     ).toBeCloseTo(2);
   });
 
+  it("weights and selects a single weekly window returned in primary", () => {
+    const halfWeek = Math.floor((now.getTime() + 3.5 * 24 * 60 * 60 * 1000) / 1000);
+    const fullWeek = Math.floor((now.getTime() + 7 * 24 * 60 * 60 * 1000) / 1000);
+    const status = profileStatus([
+      profile("single-weekly-primary", {
+        primaryUsed: 52,
+        primaryDurationMins: 10_080,
+        primaryResetsAt: halfWeek,
+        secondaryUsed: null,
+      }),
+      profile("legacy-weekly-secondary", {
+        primaryUsed: 0,
+        secondaryUsed: 40,
+        secondaryResetsAt: fullWeek,
+      }),
+    ]);
+
+    const singleWeekly = evaluateAuthProfile(status.profiles[0]!, { now });
+    expect(singleWeekly.weightedWeeklyQuotaScore).toBeCloseTo(0.96);
+    expect(singleWeekly.effectiveQuotaScore).toBeCloseTo(0.96);
+    expect(selectBestAuthProfile(status, { now })?.name).toBe("single-weekly-primary");
+  });
+
   it("marks a profile unavailable when either quota window is exhausted", () => {
     expect(
       evaluateAuthProfile(
@@ -142,7 +165,10 @@ function profile(
   name: string,
   options: {
     readonly primaryUsed?: number | undefined;
-    readonly secondaryUsed?: number | undefined;
+    readonly primaryDurationMins?: number | undefined;
+    readonly primaryResetsAt?: number | undefined;
+    readonly secondaryUsed?: number | null | undefined;
+    readonly secondaryDurationMins?: number | undefined;
     readonly secondaryResetsAt?: number | undefined;
     readonly rateLimitsOk?: boolean | undefined;
   } = {},
@@ -170,14 +196,17 @@ function profile(
             limitName: "Codex",
             primary: {
               usedPercent: options.primaryUsed ?? 0,
-              windowDurationMins: 300,
-              resetsAt: 1_779_000_000,
+              windowDurationMins: options.primaryDurationMins ?? 300,
+              resetsAt: options.primaryResetsAt ?? 1_779_000_000,
             },
-            secondary: {
-              usedPercent: options.secondaryUsed ?? 0,
-              windowDurationMins: 10_080,
-              resetsAt: options.secondaryResetsAt ?? 1_780_000_000,
-            },
+            secondary:
+              options.secondaryUsed === null
+                ? null
+                : {
+                    usedPercent: options.secondaryUsed ?? 0,
+                    windowDurationMins: options.secondaryDurationMins ?? 10_080,
+                    resetsAt: options.secondaryResetsAt ?? 1_780_000_000,
+                  },
             credits: null,
             planType: "pro",
           },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts"],
+    include: ["test/**/*.test.{ts,tsx}"],
     exclude: ["**/node_modules/**", "**/dist/**", "**/.data*/**", "**/runtime-home/**", "**/worktrees/**"],
   },
 });


### PR DESCRIPTION
## Summary
- resolve the weekly quota window by reported duration instead of assuming it is always secondary_window
- use the resolved weekly/short roles in account-pool cards, the top bar, and auth-profile ranking
- add live-shaped React E2E coverage and duration compatibility tests

## Validation
- pnpm format:check
- pnpm lint
- pnpm build
- pnpm test — 97 files, 797 tests
- manual isolated admin UI smoke: a single 7-day primary_window renders 48%, weighted score, and reset time; the legacy 5h + 7d pair remains unchanged

No deployment is included.
