### PR TITLE
Restore disk cleanup safety guards

### DIFF
--- a/docs/plans/disk-cleanup-live-hotfix-restoration.md
+++ b/docs/plans/disk-cleanup-live-hotfix-restoration.md
@@ -1,0 +1,82 @@
+# Disk Cleanup Live Hotfix Restoration Plan
+
+## Goal
+
+Restore the live worker's disk-cleanup safety behavior in source before the
+next package release, so a normal npm deployment cannot replace the current
+manual hotfix with less safe cleanup code.
+
+## Current state
+
+Production is running the worker from
+`npm-0.1.26-hotfix-process-guard-20260804T1247Z`. Compared with the published
+`@agent-session-broker/worker@0.1.26`, that release changes exactly one compiled
+runtime file: `disk-pressure-cleanup-service.js`.
+
+The live-only behavior has two parts:
+
+- cleanup candidate, deletion, and failure detail logs are sampled to five
+  entries per category, followed by aggregate counts and byte totals;
+- before destructive session or cache cleanup, the worker inspects running
+  process commands once and protects session and job roots that a process still
+  references. If process inspection fails, session and cache deletion fails
+  closed.
+
+Neither behavior exists in the source on `main`, in a reachable remote branch,
+or in a prior pull request. PR #75 does not overlap the cleanup implementation
+or tests.
+
+## Proposed changes
+
+1. Add regression tests for the live safety contract before changing the
+   implementation:
+   - a referenced session root protects inactive-session deletion;
+   - a referenced job root protects both session and cache cleanup;
+   - failed process inspection skips destructive session/cache cleanup;
+   - dry runs do not need process inspection;
+   - cleanup detail logs stop at five samples while aggregate counts and bytes
+     describe the full operation.
+2. Remove the current unguarded calls that delete inactive sessions and expired
+   caches without process evidence.
+3. Add an injectable process-command provider whose production default runs
+   `/bin/ps -axo command=`. Read it once per non-dry-run cleanup pass, pass the
+   result into session/cache candidate filtering, and fail closed when it
+   cannot be read.
+4. Bound per-item cleanup logging and emit aggregate summaries. Reuse file
+   sizes gathered during log discovery instead of restatting every old log.
+5. Keep configuration, state schema, admin APIs, and cleanup thresholds
+   unchanged. Deliver this restoration independently from quota display and
+   release-version changes.
+
+## If we do not change it
+
+Publishing and deploying a clean package from current source would overwrite
+the production-only hotfix. A cleanup pass could delete a session or cache
+directory that a still-running process references, and a large cleanup could
+again emit unbounded per-item logs.
+
+## Expected result
+
+Source builds reproduce the live worker's safety behavior. Destructive cleanup
+continues for eligible, unreferenced stale data, but skips referenced roots and
+fails closed when running processes cannot be inspected. Large cleanup passes
+retain bounded diagnostic samples plus complete aggregate telemetry.
+
+## Acceptance criteria
+
+- New focused tests fail on the current unguarded implementation and pass after
+  the restoration.
+- Process commands are read once for a non-dry-run cleanup pass and not read for
+  a dry run.
+- A command referencing the session root or one of its background-job roots
+  prevents that session's cache and inactive-session deletion.
+- A process inspection error logs the fail-closed reason and deletes no session
+  cache or inactive session; old-log cleanup remains independent.
+- Candidate, deletion, and failure detail logs are capped at five per cleanup
+  category, with aggregate counts and byte totals for the full operation.
+- Targeted tests, full tests, formatting, lint, build, and release packaging
+  pass.
+- A manual test using isolated temporary roots and an injected process-command
+  provider confirms referenced data remains and unreferenced data is removed.
+- The implementation is delivered as a separate draft pull request. No npm
+  release or production deployment is triggered by this change.

--- a/src/services/disk-pressure-cleanup-service.ts
+++ b/src/services/disk-pressure-cleanup-service.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { AppConfig } from "../config.js";
 import { getJobLogDirectory, getSessionLogDirectory, logger } from "../logger.js";
 import type { PersistedBackgroundJob, PersistedInboundMessage, SlackSessionRecord } from "../types.js";
+import { execCommand } from "../utils/exec.js";
 import { ensureDir } from "../utils/fs.js";
 import type { SessionManager } from "./session-manager.js";
 
@@ -37,10 +38,12 @@ interface BackgroundJobTerminator {
 }
 
 type StatFsProvider = (targetPath: string) => Promise<DiskUsage>;
+type ProcessCommandProvider = () => Promise<readonly string[]>;
 
 const PROTECTED_JOB_STATUSES = new Set(["registered", "running"]);
 const DARWIN_SESSION_CACHE_RELATIVE_PATHS = ["frontend/macos/.build/DerivedData", "frontend/macos/default.profraw", "frontend/macos/xcodebuild.log", "default.profraw"] as const;
 const CROSS_PLATFORM_SESSION_CACHE_RELATIVE_PATHS = ["web/node_modules", "workers/node_modules"] as const;
+const CLEANUP_DETAIL_LOG_LIMIT = 5;
 
 export class DiskPressureCleanupService {
   readonly #config: AppConfig;
@@ -48,16 +51,26 @@ export class DiskPressureCleanupService {
   readonly #jobTerminator: BackgroundJobTerminator | undefined;
   readonly #now: () => Date;
   readonly #statFs: StatFsProvider;
+  readonly #processCommandProvider: ProcessCommandProvider;
   readonly #isDarwin: boolean;
   #timer: NodeJS.Timeout | undefined;
   #running = false;
 
-  constructor(options: { readonly config: AppConfig; readonly sessions: SessionManager; readonly jobTerminator?: BackgroundJobTerminator | undefined; readonly now?: (() => Date) | undefined; readonly statFs?: StatFsProvider | undefined; readonly isDarwin?: boolean | undefined }) {
+  constructor(options: {
+    readonly config: AppConfig;
+    readonly sessions: SessionManager;
+    readonly jobTerminator?: BackgroundJobTerminator | undefined;
+    readonly now?: (() => Date) | undefined;
+    readonly statFs?: StatFsProvider | undefined;
+    readonly processCommandProvider?: ProcessCommandProvider | undefined;
+    readonly isDarwin?: boolean | undefined;
+  }) {
     this.#config = options.config;
     this.#sessions = options.sessions;
     this.#jobTerminator = options.jobTerminator;
     this.#now = options.now ?? (() => new Date());
     this.#statFs = options.statFs ?? readDiskUsage;
+    this.#processCommandProvider = options.processCommandProvider ?? readProcessCommands;
     this.#isDarwin = options.isDarwin ?? process.platform === "darwin";
   }
 
@@ -93,7 +106,8 @@ export class DiskPressureCleanupService {
       await Promise.all([ensureDir(this.#config.logDir), ensureDir(this.#config.sessionsRoot), ensureDir(this.#config.jobsRoot)]);
 
       const before = await this.#readUsage();
-      const cacheResult = await this.#cleanExpiredSessionCaches();
+      const processCommands = this.#config.diskCleanupDryRun ? [] : await this.#readProcessCommandsForSessionCleanup();
+      const cacheResult = processCommands === null ? { candidateCount: 0, deletedCount: 0, reclaimedBytes: 0 } : await this.#cleanExpiredSessionCaches(processCommands);
       let deletedLogCount = 0;
       let deletedSessionCount = 0;
 
@@ -107,7 +121,7 @@ export class DiskPressureCleanupService {
         });
 
         deletedLogCount = await this.#deleteOldLogs(this.#config.diskCleanupOldLogMs);
-        deletedSessionCount = (await this.#readUsage()).freeBytes < this.#config.diskCleanupTargetFreeBytes ? await this.#deleteInactiveSessions() : 0;
+        deletedSessionCount = processCommands !== null && (await this.#readUsage()).freeBytes < this.#config.diskCleanupTargetFreeBytes ? await this.#deleteInactiveSessions(processCommands) : 0;
       }
 
       const after = await this.#readUsage();
@@ -151,38 +165,72 @@ export class DiskPressureCleanupService {
   async #deleteOldLogs(maxAgeMs: number): Promise<number> {
     const nowMs = this.#now().getTime();
     const files = await listFiles(this.#config.logDir);
+    let candidateCount = 0;
+    let candidateBytes = 0;
+    let sampledCandidateCount = 0;
     let deletedCount = 0;
+    let deletedBytes = 0;
+    let sampledDeletedCount = 0;
+    let failureCount = 0;
+    let sampledFailureCount = 0;
 
     for (const file of files.filter((entry) => nowMs - entry.mtimeMs >= maxAgeMs).sort((left, right) => left.mtimeMs - right.mtimeMs)) {
       try {
-        const bytes = await getPathSizeBytes(file.path);
-        logger.info("Disk cleanup old log candidate", {
-          path: file.path,
-          bytes,
-          dryRun: this.#config.diskCleanupDryRun,
-        });
+        const bytes = file.bytes;
+        candidateCount += 1;
+        candidateBytes += bytes;
+        if (sampledCandidateCount < CLEANUP_DETAIL_LOG_LIMIT) {
+          sampledCandidateCount += 1;
+          logger.info("Disk cleanup old log candidate", {
+            path: file.path,
+            bytes,
+            dryRun: this.#config.diskCleanupDryRun,
+          });
+        }
         if (!this.#config.diskCleanupDryRun) {
           await fs.rm(file.path, { force: true });
           await removeEmptyParents(path.dirname(file.path), this.#config.logDir);
           deletedCount += 1;
-          logger.info("Disk cleanup old log deleted", {
-            path: file.path,
-            bytes,
-            dryRun: false,
-          });
+          deletedBytes += bytes;
+          if (sampledDeletedCount < CLEANUP_DETAIL_LOG_LIMIT) {
+            sampledDeletedCount += 1;
+            logger.info("Disk cleanup old log deleted", {
+              path: file.path,
+              bytes,
+              dryRun: false,
+            });
+          }
         }
       } catch (error) {
-        logger.warn("Failed to delete log during disk cleanup", {
-          path: file.path,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        failureCount += 1;
+        if (sampledFailureCount < CLEANUP_DETAIL_LOG_LIMIT) {
+          sampledFailureCount += 1;
+          logger.warn("Failed to delete log during disk cleanup", {
+            path: file.path,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
+    }
+
+    if (candidateCount > 0 || failureCount > 0) {
+      logger.info("Disk cleanup old logs processed", {
+        candidateCount,
+        candidateBytes,
+        sampledCandidateCount,
+        deletedCount,
+        deletedBytes,
+        sampledDeletedCount,
+        failureCount,
+        sampledFailureCount,
+        dryRun: this.#config.diskCleanupDryRun,
+      });
     }
 
     return deletedCount;
   }
 
-  async #deleteInactiveSessions(): Promise<number> {
+  async #deleteInactiveSessions(processCommands: readonly string[]): Promise<number> {
     const nowMs = this.#now().getTime();
     const candidates = await Promise.all(
       this.#sessions.listSessions().map(async (session) => {
@@ -206,6 +254,9 @@ export class DiskPressureCleanupService {
         ) {
           return null;
         }
+        if (isSessionReferencedByProcess(session, jobs, this.#config.jobsRoot, processCommands)) {
+          return null;
+        }
 
         return {
           session,
@@ -215,19 +266,31 @@ export class DiskPressureCleanupService {
       }),
     );
 
+    let candidateCount = 0;
+    let candidateBytes = 0;
+    let sampledCandidateCount = 0;
     let deletedCount = 0;
+    let deletedBytes = 0;
+    let sampledDeletedCount = 0;
+    let failureCount = 0;
+    let sampledFailureCount = 0;
     for (const candidate of candidates.filter((entry): entry is NonNullable<typeof entry> => entry !== null).sort((left, right) => left.lastActivityMs - right.lastActivityMs)) {
       try {
         const sessionRoot = path.dirname(candidate.session.workspacePath);
         const bytes = await getPathSizeBytes(sessionRoot);
-        logger.info("Disk cleanup inactive session candidate", {
-          sessionKey: candidate.session.key,
-          channelId: candidate.session.channelId,
-          rootThreadTs: candidate.session.rootThreadTs,
-          path: sessionRoot,
-          bytes,
-          dryRun: this.#config.diskCleanupDryRun,
-        });
+        candidateCount += 1;
+        candidateBytes += bytes;
+        if (sampledCandidateCount < CLEANUP_DETAIL_LOG_LIMIT) {
+          sampledCandidateCount += 1;
+          logger.info("Disk cleanup inactive session candidate", {
+            sessionKey: candidate.session.key,
+            channelId: candidate.session.channelId,
+            rootThreadTs: candidate.session.rootThreadTs,
+            path: sessionRoot,
+            bytes,
+            dryRun: this.#config.diskCleanupDryRun,
+          });
+        }
         if (!this.#config.diskCleanupDryRun) {
           await this.#cancelJobs(candidate.jobs);
           await Promise.all([
@@ -237,25 +300,47 @@ export class DiskPressureCleanupService {
           ]);
           await this.#sessions.deleteSessionByKey(candidate.session.key);
           deletedCount += 1;
-          logger.info("Disk cleanup inactive session deleted", {
-            sessionKey: candidate.session.key,
-            channelId: candidate.session.channelId,
-            rootThreadTs: candidate.session.rootThreadTs,
-            path: sessionRoot,
-            bytes,
-            dryRun: false,
-          });
+          deletedBytes += bytes;
+          if (sampledDeletedCount < CLEANUP_DETAIL_LOG_LIMIT) {
+            sampledDeletedCount += 1;
+            logger.info("Disk cleanup inactive session deleted", {
+              sessionKey: candidate.session.key,
+              channelId: candidate.session.channelId,
+              rootThreadTs: candidate.session.rootThreadTs,
+              path: sessionRoot,
+              bytes,
+              dryRun: false,
+            });
+          }
         }
       } catch (error) {
-        logger.warn("Failed to delete inactive session during disk cleanup", {
-          sessionKey: candidate.session.key,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        failureCount += 1;
+        if (sampledFailureCount < CLEANUP_DETAIL_LOG_LIMIT) {
+          sampledFailureCount += 1;
+          logger.warn("Failed to delete inactive session during disk cleanup", {
+            sessionKey: candidate.session.key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
 
       if ((await this.#readUsage()).freeBytes >= this.#config.diskCleanupTargetFreeBytes) {
         break;
       }
+    }
+
+    if (candidateCount > 0 || failureCount > 0) {
+      logger.info("Disk cleanup inactive sessions processed", {
+        candidateCount,
+        candidateBytes,
+        sampledCandidateCount,
+        deletedCount,
+        deletedBytes,
+        sampledDeletedCount,
+        failureCount,
+        sampledFailureCount,
+        dryRun: this.#config.diskCleanupDryRun,
+      });
     }
 
     return deletedCount;
@@ -290,15 +375,31 @@ export class DiskPressureCleanupService {
     return usages.reduce((lowest, usage) => (usage.freeBytes < lowest.freeBytes ? usage : lowest));
   }
 
-  async #cleanExpiredSessionCaches(): Promise<{
+  async #readProcessCommandsForSessionCleanup(): Promise<readonly string[] | null> {
+    try {
+      return await this.#processCommandProvider();
+    } catch (error) {
+      logger.warn("Skipping session cleanup because running processes could not be inspected", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  async #cleanExpiredSessionCaches(processCommands: readonly string[]): Promise<{
     readonly candidateCount: number;
     readonly deletedCount: number;
     readonly reclaimedBytes: number;
   }> {
     const nowMs = this.#now().getTime();
     let candidateCount = 0;
+    let candidateBytes = 0;
+    let sampledCandidateCount = 0;
     let deletedCount = 0;
     let reclaimedBytes = 0;
+    let sampledDeletedCount = 0;
+    let failureCount = 0;
+    let sampledFailureCount = 0;
 
     const candidates = await Promise.all(
       this.#sessions.listSessions().map(async (session) => {
@@ -315,6 +416,9 @@ export class DiskPressureCleanupService {
           return null;
         }
         if (!canCleanSessionCaches(session, inbound, jobs)) {
+          return null;
+        }
+        if (isSessionReferencedByProcess(session, jobs, this.#config.jobsRoot, processCommands)) {
           return null;
         }
 
@@ -338,15 +442,19 @@ export class DiskPressureCleanupService {
           }
 
           candidateCount += 1;
-          logger.info("Disk cleanup session cache candidate", {
-            sessionKey: candidate.session.key,
-            channelId: candidate.session.channelId,
-            rootThreadTs: candidate.session.rootThreadTs,
-            path: targetPath,
-            relativePath,
-            bytes,
-            dryRun: this.#config.diskCleanupDryRun,
-          });
+          candidateBytes += bytes;
+          if (sampledCandidateCount < CLEANUP_DETAIL_LOG_LIMIT) {
+            sampledCandidateCount += 1;
+            logger.info("Disk cleanup session cache candidate", {
+              sessionKey: candidate.session.key,
+              channelId: candidate.session.channelId,
+              rootThreadTs: candidate.session.rootThreadTs,
+              path: targetPath,
+              relativePath,
+              bytes,
+              dryRun: this.#config.diskCleanupDryRun,
+            });
+          }
 
           if (this.#config.diskCleanupDryRun) {
             continue;
@@ -355,23 +463,44 @@ export class DiskPressureCleanupService {
           await fs.rm(targetPath, { recursive: true, force: true });
           deletedCount += 1;
           reclaimedBytes += bytes;
-          logger.info("Disk cleanup session cache deleted", {
-            sessionKey: candidate.session.key,
-            channelId: candidate.session.channelId,
-            rootThreadTs: candidate.session.rootThreadTs,
-            path: targetPath,
-            relativePath,
-            bytes,
-            dryRun: false,
-          });
+          if (sampledDeletedCount < CLEANUP_DETAIL_LOG_LIMIT) {
+            sampledDeletedCount += 1;
+            logger.info("Disk cleanup session cache deleted", {
+              sessionKey: candidate.session.key,
+              channelId: candidate.session.channelId,
+              rootThreadTs: candidate.session.rootThreadTs,
+              path: targetPath,
+              relativePath,
+              bytes,
+              dryRun: false,
+            });
+          }
         } catch (error) {
-          logger.warn("Failed to delete session cache during disk cleanup", {
-            sessionKey: candidate.session.key,
-            path: targetPath,
-            error: error instanceof Error ? error.message : String(error),
-          });
+          failureCount += 1;
+          if (sampledFailureCount < CLEANUP_DETAIL_LOG_LIMIT) {
+            sampledFailureCount += 1;
+            logger.warn("Failed to delete session cache during disk cleanup", {
+              sessionKey: candidate.session.key,
+              path: targetPath,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
         }
       }
+    }
+
+    if (candidateCount > 0 || failureCount > 0) {
+      logger.info("Disk cleanup session caches processed", {
+        candidateCount,
+        candidateBytes,
+        sampledCandidateCount,
+        deletedCount,
+        reclaimedBytes,
+        sampledDeletedCount,
+        failureCount,
+        sampledFailureCount,
+        dryRun: this.#config.diskCleanupDryRun,
+      });
     }
 
     return {
@@ -403,6 +532,19 @@ async function readDiskUsage(targetPath: string): Promise<DiskUsage> {
     freeBytes: stat.bavail * stat.bsize,
     totalBytes: stat.blocks * stat.bsize,
   };
+}
+
+async function readProcessCommands(): Promise<readonly string[]> {
+  const { stdout } = await execCommand("/bin/ps", ["-axo", "command="]);
+  return stdout
+    .split(/\r?\n/u)
+    .map((command) => command.trim())
+    .filter((command) => command.length > 0);
+}
+
+function isSessionReferencedByProcess(session: SlackSessionRecord, jobs: readonly PersistedBackgroundJob[], jobsRoot: string, processCommands: readonly string[]): boolean {
+  const protectedRoots = [path.dirname(session.workspacePath), ...jobs.map((job) => path.join(jobsRoot, job.id))].map((entry) => path.resolve(entry));
+  return processCommands.some((command) => protectedRoots.some((root) => command === root || command.includes(`${root}${path.sep}`)));
 }
 
 function getLastUserVisibleActivityMs(session: SlackSessionRecord, inbound: readonly PersistedInboundMessage[]): number | undefined {
@@ -473,6 +615,7 @@ async function listFiles(directoryPath: string): Promise<
   Array<{
     readonly path: string;
     readonly mtimeMs: number;
+    readonly bytes: number;
   }>
 > {
   const entries = await fs.readdir(directoryPath, { withFileTypes: true }).catch((error) => {
@@ -491,6 +634,7 @@ async function listFiles(directoryPath: string): Promise<
       files.push({
         path: entryPath,
         mtimeMs: stat.mtimeMs,
+        bytes: stat.size,
       });
     }
   }

--- a/test/disk-pressure-cleanup-service.test.ts
+++ b/test/disk-pressure-cleanup-service.test.ts
@@ -24,8 +24,9 @@ describe("DiskPressureCleanupService", () => {
         SLACK_APP_TOKEN: "xapp-test",
         SLACK_BOT_TOKEN: "xoxb-test",
         DATA_ROOT: dataRoot,
-        DISK_CLEANUP_MIN_FREE_BYTES: "0",
-        DISK_CLEANUP_TARGET_FREE_BYTES: "0",
+        DISK_CLEANUP_MIN_FREE_BYTES: "2000",
+        DISK_CLEANUP_TARGET_FREE_BYTES: "2000",
+        DISK_CLEANUP_INACTIVE_SESSION_MS: String(DAY_MS),
         DISK_CLEANUP_SESSION_CACHE_TTL_MS: String(DAY_MS),
       } as NodeJS.ProcessEnv);
       const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
@@ -42,12 +43,16 @@ describe("DiskPressureCleanupService", () => {
       const nodeModulesPath = path.join(stale.workspacePath, "web/node_modules/pkg/index.js");
       await writeSizedFile(derivedDataPath, 8);
       await writeSizedFile(nodeModulesPath, 9);
+      const processCommandProvider = vi.fn(async () => {
+        throw new Error("dry runs must not inspect processes");
+      });
 
       const cleanup = new DiskPressureCleanupService({
         config,
         sessions,
         now: () => now,
         isDarwin: true,
+        processCommandProvider,
         statFs: async () => ({
           freeBytes: 1000,
           totalBytes: 1000,
@@ -59,6 +64,9 @@ describe("DiskPressureCleanupService", () => {
       expect(result.dryRun).toBe(true);
       expect(result.cacheCandidateCount).toBe(2);
       expect(result.deletedCacheEntryCount).toBe(0);
+      expect(result.deletedSessionCount).toBe(0);
+      expect(processCommandProvider).not.toHaveBeenCalled();
+      expect(sessions.getSessionByKey(stale.key)).toBeDefined();
       expect(await fileExists(path.dirname(derivedDataPath))).toBe(true);
       expect(await fileExists(path.dirname(nodeModulesPath))).toBe(true);
       expect(infoSpy).toHaveBeenCalledWith(
@@ -72,6 +80,303 @@ describe("DiskPressureCleanupService", () => {
       );
     } finally {
       infoSpy.mockRestore();
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed for session and cache cleanup when running processes cannot be inspected", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-cleanup-process-error-"));
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    try {
+      const config = loadConfig({
+        SLACK_APP_TOKEN: "xapp-test",
+        SLACK_BOT_TOKEN: "xoxb-test",
+        DATA_ROOT: dataRoot,
+        DISK_CLEANUP_DRY_RUN: "false",
+        DISK_CLEANUP_MIN_FREE_BYTES: "100",
+        DISK_CLEANUP_TARGET_FREE_BYTES: "100",
+        DISK_CLEANUP_INACTIVE_SESSION_MS: String(DAY_MS),
+        DISK_CLEANUP_OLD_LOG_MS: String(DAY_MS),
+        DISK_CLEANUP_SESSION_CACHE_TTL_MS: String(DAY_MS),
+      } as NodeJS.ProcessEnv);
+      const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+      const sessions = new SessionManager({ stateStore, sessionsRoot: config.sessionsRoot });
+      await sessions.load();
+
+      const now = new Date("2026-04-25T00:00:00.000Z");
+      const oldAt = new Date(now.getTime() - 8 * DAY_MS).toISOString();
+      const stale = await seedSession(sessions, stateStore, "CPROCESSERROR", "100.000", oldAt);
+      const cachePath = path.join(stale.workspacePath, "web/node_modules/pkg/index.js");
+      const oldLogPath = path.join(config.logDir, "broker", "old.jsonl");
+      await writeSizedFile(cachePath, 9);
+      await writeSizedFile(oldLogPath, 10);
+      await fs.utimes(oldLogPath, new Date(oldAt), new Date(oldAt));
+
+      const processCommandProvider = vi.fn(async () => {
+        throw new Error("ps unavailable");
+      });
+      const cleanup = new DiskPressureCleanupService({
+        config,
+        sessions,
+        now: () => now,
+        processCommandProvider,
+        statFs: async () => ({ freeBytes: 0, totalBytes: 1000 }),
+      });
+
+      const result = await cleanup.runOnce("test");
+
+      expect(processCommandProvider).toHaveBeenCalledTimes(1);
+      expect(result.deletedLogCount).toBe(1);
+      expect(result.cacheCandidateCount).toBe(0);
+      expect(result.deletedCacheEntryCount).toBe(0);
+      expect(result.deletedSessionCount).toBe(0);
+      expect(sessions.getSessionByKey(stale.key)).toBeDefined();
+      expect(await fileExists(path.join(stale.workspacePath, "web/node_modules"))).toBe(true);
+      expect(await fileExists(oldLogPath)).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith("Skipping session cleanup because running processes could not be inspected", {
+        error: "ps unavailable",
+      });
+    } finally {
+      warnSpy.mockRestore();
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("protects session and job roots referenced by running process commands", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-cleanup-process-reference-"));
+
+    try {
+      const config = loadConfig({
+        SLACK_APP_TOKEN: "xapp-test",
+        SLACK_BOT_TOKEN: "xoxb-test",
+        DATA_ROOT: dataRoot,
+        DISK_CLEANUP_DRY_RUN: "false",
+        DISK_CLEANUP_MIN_FREE_BYTES: "100",
+        DISK_CLEANUP_TARGET_FREE_BYTES: "100",
+        DISK_CLEANUP_INACTIVE_SESSION_MS: String(DAY_MS),
+        DISK_CLEANUP_SESSION_CACHE_TTL_MS: String(DAY_MS),
+      } as NodeJS.ProcessEnv);
+      const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+      const sessions = new SessionManager({ stateStore, sessionsRoot: config.sessionsRoot });
+      await sessions.load();
+
+      const now = new Date("2026-04-25T00:00:00.000Z");
+      const oldAt = new Date(now.getTime() - 8 * DAY_MS).toISOString();
+      const sessionReferenced = await seedSession(sessions, stateStore, "CSESSIONREF", "100.000", oldAt);
+      const jobReferenced = await seedSession(sessions, stateStore, "CJOBREF", "200.000", oldAt);
+      const unreferenced = await seedSession(sessions, stateStore, "CUNREFERENCED", "300.000", oldAt);
+      await seedJob(config.jobsRoot, sessions, {
+        id: "job-process-reference",
+        status: "completed",
+        sessionKey: jobReferenced.key,
+        channelId: jobReferenced.channelId,
+        rootThreadTs: jobReferenced.rootThreadTs,
+        workspacePath: jobReferenced.workspacePath,
+        at: oldAt,
+      });
+
+      for (const session of [sessionReferenced, jobReferenced, unreferenced]) {
+        await writeSizedFile(path.join(session.workspacePath, "web/node_modules/pkg/index.js"), 11);
+      }
+
+      const processCommandProvider = vi.fn(async () => [`node ${path.dirname(sessionReferenced.workspacePath)}/runner.js`, `sh ${path.join(config.jobsRoot, "job-process-reference")}/run.sh`, `node ${path.dirname(unreferenced.workspacePath)}-other/runner.js`]);
+      const cleanup = new DiskPressureCleanupService({
+        config,
+        sessions,
+        now: () => now,
+        processCommandProvider,
+        statFs: async () => ({ freeBytes: 0, totalBytes: 1000 }),
+      });
+
+      const result = await cleanup.runOnce("test");
+
+      expect(processCommandProvider).toHaveBeenCalledTimes(1);
+      expect(result.cacheCandidateCount).toBe(1);
+      expect(result.deletedCacheEntryCount).toBe(1);
+      expect(result.deletedSessionCount).toBe(1);
+      expect(sessions.getSessionByKey(sessionReferenced.key)).toBeDefined();
+      expect(sessions.getSessionByKey(jobReferenced.key)).toBeDefined();
+      expect(sessions.getSessionByKey(unreferenced.key)).toBeUndefined();
+      expect(await fileExists(path.join(sessionReferenced.workspacePath, "web/node_modules"))).toBe(true);
+      expect(await fileExists(path.join(jobReferenced.workspacePath, "web/node_modules"))).toBe(true);
+      expect(await fileExists(path.dirname(unreferenced.workspacePath))).toBe(false);
+      expect(await fileExists(path.join(config.jobsRoot, "job-process-reference"))).toBe(true);
+    } finally {
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("bounds per-item cleanup logs and emits complete aggregate summaries", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-cleanup-log-sampling-"));
+    const infoSpy = vi.spyOn(logger, "info");
+
+    try {
+      const config = loadConfig({
+        SLACK_APP_TOKEN: "xapp-test",
+        SLACK_BOT_TOKEN: "xoxb-test",
+        DATA_ROOT: dataRoot,
+        DISK_CLEANUP_DRY_RUN: "false",
+        DISK_CLEANUP_MIN_FREE_BYTES: "100",
+        DISK_CLEANUP_TARGET_FREE_BYTES: "100",
+        DISK_CLEANUP_INACTIVE_SESSION_MS: String(DAY_MS),
+        DISK_CLEANUP_OLD_LOG_MS: String(DAY_MS),
+        DISK_CLEANUP_SESSION_CACHE_TTL_MS: String(DAY_MS),
+      } as NodeJS.ProcessEnv);
+      const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+      const sessions = new SessionManager({ stateStore, sessionsRoot: config.sessionsRoot });
+      await sessions.load();
+
+      const now = new Date("2026-04-25T00:00:00.000Z");
+      const oldAt = new Date(now.getTime() - 8 * DAY_MS).toISOString();
+      for (let index = 0; index < 7; index += 1) {
+        const session = await seedSession(sessions, stateStore, `CSAMPLED${index}`, `${index}.000`, oldAt);
+        await writeSizedFile(path.join(session.workspacePath, "web/node_modules/pkg/index.js"), index + 1);
+        const oldLogPath = path.join(config.logDir, "broker", `old-${index}.jsonl`);
+        await writeSizedFile(oldLogPath, index + 1);
+        await fs.utimes(oldLogPath, new Date(oldAt), new Date(oldAt));
+      }
+
+      const processCommandProvider = vi.fn(async () => []);
+      const cleanup = new DiskPressureCleanupService({
+        config,
+        sessions,
+        now: () => now,
+        processCommandProvider,
+        statFs: async () => ({ freeBytes: 0, totalBytes: 1000 }),
+      });
+      infoSpy.mockClear();
+
+      const result = await cleanup.runOnce("test");
+
+      expect(result.cacheCandidateCount).toBe(7);
+      expect(result.deletedCacheEntryCount).toBe(7);
+      expect(result.deletedLogCount).toBe(7);
+      expect(result.deletedSessionCount).toBe(7);
+      expect(processCommandProvider).toHaveBeenCalledTimes(1);
+      for (const message of ["Disk cleanup session cache candidate", "Disk cleanup session cache deleted", "Disk cleanup old log candidate", "Disk cleanup old log deleted", "Disk cleanup inactive session candidate", "Disk cleanup inactive session deleted"]) {
+        expect(infoSpy.mock.calls.filter(([entry]) => entry === message)).toHaveLength(5);
+      }
+      expect(infoSpy).toHaveBeenCalledWith(
+        "Disk cleanup old logs processed",
+        expect.objectContaining({
+          candidateCount: 7,
+          candidateBytes: 28,
+          sampledCandidateCount: 5,
+          deletedCount: 7,
+          deletedBytes: 28,
+          sampledDeletedCount: 5,
+          failureCount: 0,
+          sampledFailureCount: 0,
+          dryRun: false,
+        }),
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        "Disk cleanup session caches processed",
+        expect.objectContaining({
+          candidateCount: 7,
+          candidateBytes: result.cacheReclaimedBytes,
+          sampledCandidateCount: 5,
+          deletedCount: 7,
+          reclaimedBytes: result.cacheReclaimedBytes,
+          sampledDeletedCount: 5,
+          failureCount: 0,
+          sampledFailureCount: 0,
+          dryRun: false,
+        }),
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        "Disk cleanup inactive sessions processed",
+        expect.objectContaining({
+          candidateCount: 7,
+          candidateBytes: expect.any(Number),
+          sampledCandidateCount: 5,
+          deletedCount: 7,
+          deletedBytes: expect.any(Number),
+          sampledDeletedCount: 5,
+          failureCount: 0,
+          sampledFailureCount: 0,
+          dryRun: false,
+        }),
+      );
+      const sessionSummary = infoSpy.mock.calls.find(([entry]) => entry === "Disk cleanup inactive sessions processed")?.[1] as { readonly candidateBytes?: number; readonly deletedBytes?: number } | undefined;
+      expect(sessionSummary?.candidateBytes).toBeGreaterThan(0);
+      expect(sessionSummary?.deletedBytes).toBe(sessionSummary?.candidateBytes);
+    } finally {
+      infoSpy.mockRestore();
+      await fs.rm(dataRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("bounds cleanup failure details while preserving aggregate failure counts", async () => {
+    const dataRoot = await fs.mkdtemp(path.join(os.tmpdir(), "slack-codex-cleanup-failure-sampling-"));
+    const infoSpy = vi.spyOn(logger, "info");
+    const warnSpy = vi.spyOn(logger, "warn");
+    const remove = fs.rm.bind(fs);
+    let removeSpy: { mockRestore(): void } | undefined;
+
+    try {
+      const config = loadConfig({
+        SLACK_APP_TOKEN: "xapp-test",
+        SLACK_BOT_TOKEN: "xoxb-test",
+        DATA_ROOT: dataRoot,
+        DISK_CLEANUP_DRY_RUN: "false",
+        DISK_CLEANUP_MIN_FREE_BYTES: "100",
+        DISK_CLEANUP_TARGET_FREE_BYTES: "100",
+        DISK_CLEANUP_OLD_LOG_MS: String(DAY_MS),
+      } as NodeJS.ProcessEnv);
+      const stateStore = new StateStore(config.stateDir, config.sessionsRoot);
+      const sessions = new SessionManager({ stateStore, sessionsRoot: config.sessionsRoot });
+      await sessions.load();
+
+      const now = new Date("2026-04-25T00:00:00.000Z");
+      const oldAt = new Date(now.getTime() - 8 * DAY_MS).toISOString();
+      const failedPaths = new Set<string>();
+      for (let index = 0; index < 7; index += 1) {
+        const oldLogPath = path.join(config.logDir, "broker", `fail-${index}.jsonl`);
+        await writeSizedFile(oldLogPath, index + 1);
+        await fs.utimes(oldLogPath, new Date(oldAt), new Date(oldAt));
+        failedPaths.add(path.resolve(oldLogPath));
+      }
+
+      removeSpy = vi.spyOn(fs, "rm").mockImplementation(async (targetPath, options) => {
+        if (failedPaths.has(path.resolve(String(targetPath)))) {
+          throw new Error("rm denied");
+        }
+        return remove(targetPath, options);
+      });
+      const cleanup = new DiskPressureCleanupService({
+        config,
+        sessions,
+        processCommandProvider: async () => [],
+        now: () => now,
+        statFs: async () => ({ freeBytes: 0, totalBytes: 1000 }),
+      });
+      infoSpy.mockClear();
+      warnSpy.mockClear();
+
+      const result = await cleanup.runOnce("test");
+
+      expect(result.deletedLogCount).toBe(0);
+      expect(warnSpy.mock.calls.filter(([entry]) => entry === "Failed to delete log during disk cleanup")).toHaveLength(5);
+      expect(infoSpy).toHaveBeenCalledWith(
+        "Disk cleanup old logs processed",
+        expect.objectContaining({
+          candidateCount: 7,
+          candidateBytes: 28,
+          sampledCandidateCount: 5,
+          deletedCount: 0,
+          deletedBytes: 0,
+          sampledDeletedCount: 0,
+          failureCount: 7,
+          sampledFailureCount: 5,
+          dryRun: false,
+        }),
+      );
+    } finally {
+      removeSpy?.mockRestore();
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
       await fs.rm(dataRoot, { force: true, recursive: true });
     }
   });
@@ -129,6 +434,7 @@ describe("DiskPressureCleanupService", () => {
         sessions,
         now: () => now,
         isDarwin: true,
+        processCommandProvider: async () => [],
         statFs: async () => ({
           freeBytes: 1000,
           totalBytes: 1000,
@@ -191,6 +497,7 @@ describe("DiskPressureCleanupService", () => {
         sessions,
         now: () => now,
         isDarwin: false,
+        processCommandProvider: async () => [],
         statFs: async () => ({
           freeBytes: 1000,
           totalBytes: 1000,
@@ -311,6 +618,7 @@ describe("DiskPressureCleanupService", () => {
         sessions,
         jobTerminator: { cancelJob },
         now: () => now,
+        processCommandProvider: async () => [],
         statFs: async () => ({
           freeBytes: sessions.listSessions().length <= 2 ? 100 : 0,
           totalBytes: 1000,
@@ -381,6 +689,7 @@ describe("DiskPressureCleanupService", () => {
         config,
         sessions,
         now: () => now,
+        processCommandProvider: async () => [],
         statFs: async (targetPath) => {
           const isLogRoot = path.resolve(targetPath) === path.resolve(config.logDir);
           return {


### PR DESCRIPTION
## Summary

- restore the live worker's process-aware disk cleanup guard in source
- fail closed for session/cache deletion when process inspection is unavailable
- cap per-item cleanup details at five while preserving complete aggregate counts and byte totals
- document the source-restoration plan so the safety behavior survives a normal package release

## Validation

- observed the new focused regressions fail against the old implementation before restoring the guard
- pnpm exec vitest run test/disk-pressure-cleanup-service.test.ts --no-file-parallelism (9/9)
- pnpm test (97 files, 801 tests)
- pnpm build
- pnpm lint
- pnpm format:check
- pnpm release:pack
- isolated manual smoke against compiled dist: referenced session/job roots retained, unreferenced stale data removed, inspection failure retained session/cache while old-log cleanup continued
- compiled cleanup service is semantically identical to the live hotfix (normalized SHA-256 match)

## Scope

This PR does not bump package versions, publish npm packages, or deploy production.
