### PR TITLE
Release 0.1.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-session-broker-repo",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "description": "Slack + China Feishu broker that routes chat sessions into Codex app-server sessions with isolated workspaces.",
   "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/admin",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Admin service and UI for the agent session broker.",
   "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
   "bugs": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/worker",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Worker runtime for the agent session broker.",
   "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- bump the private workspace, admin package, and worker package to 0.1.27
- prepare the merged quota-window fix and restored disk-cleanup safety behavior for npm publication
- keep publication and production deployment outside this version-bump PR

## Validation

- pnpm format:check
- pnpm lint
- pnpm build
- pnpm test (97 files, 801 tests)
- pnpm release:pack
- manually extracted both tarballs and verified package names/versions, admin UI boundary, worker cleanup service, and byte-identical staged cleanup output

## Release follow-up

After merge, an upstream maintainer must create and push the exact v0.1.27 tag. The tag triggers the Publish NPM Package workflow for both public packages. Production deployment is a separate human-operated step.
