### PR TITLE
Release 0.1.28 with canonical provenance metadata

### DIFF
--- a/docs/plans/npm-provenance-repository-rename.md
+++ b/docs/plans/npm-provenance-repository-rename.md
@@ -1,0 +1,56 @@
+# NPM Provenance Repository Rename
+
+## Goal
+
+Publish the admin and worker packages with provenance metadata that identifies
+the canonical `HOOLC/open-worker` GitHub repository.
+
+## Current State
+
+The repository was renamed from `HOOLC/slack-codex-broker` to
+`HOOLC/open-worker`, but the root and publishable package manifests still point
+at the old repository. The `v0.1.27` workflow built, tested, staged, and packed
+both packages, then npm rejected the admin publish with `E422` because the
+package repository did not match the GitHub provenance source. The worker
+publish was skipped, so neither `0.1.27` package exists in npm.
+
+The old repository URL also remains in the isolated MCP OAuth client metadata.
+
+## Proposed Changes
+
+1. Add an end-to-end repository identity contract that compares the root,
+   admin, worker, and OAuth client metadata with GitHub's canonical repository
+   identity.
+2. Replace the stale repository, homepage, issue, and OAuth client URLs with
+   `HOOLC/open-worker`.
+3. Bump the root, admin, and worker versions to `0.1.28`; keep the failed
+   `v0.1.27` tag immutable.
+4. Build, test, stage, and pack both packages, then inspect the staged and packed
+   manifests before creating the release pull request.
+
+## If We Do Not Change It
+
+Every provenance-enabled publish from the current manifests will fail after the
+build, leaving production unable to install a release newer than `0.1.26`.
+
+## After the Change
+
+Pull-request CI validates the same repository identity npm provenance uses.
+The next versioned tag can publish both `0.1.28` packages from the canonical
+repository without moving or reusing `v0.1.27`.
+
+## Acceptance Criteria
+
+- The root, admin, and worker manifests use the canonical repository, homepage,
+  and issue URLs.
+- The isolated MCP OAuth metadata uses the canonical repository URL.
+- Root, admin, and worker versions are all `0.1.28`.
+- The repository identity end-to-end test fails for the old URL and passes for
+  `HOOLC/open-worker`.
+- Formatting, lint, build, focused tests, and the full test suite pass.
+- Staged and packed admin/worker manifests contain version `0.1.28` and the
+  canonical repository URL.
+- The release pull request passes exact-head CI before merge and tagging.
+- A new immutable tag points directly to the merge commit, and npm serves both
+  `@agent-session-broker/admin@0.1.28` and
+  `@agent-session-broker/worker@0.1.28`.

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "agent-session-broker-repo",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "description": "Slack + China Feishu broker that routes chat sessions into Codex app-server sessions with isolated workspaces.",
-  "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
+  "homepage": "https://github.com/HOOLC/open-worker#readme",
   "bugs": {
-    "url": "https://github.com/HOOLC/slack-codex-broker/issues"
+    "url": "https://github.com/HOOLC/open-worker/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HOOLC/slack-codex-broker.git"
+    "url": "git+https://github.com/HOOLC/open-worker.git"
   },
   "type": "module",
   "scripts": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@agent-session-broker/admin",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Admin service and UI for the agent session broker.",
-  "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
+  "homepage": "https://github.com/HOOLC/open-worker#readme",
   "bugs": {
-    "url": "https://github.com/HOOLC/slack-codex-broker/issues"
+    "url": "https://github.com/HOOLC/open-worker/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HOOLC/slack-codex-broker.git"
+    "url": "git+https://github.com/HOOLC/open-worker.git"
   },
   "bin": {
     "agent-session-broker-macos-bootstrap": "./scripts/ops/macos-bootstrap.mjs"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@agent-session-broker/worker",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Worker runtime for the agent session broker.",
-  "homepage": "https://github.com/HOOLC/slack-codex-broker#readme",
+  "homepage": "https://github.com/HOOLC/open-worker#readme",
   "bugs": {
-    "url": "https://github.com/HOOLC/slack-codex-broker/issues"
+    "url": "https://github.com/HOOLC/open-worker/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HOOLC/slack-codex-broker.git"
+    "url": "git+https://github.com/HOOLC/open-worker.git"
   },
   "files": [
     "dist/src/",

--- a/src/services/codex/isolated-mcp-service.ts
+++ b/src/services/codex/isolated-mcp-service.ts
@@ -205,7 +205,7 @@ class StoredOauthProvider implements OAuthClientProvider {
     return {
       redirect_uris: [],
       client_name: "slack-codex-broker",
-      client_uri: "https://github.com/HOOLC/slack-codex-broker",
+      client_uri: "https://github.com/HOOLC/open-worker",
       grant_types: this.#entry.refresh_token ? ["refresh_token"] : ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.#entry.client_secret ? "client_secret_post" : "none",

--- a/test/npm-package-deployment.test.ts
+++ b/test/npm-package-deployment.test.ts
@@ -25,12 +25,18 @@ describe("npm package deployment contract", () => {
     };
     const adminPackageJson = JSON.parse(await fs.readFile(new URL("../packages/admin/package.json", import.meta.url), "utf8")) as {
       readonly name?: string;
+      readonly repository?: { readonly url?: string };
+      readonly bugs?: { readonly url?: string };
+      readonly homepage?: string;
       readonly publishConfig?: Record<string, string>;
       readonly files?: readonly string[];
       readonly bin?: Record<string, string>;
     };
     const workerPackageJson = JSON.parse(await fs.readFile(new URL("../packages/worker/package.json", import.meta.url), "utf8")) as {
       readonly name?: string;
+      readonly repository?: { readonly url?: string };
+      readonly bugs?: { readonly url?: string };
+      readonly homepage?: string;
       readonly publishConfig?: Record<string, string>;
       readonly files?: readonly string[];
     };
@@ -39,9 +45,11 @@ describe("npm package deployment contract", () => {
       name: "agent-session-broker-repo",
       private: true,
     });
-    expect(packageJson.repository?.url).toBe("git+https://github.com/HOOLC/slack-codex-broker.git");
-    expect(packageJson.bugs?.url).toBe("https://github.com/HOOLC/slack-codex-broker/issues");
-    expect(packageJson.homepage).toBe("https://github.com/HOOLC/slack-codex-broker#readme");
+    for (const manifest of [packageJson, adminPackageJson, workerPackageJson]) {
+      expect(manifest.repository?.url).toBe("git+https://github.com/HOOLC/open-worker.git");
+      expect(manifest.bugs?.url).toBe("https://github.com/HOOLC/open-worker/issues");
+      expect(manifest.homepage).toBe("https://github.com/HOOLC/open-worker#readme");
+    }
     expect(adminPackageJson).toMatchObject({
       name: "@agent-session-broker/admin",
       bin: {

--- a/test/npm-provenance-repository.e2e.test.ts
+++ b/test/npm-provenance-repository.e2e.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const CANONICAL_REPOSITORY = "HOOLC/open-worker";
+const CANONICAL_REPOSITORY_URL = `https://github.com/${CANONICAL_REPOSITORY}`;
+
+type PackageMetadata = {
+  readonly version?: string;
+  readonly homepage?: string;
+  readonly bugs?: { readonly url?: string };
+  readonly repository?: { readonly url?: string };
+};
+
+describe("npm provenance repository identity", () => {
+  it("keeps every release manifest aligned with the canonical GitHub repository", async () => {
+    const manifests = await Promise.all(
+      ["../package.json", "../packages/admin/package.json", "../packages/worker/package.json"].map(async (relativePath) => {
+        return JSON.parse(await fs.readFile(new URL(relativePath, import.meta.url), "utf8")) as PackageMetadata;
+      }),
+    );
+
+    for (const manifest of manifests) {
+      expect(normalizeRepositoryUrl(manifest.repository?.url)).toBe(CANONICAL_REPOSITORY_URL);
+      expect(manifest.homepage).toBe(`${CANONICAL_REPOSITORY_URL}#readme`);
+      expect(manifest.bugs?.url).toBe(`${CANONICAL_REPOSITORY_URL}/issues`);
+    }
+    expect(manifests.map((manifest) => manifest.version)).toEqual([manifests[0]?.version, manifests[0]?.version, manifests[0]?.version]);
+    expect(manifests[0]?.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("publishes the canonical repository as the isolated MCP OAuth client URI", async () => {
+    const source = await fs.readFile(new URL("../src/services/codex/isolated-mcp-service.ts", import.meta.url), "utf8");
+    expect(source).toContain(`client_uri: "${CANONICAL_REPOSITORY_URL}"`);
+  });
+});
+
+function normalizeRepositoryUrl(value: string | undefined): string | undefined {
+  return value?.replace(/^git\+/, "").replace(/\.git$/, "");
+}


### PR DESCRIPTION
## Summary

- update root, admin, worker, and OAuth client repository metadata to the canonical `HOOLC/open-worker` repository
- add regression coverage for both publishable manifests so npm provenance mismatches fail in PR CI
- release the corrected packages as `0.1.28` without moving failed tag `v0.1.27`

## Root cause

The `v0.1.27` publish workflow built and packed successfully, but npm rejected admin publication with E422 because the published manifest still referenced `HOOLC/slack-codex-broker` while GitHub provenance identified `HOOLC/open-worker`. Worker publication was then skipped.

Failed run: https://github.com/HOOLC/open-worker/actions/runs/31793841733

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test` — 98 files / 803 tests
- `pnpm release:pack`
- manual source/staged/tarball manifest inspection for admin and worker
- manual tarball boundary inspection: admin UI only in admin; runtime entrypoints in both; no source/test/local state
- compiled packed OAuth client URI inspection
- `git diff --exit-code -- pnpm-lock.yaml`

## Release contract

After exact-head CI passes and this PR merges, create a new lightweight `v0.1.28` tag at the merge commit and require both npm packages to become readable before any production rollout.
