### PR TITLE
Release 0.1.29 with complete runtime packages

### DIFF
--- a/docs/plans/npm-runtime-dependency-cold-start.md
+++ b/docs/plans/npm-runtime-dependency-cold-start.md
@@ -1,0 +1,76 @@
+# NPM Runtime Dependency Cold Start
+
+## Goal
+
+Publish admin and worker npm packages that can be installed and started from
+their tarballs without relying on the private build workspace's
+`node_modules`.
+
+## Current State
+
+The private root manifest declares the full runtime dependency set, but the
+publishable admin and worker manifests do not. The `0.1.28` build, test, stage,
+pack, and publish jobs all ran with the root dependencies installed, so they
+did not exercise the dependency boundary of either public package.
+
+Production installed the admin package successfully and switched its symlink,
+then the restarted process failed during module loading with
+`ERR_MODULE_NOT_FOUND: @larksuiteoapi/node-sdk`. The deployment request had
+already returned success, so the operation record did not reflect the later
+cold-start failure. Admin was rolled back to `0.1.26`; worker remained on its
+existing `0.1.26` hotfix.
+
+The live account-pool API still returns a weekly quota window, but the deployed
+`0.1.26` UI reads that response shape incorrectly. The quota fix is already in
+the current source tree and will become visible when a safe package release can
+be deployed.
+
+## Proposed Changes
+
+1. Add an end-to-end release test that stages and packs both packages, installs
+   the tarballs into clean temporary projects, runs the installed admin CLI,
+   starts each real package entry point, and checks its health/readiness
+   endpoint.
+2. Keep the publishable admin and worker dependency declarations aligned with
+   every external runtime module reachable from their packaged server code,
+   and stage the complete relative-import closure of the admin CLI.
+3. Bump the root, admin, and worker versions to `0.1.29`; keep the failed
+   `0.1.28` tag and package versions immutable.
+4. Run formatting, lint, build, focused tests, the full test suite, staging,
+   packing, clean installation, and cold-start verification before opening a
+   draft pull request.
+
+## If We Do Not Change It
+
+The registry can continue accepting packages that install successfully but
+cannot start. Production deployment will fail after the symlink switch, the
+operation log can misleadingly show success, and the already-implemented
+account-pool quota fix will remain unavailable on the live admin UI.
+
+## After the Change
+
+Pull-request CI verifies the same clean package boundary used by production.
+Both `0.1.29` tarballs must resolve their own runtime imports and boot from a
+fresh install before they can be published. A human operator can then deploy
+the new release and verify the account-pool card without retrying `0.1.28`.
+
+## Acceptance Criteria
+
+- Root, admin, and worker manifests all use version `0.1.29`.
+- The admin and worker manifests declare every external dependency required by
+  their packaged server entry points.
+- A regression test fails against the `0.1.28` manifest boundary.
+- The test packs and installs both artifacts without linking the repository or
+  inheriting its `node_modules`.
+- The installed `agent-session-broker-macos-bootstrap --help` command exits
+  successfully using only files from the admin tarball.
+- The installed admin entry point cold-starts and returns HTTP 200 from
+  `/healthz`.
+- The installed worker entry point cold-starts and returns HTTP 200 from both
+  `/healthz` and `/readyz` while connected to an isolated mock Slack endpoint.
+- Formatting, lint, build, focused tests, and the full test suite pass.
+- Staged and packed manifests contain version `0.1.29` and the complete runtime
+  dependency set.
+- The release pull request is opened as a draft and passes exact-head CI before
+  any merge or tag is considered.
+- No production deployment is performed by this change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-session-broker-repo",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "description": "Slack + China Feishu broker that routes chat sessions into Codex app-server sessions with isolated workspaces.",
   "homepage": "https://github.com/HOOLC/open-worker#readme",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/admin",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Admin service and UI for the agent session broker.",
   "homepage": "https://github.com/HOOLC/open-worker#readme",
   "bugs": {
@@ -19,6 +19,10 @@
     "dist/admin-ui/",
     "scripts/ops/lib.mjs",
     "scripts/ops/macos-bootstrap.mjs",
+    "scripts/ops/macos-bootstrap-helpers.mjs",
+    "scripts/ops/macos-bootstrap-helpers-1.mjs",
+    "scripts/ops/macos-bootstrap-helpers-2.mjs",
+    "scripts/ops/macos-bootstrap-helpers-3.mjs",
     "scripts/ops/macos-launchd-launcher.mjs",
     "scripts/ops/macos-launchd-restart.mjs",
     "README.md",
@@ -30,7 +34,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.66.0",
     "@modelcontextprotocol/sdk": "1.27.1",
+    "marked": "^18.0.4",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "ws": "^8.18.3"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-session-broker/worker",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Worker runtime for the agent session broker.",
   "homepage": "https://github.com/HOOLC/open-worker#readme",
   "bugs": {
@@ -24,7 +24,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@larksuiteoapi/node-sdk": "^1.66.0",
     "@modelcontextprotocol/sdk": "1.27.1",
+    "marked": "^18.0.4",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "ws": "^8.18.3"

--- a/scripts/build/stage-npm-packages.mjs
+++ b/scripts/build/stage-npm-packages.mjs
@@ -12,7 +12,7 @@ const packageTargets = [
     source: path.join(repoRoot, "packages", "admin"),
     destination: path.join(stageRoot, "admin"),
     includeAdminUi: true,
-    scripts: ["lib.mjs", "macos-bootstrap.mjs", "macos-launchd-launcher.mjs", "macos-launchd-restart.mjs"],
+    scripts: ["lib.mjs", "macos-bootstrap.mjs", "macos-bootstrap-helpers.mjs", "macos-bootstrap-helpers-1.mjs", "macos-bootstrap-helpers-2.mjs", "macos-bootstrap-helpers-3.mjs", "macos-launchd-launcher.mjs", "macos-launchd-restart.mjs"],
   },
   {
     source: path.join(repoRoot, "packages", "worker"),

--- a/test/npm-package-cold-start.e2e.test.ts
+++ b/test/npm-package-cold-start.e2e.test.ts
@@ -1,0 +1,318 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { getFreePort } from "./e2e-broker-helpers.js";
+import { MockSlackServer } from "./manual/mock-slack-server.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const packageTargets = ["admin", "worker"] as const;
+const commandTimeoutMs = 30_000;
+const installTimeoutMs = 60_000;
+const setupTimeoutMs = 180_000;
+const testTimeoutMs = 30_000;
+
+let fixtureRoot = "";
+const installRoots = new Map<(typeof packageTargets)[number], string>();
+
+describe.sequential("published npm package cold starts", () => {
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "broker-npm-cold-start-"));
+    const archiveRoot = path.join(fixtureRoot, "archives");
+
+    await runCommand("pnpm", ["build"], { cwd: repoRoot });
+    await runCommand(process.execPath, [path.join(repoRoot, "scripts/build/stage-npm-packages.mjs")], { cwd: repoRoot });
+    await fs.mkdir(archiveRoot, { recursive: true });
+
+    const results = await Promise.allSettled(packageTargets.map((target) => prepareTargetInstall(target, archiveRoot)));
+    const failures = results.filter((result): result is PromiseRejectedResult => result.status === "rejected").map((result) => result.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "Failed to prepare clean package installs");
+    }
+  }, setupTimeoutMs);
+
+  afterAll(async () => {
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it(
+    "runs the admin bootstrap CLI from a clean tarball install",
+    async () => {
+      const installRoot = requireInstallRoot("admin");
+      const binPath = path.join(installRoot, "node_modules", ".bin", "agent-session-broker-macos-bootstrap");
+      const { stdout } = await runCommand(binPath, ["--help"], {
+        cwd: fixtureRoot,
+        env: {
+          HOME: path.join(fixtureRoot, "bootstrap-home"),
+          PATH: process.env.PATH ?? "",
+          TMPDIR: os.tmpdir(),
+          LANG: "C.UTF-8",
+          NODE_OPTIONS: "",
+          NODE_PATH: "",
+        },
+      });
+
+      expect(stdout).toContain("Usage:");
+      expect(stdout).toContain("--package-version");
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    "boots the admin entry point from a clean tarball install",
+    async () => {
+      const service = await startPackedService("admin");
+      try {
+        await expect(waitForHttpOk(`${service.baseUrl}/healthz`, service)).resolves.toMatchObject({ ok: true });
+        await waitForLog(service, "Admin service booted");
+        await expectServiceToStayAlive(service);
+      } finally {
+        await service.stop();
+      }
+    },
+    testTimeoutMs,
+  );
+
+  it(
+    "boots the worker entry point from a clean tarball install",
+    async () => {
+      const mockSlack = new MockSlackServer("UBOT", {
+        appId: "AAPP",
+        botId: "BBOT",
+      });
+      let mockStarted = false;
+      let service: Awaited<ReturnType<typeof startPackedService>> | undefined;
+      try {
+        const slackPort = await mockSlack.start();
+        mockStarted = true;
+        service = await startPackedService("worker", slackPort);
+        await expect(waitForHttpOk(`${service.baseUrl}/healthz`, service)).resolves.toMatchObject({ ok: true });
+        await expect(waitForHttpOk(`${service.baseUrl}/readyz`, service)).resolves.toMatchObject({ ok: true });
+        await withTimeout(mockSlack.waitForSocket(), 15_000, "mock Slack socket connection");
+        await waitForLog(service, "Worker service booted");
+        await expectServiceToStayAlive(service);
+      } finally {
+        const cleanups: Promise<unknown>[] = [];
+        if (service) {
+          cleanups.push(service.stop());
+        }
+        if (mockStarted) {
+          cleanups.push(withTimeout(mockSlack.stop(), 5_000, "mock Slack cleanup"));
+        }
+        await settleAll(cleanups, "Failed to clean up worker cold-start resources");
+      }
+    },
+    testTimeoutMs,
+  );
+});
+
+async function prepareTargetInstall(target: (typeof packageTargets)[number], archiveRoot: string): Promise<void> {
+  const { stdout } = await runCommand("npm", ["pack", path.join(repoRoot, "artifacts/npm-packages", target), "--pack-destination", archiveRoot, "--json"], {
+    cwd: repoRoot,
+  });
+  const packResult = JSON.parse(stdout) as Array<{ readonly filename?: string }>;
+  const filename = packResult[0]?.filename;
+  if (!filename) {
+    throw new Error(`npm pack did not report an archive for ${target}: ${stdout}`);
+  }
+
+  const archivePath = path.join(archiveRoot, filename);
+  const installRoot = path.join(fixtureRoot, `install-${target}`);
+  installRoots.set(target, installRoot);
+  await fs.mkdir(installRoot, { recursive: true });
+  await fs.writeFile(path.join(installRoot, "package.json"), `${JSON.stringify({ private: true }, null, 2)}\n`, "utf8");
+  await runCommand("npm", ["install", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund", "--package-lock=false", "--install-strategy=nested", archivePath], {
+    cwd: installRoot,
+    timeoutMs: installTimeoutMs,
+  });
+  await runCommand("npm", ["ls", "--omit=dev", "--all"], { cwd: installRoot });
+}
+
+async function runCommand(
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly cwd: string;
+    readonly env?: NodeJS.ProcessEnv;
+    readonly timeoutMs?: number;
+  },
+): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  return await execFileAsync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    killSignal: "SIGKILL",
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: options.timeoutMs ?? commandTimeoutMs,
+  });
+}
+
+async function startPackedService(
+  target: (typeof packageTargets)[number],
+  slackPort?: number,
+): Promise<{
+  readonly baseUrl: string;
+  readonly child: ChildProcess;
+  readonly logs: string[];
+  readonly stop: () => Promise<void>;
+}> {
+  const runtimeRoot = path.join(fixtureRoot, `runtime-${target}`);
+  const port = await getFreePort();
+  await fs.mkdir(runtimeRoot, { recursive: true });
+
+  const logs: string[] = [];
+  const packageName = `@agent-session-broker/${target}`;
+  const installRoot = requireInstallRoot(target);
+  const entryPath = path.join(installRoot, "node_modules", packageName, "dist/src", `${target}-index.js`);
+  const slackBaseUrl = slackPort ? `http://127.0.0.1:${slackPort}/api` : "http://127.0.0.1:1/api";
+  const child = spawn(process.execPath, [entryPath], {
+    cwd: runtimeRoot,
+    env: {
+      HOME: path.join(runtimeRoot, "home"),
+      PATH: process.env.PATH ?? "",
+      TMPDIR: os.tmpdir(),
+      LANG: "C.UTF-8",
+      NODE_ENV: "test",
+      NODE_OPTIONS: "",
+      NODE_PATH: "",
+      SERVICE_NAME: `npm-cold-start-${target}`,
+      SLACK_APP_TOKEN: "xapp-test",
+      SLACK_BOT_TOKEN: "xoxb-test",
+      SLACK_API_BASE_URL: slackBaseUrl,
+      SLACK_SOCKET_OPEN_URL: "apps.connections.open",
+      DATA_ROOT: path.join(runtimeRoot, "data"),
+      STATE_DIR: path.join(runtimeRoot, "state"),
+      SESSIONS_ROOT: path.join(runtimeRoot, "sessions"),
+      REPOS_ROOT: path.join(runtimeRoot, "repos"),
+      JOBS_ROOT: path.join(runtimeRoot, "jobs"),
+      LOG_DIR: path.join(runtimeRoot, "logs"),
+      CODEX_HOME: path.join(runtimeRoot, "codex-home"),
+      PORT: String(port),
+      WORKER_PORT: String(port),
+      WORKER_BIND_HOST: "127.0.0.1",
+      BROKER_HTTP_BASE_URL: `http://127.0.0.1:${port}`,
+      ADMIN_BASE_URL: `http://127.0.0.1:${port}`,
+      WORKER_BASE_URL: `http://127.0.0.1:${port}`,
+      FEISHU_ENABLED: "false",
+      DISK_CLEANUP_ENABLED: "false",
+      LOG_RAW_SLACK_EVENTS: "false",
+      LOG_RAW_CODEX_RPC: "false",
+      LOG_RAW_HTTP_REQUESTS: "false",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout?.on("data", (chunk) => logs.push(chunk.toString()));
+  child.stderr?.on("data", (chunk) => logs.push(chunk.toString()));
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    child,
+    logs,
+    stop: () => stopChild(child),
+  };
+}
+
+function requireInstallRoot(target: (typeof packageTargets)[number]): string {
+  const installRoot = installRoots.get(target);
+  if (!installRoot) {
+    throw new Error(`Missing clean install root for ${target}`);
+  }
+  return installRoot;
+}
+
+async function waitForHttpOk(
+  url: string,
+  service: {
+    readonly child: ChildProcess;
+    readonly logs: readonly string[];
+  },
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (service.child.exitCode !== null || service.child.signalCode !== null) {
+      throw new Error(`Packed service exited before ${url} became healthy:\n${service.logs.join("")}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return (await response.json()) as Record<string, unknown>;
+      }
+    } catch {
+      // The process may still be starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${url}:\n${service.logs.join("")}`);
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  await Promise.race([once(child, "exit"), new Promise((resolve) => setTimeout(resolve, 5_000))]);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await once(child, "exit");
+  }
+}
+
+async function waitForLog(
+  service: {
+    readonly child: ChildProcess;
+    readonly logs: readonly string[];
+  },
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    if (service.logs.join("").includes(expected)) {
+      return;
+    }
+    if (service.child.exitCode !== null || service.child.signalCode !== null) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Packed service did not log ${JSON.stringify(expected)}:\n${service.logs.join("")}`);
+}
+
+async function expectServiceToStayAlive(service: { readonly child: ChildProcess; readonly logs: readonly string[] }): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  if (service.child.exitCode !== null || service.child.signalCode !== null) {
+    throw new Error(`Packed service exited after reporting healthy:\n${service.logs.join("")}`);
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function settleAll(promises: readonly Promise<unknown>[], message: string): Promise<void> {
+  const results = await Promise.allSettled(promises);
+  const failures = results.filter((result): result is PromiseRejectedResult => result.status === "rejected").map((result) => result.reason);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, message);
+  }
+}

--- a/test/npm-package-deployment.test.ts
+++ b/test/npm-package-deployment.test.ts
@@ -22,6 +22,7 @@ describe("npm package deployment contract", () => {
       readonly bugs?: { readonly url?: string };
       readonly homepage?: string;
       readonly scripts?: Record<string, string>;
+      readonly dependencies?: Record<string, string>;
     };
     const adminPackageJson = JSON.parse(await fs.readFile(new URL("../packages/admin/package.json", import.meta.url), "utf8")) as {
       readonly name?: string;
@@ -31,6 +32,7 @@ describe("npm package deployment contract", () => {
       readonly publishConfig?: Record<string, string>;
       readonly files?: readonly string[];
       readonly bin?: Record<string, string>;
+      readonly dependencies?: Record<string, string>;
     };
     const workerPackageJson = JSON.parse(await fs.readFile(new URL("../packages/worker/package.json", import.meta.url), "utf8")) as {
       readonly name?: string;
@@ -39,6 +41,7 @@ describe("npm package deployment contract", () => {
       readonly homepage?: string;
       readonly publishConfig?: Record<string, string>;
       readonly files?: readonly string[];
+      readonly dependencies?: Record<string, string>;
     };
 
     expect(packageJson).toMatchObject({
@@ -59,6 +62,14 @@ describe("npm package deployment contract", () => {
     expect(workerPackageJson).toMatchObject({
       name: "@agent-session-broker/worker",
     });
+    const serverRuntimeDependencies = {
+      "@larksuiteoapi/node-sdk": packageJson.dependencies?.["@larksuiteoapi/node-sdk"],
+      "@modelcontextprotocol/sdk": packageJson.dependencies?.["@modelcontextprotocol/sdk"],
+      marked: packageJson.dependencies?.marked,
+      ws: packageJson.dependencies?.ws,
+    };
+    expect(adminPackageJson.dependencies).toMatchObject(serverRuntimeDependencies);
+    expect(workerPackageJson.dependencies).toMatchObject(serverRuntimeDependencies);
     expect(adminPackageJson.publishConfig).toMatchObject({
       access: "public",
       registry: "https://registry.npmjs.org/",
@@ -67,7 +78,20 @@ describe("npm package deployment contract", () => {
       access: "public",
       registry: "https://registry.npmjs.org/",
     });
-    expect(adminPackageJson.files).toEqual(expect.arrayContaining(["dist/src/", "dist/admin-ui/", "scripts/ops/lib.mjs", "scripts/ops/macos-bootstrap.mjs", "scripts/ops/macos-launchd-launcher.mjs", "scripts/ops/macos-launchd-restart.mjs"]));
+    expect(adminPackageJson.files).toEqual(
+      expect.arrayContaining([
+        "dist/src/",
+        "dist/admin-ui/",
+        "scripts/ops/lib.mjs",
+        "scripts/ops/macos-bootstrap.mjs",
+        "scripts/ops/macos-bootstrap-helpers.mjs",
+        "scripts/ops/macos-bootstrap-helpers-1.mjs",
+        "scripts/ops/macos-bootstrap-helpers-2.mjs",
+        "scripts/ops/macos-bootstrap-helpers-3.mjs",
+        "scripts/ops/macos-launchd-launcher.mjs",
+        "scripts/ops/macos-launchd-restart.mjs",
+      ]),
+    );
     expect(workerPackageJson.files).toEqual(expect.arrayContaining(["dist/src/", "scripts/ops/macos-launchd-launcher.mjs", "scripts/ops/macos-launchd-restart.mjs"]));
     expect(workerPackageJson.files).not.toEqual(expect.arrayContaining(["dist/admin-ui/"]));
     expect(adminPackageJson.files).not.toEqual(expect.arrayContaining(["src/", "test/", "dist/test/", ".data/", ".data-agent-trace-preview/"]));
@@ -82,6 +106,10 @@ describe("npm package deployment contract", () => {
     const stageScript = await fs.readFile(new URL("../scripts/build/stage-npm-packages.mjs", import.meta.url), "utf8");
     expect(stageScript).toContain('"lib.mjs"');
     expect(stageScript).toContain('"macos-bootstrap.mjs"');
+    expect(stageScript).toContain('"macos-bootstrap-helpers.mjs"');
+    expect(stageScript).toContain('"macos-bootstrap-helpers-1.mjs"');
+    expect(stageScript).toContain('"macos-bootstrap-helpers-2.mjs"');
+    expect(stageScript).toContain('"macos-bootstrap-helpers-3.mjs"');
   });
 
   it("makes CI produce the same packed artifacts that deployment consumes", async () => {


### PR DESCRIPTION
## Summary

- bump the root, admin, and worker packages to `0.1.29`
- declare the Lark SDK and `marked` runtime dependencies in both published packages
- stage the complete admin bootstrap helper import closure
- add clean-tarball E2E coverage for the installed admin CLI and real Admin/Worker cold starts

## Root cause

The `0.1.28` workflow tested from the private workspace, whose root `node_modules` masked missing dependencies in both public package manifests. The admin bootstrap bin also referenced helper modules that were not staged. A production Admin switch therefore returned success before its deferred restart failed with `ERR_MODULE_NOT_FOUND`.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- focused package/release tests: 17/17 passed
- `pnpm release:pack`; inspected both `0.1.29` tarball manifests and admin helper closure
- manual clean-tarball verification: installed each package independently, ran bootstrap `--help`, cold-started Admin and Worker, checked `/healthz` and `/readyz`, and confirmed Worker connected to a local mock Slack WebSocket
- local full-suite attempts reached 98/99 files; the remaining pre-existing timing/process flakes (`e2e-broker-part2` or `job-manager`) pass when rerun in isolation. Exact-head CI is the merge gate.

## Deployment boundary

This PR does not deploy production. `0.1.28` remains failed and the live `0.1.26` services/hotfixes remain unchanged.
